### PR TITLE
Make some runtime checks disabled by default

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -5,7 +5,7 @@ import com.smeup.rpgparser.parsing.ast.AssignmentOperator.*
 import com.smeup.rpgparser.utils.Comparison.*
 import com.smeup.rpgparser.parsing.parsetreetoast.LogicalCondition
 import com.smeup.rpgparser.parsing.parsetreetoast.MuteAnnotationExecutionLogEntry
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.utils.*
 import com.strumenta.kolasu.model.ancestor
 import java.lang.IllegalArgumentException
@@ -23,6 +23,10 @@ import kotlin.system.measureTimeMillis
 
 class LeaveException : Exception()
 class IterException : Exception()
+
+object InterpreterConfiguration {
+    var disableDynamicChecksOnAssignement = false
+}
 
 interface InterpretationContext {
     val currentProgramName: String
@@ -181,8 +185,10 @@ class InternalInterpreter(val systemInterface: SystemInterface) : InterpreterCor
                         it.name in initialValues -> {
                             val initialValue = initialValues[it.name]
                                     ?: throw RuntimeException("Initial values for ${it.name} not found")
-                            require(initialValue.assignableTo(it.type)) {
-                                "Initial value for ${it.name} is not compatible. Passed $initialValue, type: ${it.type}"
+                            if (!InterpreterConfiguration.disableDynamicChecksOnAssignement) {
+                                require(initialValue.assignableTo(it.type)) {
+                                    "Initial value for ${it.name} is not compatible. Passed $initialValue, type: ${it.type}"
+                                }
                             }
                             initialValue
                         }
@@ -311,7 +317,7 @@ class InternalInterpreter(val systemInterface: SystemInterface) : InterpreterCor
 
     private fun executeMutes(muteAnnotations: MutableList<MuteAnnotation>, compilationUnit: CompilationUnit) {
         muteAnnotations.forEach {
-            it.resolve(compilationUnit)
+            it.resolveAndValidate(compilationUnit)
             when (it) {
                 is MuteComparisonAnnotation -> {
                     val exp: Expression = when (it.comparison) {
@@ -1110,8 +1116,10 @@ class InternalInterpreter(val systemInterface: SystemInterface) : InterpreterCor
                 // Before assigning the single element we do a sanity check:
                 // is the value we have for the array compatible with the type
                 // we expect for such array?
-                require(arrayValue.assignableTo(targetType)) {
-                    "The value $arrayValue is not assignable to $targetType"
+                if (!InterpreterConfiguration.disableDynamicChecksOnAssignement) {
+                    require(arrayValue.assignableTo(targetType)) {
+                        "The value $arrayValue is not assignable to $targetType"
+                    }
                 }
                 val indexValue = interpret(target.index)
                 val elementType = (targetType as ArrayType).element

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -25,7 +25,10 @@ class LeaveException : Exception()
 class IterException : Exception()
 
 object InterpreterConfiguration {
-    var disableDynamicChecksOnAssignement = false
+    /**
+     * Enable runtime checks during assignments
+     */
+    var enableRuntimeChecksOnAssignement = false
 }
 
 interface InterpretationContext {
@@ -185,7 +188,7 @@ class InternalInterpreter(val systemInterface: SystemInterface) : InterpreterCor
                         it.name in initialValues -> {
                             val initialValue = initialValues[it.name]
                                     ?: throw RuntimeException("Initial values for ${it.name} not found")
-                            if (!InterpreterConfiguration.disableDynamicChecksOnAssignement) {
+                            if (InterpreterConfiguration.enableRuntimeChecksOnAssignement) {
                                 require(initialValue.assignableTo(it.type)) {
                                     "Initial value for ${it.name} is not compatible. Passed $initialValue, type: ${it.type}"
                                 }
@@ -1125,7 +1128,7 @@ class InternalInterpreter(val systemInterface: SystemInterface) : InterpreterCor
                 // Before assigning the single element we do a sanity check:
                 // is the value we have for the array compatible with the type
                 // we expect for such array?
-                if (!InterpreterConfiguration.disableDynamicChecksOnAssignement) {
+                if (InterpreterConfiguration.enableRuntimeChecksOnAssignement) {
                     require(arrayValue.assignableTo(targetType)) {
                         "The value $arrayValue is not assignable to $targetType"
                     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -1154,18 +1154,18 @@ class InternalInterpreter(val systemInterface: SystemInterface) : InterpreterCor
                 return coercedValue
             }
             is PredefinedGlobalIndicatorExpr -> {
-                if (value.assignableTo(BooleanType)) {
+                return if (value.assignableTo(BooleanType)) {
                     val coercedValue = coerce(value, BooleanType)
                     for (index in ALL_PREDEFINED_INDEXES) {
                         predefinedIndicators[index] = coercedValue
                     }
-                    return coercedValue
+                    coercedValue
                 } else {
                     val coercedValue = coerce(value, ArrayType(BooleanType, 100)).asArray()
                     for (index in ALL_PREDEFINED_INDEXES) {
                         predefinedIndicators[index] = coercedValue.getElement(index)
                     }
-                    return coercedValue
+                    coercedValue
                 }
             }
             else -> TODO(target.toString())

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -3,7 +3,7 @@ package com.smeup.rpgparser.interpreter
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.smeup.rpgparser.parsing.ast.DataWrapUpChoice
 import com.smeup.rpgparser.parsing.facade.RpgParserFacade
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import java.io.InputStream
 
 data class ProgramParam(val name: String, val type: Type)
@@ -27,7 +27,7 @@ class RpgProgram(val cu: CompilationUnit, dbInterface: DBInterface, val name: St
     }
 
     init {
-        cu.resolve(dbInterface)
+        cu.resolveAndValidate(dbInterface)
     }
 
     companion object {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
@@ -7,6 +7,7 @@ import java.lang.IllegalStateException
 import kotlin.math.ceil
 import com.smeup.rpgparser.parsing.ast.*
 import java.math.BigDecimal
+import kotlin.math.max
 
 // Supported data types:
 // * Character Format
@@ -228,6 +229,15 @@ fun Expression.type(): Type {
         is OnRefExpr, is OffRefExpr -> return BooleanType
         is FigurativeConstantRef -> {
             FigurativeType
+        }
+        is PlusExpr -> {
+            val leftType = this.left.type()
+            val rightType = this.right.type()
+            if (leftType is NumberType && rightType is NumberType) {
+                return NumberType(max(leftType.entireDigits, rightType.entireDigits), max(leftType.decimalDigits, rightType.decimalDigits))
+            } else {
+                TODO("We do not know the type of a sum of types $leftType and $rightType")
+            }
         }
         else -> TODO("We do not know how to calculate the type of $this (${this.javaClass.canonicalName})")
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
@@ -158,6 +158,14 @@ data class NumberType(val entireDigits: Int, val decimalDigits: Int, val rpgType
         get() = !integer
     val numberOfDigits: Int
         get() = entireDigits + decimalDigits
+
+    override fun canBeAssigned(valueType: Type): Boolean {
+        if (valueType is NumberType) {
+            return valueType.entireDigits <= this.entireDigits && valueType.decimalDigits <= this.decimalDigits
+        } else {
+            return false
+        }
+    }
 }
 
 data class ArrayType(val element: Type, val nElements: Int, val compileTimeRecordsPerLine: Int? = null) : Type() {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/muterunner.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/muterunner.kt
@@ -18,7 +18,7 @@ import com.smeup.rpgparser.parsing.ast.MuteComparisonAnnotationExecuted
 import com.smeup.rpgparser.parsing.facade.RpgParserFacade
 import com.smeup.rpgparser.parsing.facade.RpgParserResult
 import com.smeup.rpgparser.parsing.parsetreetoast.injectMuteAnnotation
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.parsing.parsetreetoast.toAst
 import com.smeup.rpgparser.rpginterop.RpgProgramFinder
 import com.smeup.rpgparser.utils.asDouble
@@ -156,7 +156,7 @@ fun RpgParserResult.executeMuteAnnotations(
             }
         }
     }
-    cu.resolve(systemInterface.db)
+    cu.resolveAndValidate(systemInterface.db)
     val interpreter = InternalInterpreter(systemInterface)
     interpreter.execute(cu, parameters)
     return interpreter.systemInterface.executedAnnotationInternal.toSortedMap()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -69,13 +69,19 @@ fun MuteAnnotation.resolveAndValidate(cu: CompilationUnit) {
     this.resolveFunctionCalls(cu)
 }
 
-fun CompilationUnit.resolveAndValidate(databaseInterface: DBInterface): List<Error> {
+/**
+ * In case of semantic errors we could either raise exceptions or return a list of errors.
+ */
+fun CompilationUnit.resolveAndValidate(databaseInterface: DBInterface, raiseException: Boolean = true): List<Error> {
     this.resolve(databaseInterface)
-    return this.validate()
+    return this.validate(raiseException)
 }
 
 class SemanticErrorsException(val errors: List<Error>) : RuntimeException("Semantic errors found: $errors")
 
+/**
+ * In case of semantic errors we could either raise exceptions or return a list of errors.
+ */
 private fun CompilationUnit.validate(raiseException: Boolean = true): List<Error> {
     val errors = LinkedList<Error>()
     // TODO validate SubstExpr for assignability
@@ -85,7 +91,7 @@ private fun CompilationUnit.validate(raiseException: Boolean = true): List<Error
         val targetType = it.target.type()
         val valueType = it.value.type()
         if (!targetType.canBeAssigned(valueType)) {
-            errors.add(Error(ErrorType.SEMANTIC, "Invalid assignement: cannot assign ${it.target} having type $targetType to ${it.value} having type $valueType", it.position))
+            errors.add(Error(ErrorType.SEMANTIC, "Invalid assignement: cannot assign ${it.value} having type $valueType to ${it.target} having type $targetType", it.position))
         }
     }
     if (errors.isNotEmpty()) {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/sql/dbTestUtils.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/sql/dbTestUtils.kt
@@ -5,7 +5,7 @@ import com.smeup.rpgparser.assertASTCanBeProduced
 import com.smeup.rpgparser.execute
 import com.smeup.rpgparser.interpreter.FileMetadata
 import com.smeup.rpgparser.interpreter.StringValue
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import java.util.concurrent.ThreadLocalRandom
 
 // Using random DB name in order to have different dbs for each test
@@ -24,7 +24,7 @@ fun outputOfDBPgm(programName: String, initialSQL: List<String>, inputParms: Map
     val cu = assertASTCanBeProduced(programName, printTree = printTree)
     val dbInterface = connectionForTest()
     dbInterface.execute(initialSQL)
-    cu.resolve(dbInterface)
+    cu.resolveAndValidate(dbInterface)
     val si = CollectorSystemInterface()
     si.databaseInterface = dbInterface
     execute(cu, inputParms, si)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterSmokeTest.kt
@@ -3,7 +3,7 @@ package com.smeup.rpgparser.evaluation
 import com.smeup.rpgparser.*
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.logging.*
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import org.junit.Test
 
 class InterpreterSmokeTest {
@@ -11,7 +11,7 @@ class InterpreterSmokeTest {
     @Test
     fun executeJD_001() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
         // We need JD_URL in Kotlin. We want it to print its third parameter
     }
@@ -19,14 +19,14 @@ class InterpreterSmokeTest {
     @Test
     fun executeJD_002() {
         val cu = assertASTCanBeProduced("JD_002")
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
     @Test
     fun executeJD_003() {
         val cu = assertASTCanBeProduced("JD_003")
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
@@ -48,7 +48,7 @@ class InterpreterSmokeTest {
             }
         }
 
-        cu.resolve(mockDBInterface)
+        cu.resolveAndValidate(mockDBInterface)
         val si = CollectorSystemInterface(consoleLoggingConfiguration(STATEMENT_LOGGER, EXPRESSION_LOGGER))
         si.databaseInterface = mockDBInterface
         execute(cu, mapOf("ipToFind" to StringValue("127.0.0.1")), si)
@@ -66,7 +66,7 @@ class InterpreterSmokeTest {
             }
         }
 
-        cu.resolve(mockDBInterface)
+        cu.resolveAndValidate(mockDBInterface)
         val si = CollectorSystemInterface(consoleLoggingConfiguration(STATEMENT_LOGGER, EXPRESSION_LOGGER))
         si.databaseInterface = mockDBInterface
         execute(cu, mapOf(), si)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -7,7 +7,7 @@ import com.smeup.rpgparser.jvminterop.JvmProgramRaw
 import com.smeup.rpgparser.logging.EXPRESSION_LOGGER
 import com.smeup.rpgparser.logging.STATEMENT_LOGGER
 import com.smeup.rpgparser.logging.consoleLoggingConfiguration
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.utils.asInt
 import org.junit.Ignore
 import org.junit.Test
@@ -20,7 +20,7 @@ class InterpreterTest {
     @Test
     fun executeCALCFIB_initialDeclarations_dec() {
         val cu = assertASTCanBeProduced("CALCFIB_1", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf("ppdat" to StringValue("3")))
         assertIsIntValue(interpreter["NBR"], 3)
     }
@@ -28,7 +28,7 @@ class InterpreterTest {
     @Test
     fun executeCALCFIB_initialDeclarations_inz() {
         val cu = assertASTCanBeProduced("CALCFIB_1", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         assertTrue(cu.getDataDefinition("ppdat").initializationValue == null)
         assertTrue(cu.getDataDefinition("NBR").initializationValue == null)
@@ -46,7 +46,7 @@ class InterpreterTest {
     @Test
     fun executeCALCFIB_otherClauseOfSelect() {
         val cu = assertASTCanBeProduced("CALCFIB_2", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val si = CollectorSystemInterface()
         val logHandler = ListLogHandler()
         val interpreter = execute(cu, mapOf("ppdat" to StringValue("10")), si, listOf(logHandler))
@@ -58,7 +58,7 @@ class InterpreterTest {
 
     private fun assertFibonacci(input: String, output: String) {
         val cu = assertASTCanBeProduced("CALCFIB", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val si = CollectorSystemInterface()
         val logHandler = ListLogHandler()
         execute(cu, mapOf("ppdat" to StringValue(input)), si, listOf(logHandler))
@@ -99,7 +99,7 @@ class InterpreterTest {
     @Test
     fun executeHELLO() {
         val cu = assertASTCanBeProduced("HELLO", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val si = CollectorSystemInterface()
         val logHandler = ListLogHandler()
         execute(cu, mapOf(), si, listOf(logHandler))
@@ -110,7 +110,7 @@ class InterpreterTest {
     @Test
     fun executeCallToFibonacciWrittenInRpg() {
         val cu = assertASTCanBeProduced("CALCFIBCAL", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val si = CollectorSystemInterface()
         val logHandler = ListLogHandler()
         si.programs["CALCFIB"] = rpgProgram("CALCFIB")
@@ -122,7 +122,7 @@ class InterpreterTest {
     @Test
     fun executeCallToFibonacciWrittenOnTheJvm() {
         val cu = assertASTCanBeProduced("CALCFIBCAL", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val si = CollectorSystemInterface()
         val logHandler = ListLogHandler()
         si.programs["CALCFIB"] = object : JvmProgramRaw("CALCFIB", listOf(ProgramParam("ppdat", StringType(8, false)))) {
@@ -148,7 +148,7 @@ class InterpreterTest {
     @Test
     fun executeFibonacciWrittenInRpgAsProgram() {
         val cu = assertASTCanBeProduced("CALCFIB", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val si = CollectorSystemInterface()
         val rpgProgram = RpgProgram(cu, DummyDBInterface)
         rpgProgram.execute(si, linkedMapOf("ppdat" to StringValue("10")))
@@ -792,7 +792,7 @@ class InterpreterTest {
             override fun metadataOf(name: String): FileMetadata? = FileMetadata(name, name, listOf(f1, f2, f3))
         }
 
-        cu.resolve(mockDBInterface)
+        cu.resolveAndValidate(mockDBInterface)
 
         val si = CollectorSystemInterface()
         si.databaseInterface = mockDBInterface
@@ -822,7 +822,7 @@ class InterpreterTest {
             }
         }
 
-        cu.resolve(mockDBInterface)
+        cu.resolveAndValidate(mockDBInterface)
         val si = CollectorSystemInterface(consoleLoggingConfiguration(STATEMENT_LOGGER, EXPRESSION_LOGGER))
         si.databaseInterface = mockDBInterface
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/JDExamplesTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/JDExamplesTest.kt
@@ -4,7 +4,7 @@ import com.smeup.rpgparser.*
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.jvminterop.JvmProgramRaw
 import com.smeup.rpgparser.logging.*
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -20,7 +20,7 @@ class JDExamplesTest {
     @Test
     fun executeJD_000_datadefinitions() {
         val cu = assertASTCanBeProduced("JD_000_datainit", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val allDefinitions = cu.allDataDefinitions
 
@@ -56,7 +56,7 @@ class JDExamplesTest {
     @Test
     fun executeJD_000_datainit() {
         val cu = assertASTCanBeProduced("JD_000_datainit", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = execute(cu, mapOf())
 
@@ -82,14 +82,14 @@ class JDExamplesTest {
     @Test
     fun executeJD_000_base() {
         val cu = assertASTCanBeProduced("JD_000_base", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
     @Test
     fun executeJD_001_datadefinitions() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val svarDef = cu.getDataOrFieldDefinition("\$\$SVAR") as FieldDefinition
         assertEquals(ArrayType(StringType(1050), 200), svarDef.type)
@@ -119,7 +119,7 @@ class JDExamplesTest {
             }
         }
         val cu = assertASTCanBeProduced("JD_000", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val jd001program = si.findProgram("JD_001")!!
         val jd001params = jd001program.params()
@@ -130,7 +130,7 @@ class JDExamplesTest {
         val svarskDef = cu.allDataDefinitions.find { it.name == "U\$SVARSK" }!! as FieldDefinition
         assertEquals(ArrayType(StringType(1050), 200), svarskDef.type)
 
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         execute(cu, mapOf(), systemInterface = si, logHandlers = SimpleLogHandler.fromFlag(false))
 
@@ -181,7 +181,7 @@ class JDExamplesTest {
     @Test
     fun paramsTypesOfJD_001() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val programJD_001 = RpgProgram(cu, DummyDBInterface, "JD_001")
         val params = programJD_001.params()
         assertEquals(4, params.size)
@@ -202,7 +202,7 @@ class JDExamplesTest {
     @Test
     fun executeJD_001_plist() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val logHandler = ListLogHandler()
         val interpreter = execute(cu, mapOf(
                 "U\$FUNZ" to StringValue("Foo"),
@@ -220,7 +220,7 @@ class JDExamplesTest {
     @Test
     fun executeJD_001_settingVars() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val logHandler = ListLogHandler()
         val interpreter = execute(cu, mapOf(
                 "U\$FUNZ" to StringValue("Foo"),
@@ -236,7 +236,7 @@ class JDExamplesTest {
     @Test
     fun executeJD_001_inzFunz() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val logHandler = ListLogHandler()
         val interpreter = execute(cu, mapOf(
                 "U\$FUNZ" to StringValue("INZ"),
@@ -256,7 +256,7 @@ class JDExamplesTest {
     @Test
     fun executeJD_001_recognizeDataDefinitions() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val unnamedDS = cu.getDataDefinition("@UNNAMED_DS_16")
         assertEquals(false, unnamedDS.type is ArrayType)
@@ -283,7 +283,7 @@ class JDExamplesTest {
     @Test
     fun executeJD_001_complete_url_not_found() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf("U\$FUNZ" to "INZ".asValue()))
         interpreter.execute(cu, mapOf("U\$FUNZ" to "ESE".asValue()), reinitialization = false)
         interpreter.execute(cu, mapOf("U\$FUNZ" to "CLO".asValue()), reinitialization = false)
@@ -305,7 +305,7 @@ class JDExamplesTest {
             }
         }
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf(
                 "U\$FUNZ" to "INZ".asValue(),
                 "U\$SVARSK" to createArrayValue(StringType(1050), 200) { i ->
@@ -385,7 +385,7 @@ class JDExamplesTest {
             }
         }
         val cu = assertASTCanBeProduced("JD_002", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf("U\$FUNZ" to "INZ".asValue()), systemInterface = si, logHandlers = SimpleLogHandler.fromFlag(true))
         interpreter.execute(cu, mapOf("U\$FUNZ" to "ESE".asValue()), reinitialization = false)
         interpreter.execute(cu, mapOf("U\$FUNZ" to "CLO".asValue()), reinitialization = false)
@@ -421,7 +421,7 @@ class JDExamplesTest {
             }
         }
         val cu = assertASTCanBeProduced("JD_002", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf(
                 "U\$FUNZ" to "INZ".asValue(),
                 "U\$SVARSK" to createArrayValue(StringType(1050), 200) { i ->
@@ -476,7 +476,7 @@ class JDExamplesTest {
             }
         }
         val cu = assertASTCanBeProduced("JD_002", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf(
                 "U\$FUNZ" to "INZ".asValue(),
                 "U\$SVARSK" to createArrayValue(StringType(1050), 200) { i ->
@@ -527,7 +527,7 @@ class JDExamplesTest {
             }
         }
         val cu = assertASTCanBeProduced("JD_003", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf("U\$FUNZ" to "INZ".asValue()),
                 systemInterface = si, logHandlers = SimpleLogHandler.fromFlag(true))
         interpreter.execute(cu, mapOf("U\$FUNZ" to "EXE".asValue()), reinitialization = false)
@@ -583,7 +583,7 @@ class JDExamplesTest {
             }
         }
         val cu = assertASTCanBeProduced("JD_003", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf("U\$FUNZ" to "INZ".asValue(),
                 "U\$SVARSK" to createArrayValue(StringType(1050), 200) { i ->
                     when (i) {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
@@ -148,7 +148,7 @@ class MuteExecutionTest {
     // this program test operations on arrays of unequal size (simplified version of MUTE09_04 without MOVEA)
     fun executeMUTE09_05() {
         val cu = assertASTCanBeProduced("mute/MUTE09_05", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         cu.assertNrOfMutesAre(115)
         val interpreter = execute(cu, emptyMap())
         assertEquals(115, interpreter.systemInterface.getExecutedAnnotation().size)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
@@ -7,10 +7,9 @@ import com.smeup.rpgparser.assertNrOfMutesAre
 import com.smeup.rpgparser.execute
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.jvminterop.JvmProgramRaw
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import org.junit.Test
 import java.util.concurrent.TimeoutException
-import kotlin.test.Ignore
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -21,7 +20,7 @@ class MuteExecutionTest {
     @Test
     fun executeSimpleMute() {
         val cu = assertASTCanBeProduced("mute/SIMPLE_MUTE", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         cu.assertNrOfMutesAre(3)
         val interpreter = execute(cu, emptyMap())
         assertEquals(3, interpreter.systemInterface.getExecutedAnnotation().size)
@@ -33,7 +32,7 @@ class MuteExecutionTest {
     @Test
     fun executeMuteWithScope() {
         val cu = assertASTCanBeProduced("mute/MUTE01_SCOPE", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         cu.assertNrOfMutesAre(5)
         val interpreter = execute(cu, emptyMap())
         assertEquals(5, interpreter.systemInterface.getExecutedAnnotation().size)
@@ -42,7 +41,7 @@ class MuteExecutionTest {
     @Test
     fun parsingSimpleMuteTimeout() {
         val cu = assertASTCanBeProduced("mute/SIMPLE_MUTE_TIMEOUT", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         cu.assertNrOfMutesAre(4)
         assertEquals(2, cu.timeouts.size)
         assertEquals(123, cu.timeouts[0].timeout)
@@ -52,7 +51,7 @@ class MuteExecutionTest {
     @Test
     fun executionWithShortTimeoutFails() {
         val cu = assertASTCanBeProduced("mute/SIMPLE_MUTE_TIMEOUT_SHORT", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         assertEquals(2, cu.timeouts.size)
         assertEquals(1, cu.timeouts[0].timeout)
         assertEquals(234, cu.timeouts[1].timeout)
@@ -76,7 +75,7 @@ class MuteExecutionTest {
     @Test
     fun executionWithLongTimeoutDoesNotFail() {
         val cu = assertASTCanBeProduced("mute/SIMPLE_MUTE_TIMEOUT_LONG", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         assertEquals(1, cu.timeouts.size)
         assertEquals(12345, cu.timeouts[0].timeout)
         execute(cu, emptyMap())
@@ -85,7 +84,7 @@ class MuteExecutionTest {
     @Test
     fun executeSIMPLE_MUTE_FAIL_STATIC_MESSAGE() {
         val cu = assertASTCanBeProduced("mute/SIMPLE_MUTE_FAIL_STATIC_MESSAGE", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         cu.assertNrOfMutesAre(1)
         val interpreter = execute(cu, emptyMap())
         assertEquals(1, interpreter.systemInterface.getExecutedAnnotation().size)
@@ -97,7 +96,7 @@ class MuteExecutionTest {
     @Test
     fun executeSIMPLE_MUTE_FAIL_EVALUATED_MESSAGE() {
         val cu = assertASTCanBeProduced("mute/SIMPLE_MUTE_FAIL_EVALUATED_MESSAGE", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         cu.assertNrOfMutesAre(1)
         val interpreter = execute(cu, emptyMap())
         assertEquals(1, interpreter.systemInterface.getExecutedAnnotation().size)
@@ -109,7 +108,7 @@ class MuteExecutionTest {
     @Test
     fun executeSIMPLE_MUTE_FAIL_WITH_IF_NO_STATEMENTS_BEFORE_ENDIF_WRONG_USAGE() {
         val cu = assertASTCanBeProduced("mute/SIMPLE_MUTE_FAIL_WITH_IF_NO_STATEMENTS_BEFORE_ENDIF_WRONG_USAGE", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, emptyMap())
         assertEquals(1, interpreter.systemInterface.getExecutedAnnotation().size)
         val muteAnnotationExecuted = interpreter.systemInterface.getExecutedAnnotation().values.first()
@@ -119,7 +118,7 @@ class MuteExecutionTest {
     @Test
     fun executeSIMPLE_MUTE_FAIL_WITH_IF_NO_STATEMENTS_BEFORE_ENDIF_CORRECT_USAGE() {
         val cu = assertASTCanBeProduced("mute/SIMPLE_MUTE_FAIL_WITH_IF_NO_STATEMENTS_BEFORE_ENDIF_CORRECT_USAGE", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, emptyMap())
         assertEquals(0, interpreter.systemInterface.getExecutedAnnotation().size)
     }
@@ -127,7 +126,7 @@ class MuteExecutionTest {
     @Test
     fun executeSSIMPLE_MUTE_FAIL_WITH_IF_AND_STATEMENTS_BEFORE_ENDIF() {
         val cu = assertASTCanBeProduced("mute/SIMPLE_MUTE_FAIL_WITH_IF_AND_STATEMENTS_BEFORE_ENDIF", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, emptyMap())
         assertEquals(0, interpreter.systemInterface.getExecutedAnnotation().size)
     }
@@ -137,7 +136,7 @@ class MuteExecutionTest {
     // this program test operations on arrays of unequal size
     fun executeMUTE09_04() {
         val cu = assertASTCanBeProduced("mute/MUTE09_04", true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         cu.assertNrOfMutesAre(115)
         val interpreter = execute(cu, emptyMap())
         assertEquals(115, interpreter.systemInterface.getExecutedAnnotation().size)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/TypeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/TypeTest.kt
@@ -1,0 +1,21 @@
+package com.smeup.rpgparser.interpreter
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TypeTest {
+
+    @Test
+    fun aSmallerIntIsAssignableToALargerInt() {
+        val valueType = NumberType(1, 0)
+        val targetType = NumberType(8, 0)
+        assertEquals(true, targetType.canBeAssigned(valueType))
+    }
+
+    @Test
+    fun twoSameNumberTypesAreAssignableToEachOther() {
+        val valueType = NumberType(8, 3)
+        val targetType = NumberType(8, 3)
+        assertEquals(true, targetType.canBeAssigned(valueType))
+    }
+}

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgDeceditTest09.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgDeceditTest09.kt
@@ -5,7 +5,7 @@ import com.smeup.rpgparser.executeAnnotations
 import com.smeup.rpgparser.interpreter.DummyDBInterface
 import com.smeup.rpgparser.interpreter.InternalInterpreter
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import org.junit.Test
 
 class RpgDeceditTest09 {
@@ -13,7 +13,7 @@ class RpgDeceditTest09 {
     @Test
     fun parseMUTE09_02() {
         val cu = assertASTCanBeProduced("overlay/MUTE09_02", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
 
@@ -28,7 +28,7 @@ class RpgDeceditTest09 {
     @Test
     fun parseMUTE09_02_comma() {
         val cu = assertASTCanBeProduced("overlay/MUTE09_02_COMMA", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
         // Changes the default decedit
@@ -44,7 +44,7 @@ class RpgDeceditTest09 {
     @Test
     fun parseMUTE09_02A() {
         val cu = assertASTCanBeProduced("overlay/MUTE09_02A", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.decedit = "0,"

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgEvalTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgEvalTest.kt
@@ -5,7 +5,7 @@ import com.smeup.rpgparser.execution.ResourceProgramFinder
 import com.smeup.rpgparser.interpreter.DummyDBInterface
 import com.smeup.rpgparser.interpreter.InternalInterpreter
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.rpginterop.RpgSystem
 import org.junit.Test
 
@@ -15,7 +15,7 @@ class RpgEvalTest {
     fun EVAL_runtime() {
         RpgSystem.addProgramFinder(ResourceProgramFinder("/"))
         val cu = com.smeup.rpgparser.assertASTCanBeProduced("overlay/EVALH", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgParserOverlayTest03.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgParserOverlayTest03.kt
@@ -6,7 +6,7 @@ import com.smeup.rpgparser.executeAnnotations
 import com.smeup.rpgparser.interpreter.DummyDBInterface
 import com.smeup.rpgparser.interpreter.InternalInterpreter
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
 import com.smeup.rpgparser.rpginterop.RpgSystem
 import org.junit.Test
@@ -33,7 +33,7 @@ public class RpgParserOverlayTest03 {
     fun parseMUTE03_09_runtime() {
         RpgSystem.addProgramFinder(DirRpgProgramFinder(File("src/test/resources/overlay")))
         val cu = assertASTCanBeProduced("overlay/MUTE03_09", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgParserOverlayTest11.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgParserOverlayTest11.kt
@@ -7,7 +7,7 @@ import com.smeup.rpgparser.interpreter.DummyDBInterface
 import com.smeup.rpgparser.interpreter.InternalInterpreter
 import com.smeup.rpgparser.interpreter.NumberType
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
 import com.smeup.rpgparser.rpginterop.RpgSystem
 import org.junit.Test
@@ -30,7 +30,7 @@ class RpgParserOverlayTest11 {
     fun parseMUTE11_11C_runtime() {
         RpgSystem.addProgramFinder(DirRpgProgramFinder(File("src/test/resources/overlay")))
         val cu = assertASTCanBeProduced("overlay/MUTE11_11C", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())
@@ -49,7 +49,7 @@ class RpgParserOverlayTest11 {
     @Test
     fun parseMUTE11_15_ast() {
         val cu = assertASTCanBeProduced("overlay/MUTE11_15", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val FUND1 = cu.getDataDefinition("£FUND1")
         val FUNQT = FUND1.getFieldByName("£FUNQT")
@@ -62,7 +62,7 @@ class RpgParserOverlayTest11 {
     fun parseMUTE11_15_runtime() {
         RpgSystem.addProgramFinder(DirRpgProgramFinder(File("src/test/resources/overlay")))
         val cu = assertASTCanBeProduced("overlay/MUTE11_15", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())
@@ -86,7 +86,7 @@ class RpgParserOverlayTest11 {
     @Test
     fun parseMUTE11_16_runtime() {
         val cu = assertASTCanBeProduced("overlay/MUTE11O16", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         RpgSystem.addProgramFinder(DirRpgProgramFinder(File("src/test/resources/overlay")))
 
         val interpreter = InternalInterpreter(JavaSystemInterface())

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgParserOverlayTest12.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgParserOverlayTest12.kt
@@ -13,7 +13,7 @@ import com.smeup.rpgparser.jvminterop.JavaSystemInterface
 import com.smeup.rpgparser.parsing.ast.ArrayAccessExpr
 import com.smeup.rpgparser.parsing.ast.FunctionCall
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.strumenta.kolasu.model.collectByType
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -55,7 +55,7 @@ class RpgParserOverlayTest12 {
     @Test
     fun parseMUTE12_01_runtime() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_01", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
 
@@ -166,7 +166,7 @@ class RpgParserOverlayTest12 {
     @Test
     fun parseMUTE12_02_runtime() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_02", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
 
@@ -186,7 +186,7 @@ class RpgParserOverlayTest12 {
     @Test
     fun parseMUTE12_03_ast() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_03", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val functionCalls = cu.collectByType(FunctionCall::class.java)
         assertEquals(0, functionCalls.size)
         val arrayAccesses = cu.collectByType(ArrayAccessExpr::class.java)
@@ -202,7 +202,7 @@ class RpgParserOverlayTest12 {
     @Test
     fun parseMUTE12_03_inz() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_03", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())
     }
@@ -210,7 +210,7 @@ class RpgParserOverlayTest12 {
     @Test
     fun parseMUTE12_03_runtime() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_03", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())
         val annotations = interpreter.systemInterface.getExecutedAnnotation().toSortedMap()
@@ -233,7 +233,7 @@ class RpgParserOverlayTest12 {
     @Test
     fun parseMUTE12_04_runtime() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_04", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())
         val annotations = interpreter.systemInterface.getExecutedAnnotation().toSortedMap()
@@ -256,7 +256,7 @@ class RpgParserOverlayTest12 {
     @Test
     fun parseMUTE12_05_runtime() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_05", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
 
@@ -281,7 +281,7 @@ class RpgParserOverlayTest12 {
     @Test
     fun parseMUTE12_06_runtime() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_06", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgSortATest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgSortATest.kt
@@ -3,7 +3,7 @@ package com.smeup.rpgparser.overlay
 import com.smeup.rpgparser.assertASTCanBeProduced
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import org.junit.Test
 import java.nio.charset.Charset
 import kotlin.test.assertEquals
@@ -37,7 +37,7 @@ class RpgSortATest {
     @Test
     fun executeSORTA() {
         val cu = assertASTCanBeProduced("overlay/SORTATEST", considerPosition = true, withMuteSupport = true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserDataOverlay.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserDataOverlay.kt
@@ -4,7 +4,7 @@ import com.smeup.rpgparser.assertASTCanBeProduced
 import com.smeup.rpgparser.assertCanBeParsed
 import com.smeup.rpgparser.execute
 import com.smeup.rpgparser.interpreter.DummyDBInterface
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -18,7 +18,7 @@ class RpgParserDataOverlay {
         assertCanBeParsed("struct/OVERLAY_01", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/OVERLAY_01", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
@@ -30,7 +30,7 @@ class RpgParserDataOverlay {
         assertCanBeParsed("struct/OVERLAY_02", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/OVERLAY_02", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
@@ -39,7 +39,7 @@ class RpgParserDataOverlay {
         assertCanBeParsed("struct/OVERLAY_03", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/OVERLAY_03", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val dataDefinition = cu.dataDefinitions[0]
         assertEquals(1, cu.dataDefinitions.size)
 
@@ -71,7 +71,7 @@ class RpgParserDataOverlay {
         assertCanBeParsed("struct/OVERLAY_04", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/OVERLAY_04", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
@@ -80,7 +80,7 @@ class RpgParserDataOverlay {
         assertCanBeParsed("struct/OVERLAY_05", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/OVERLAY_05", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserDataStruct.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserDataStruct.kt
@@ -7,7 +7,7 @@ import com.smeup.rpgparser.executeAnnotations
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -17,7 +17,7 @@ class RpgParserDataStruct {
     @Test
     fun parseSTRUCT_01_MYDS_isRecognizedCorrectly() {
         val cu = assertASTCanBeProduced("struct/STRUCT_01", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val dataDefinition = cu.getDataDefinition("MYDS")
         assertEquals(0, dataDefinition.fields[0].startOffset)
@@ -33,7 +33,7 @@ class RpgParserDataStruct {
 
         val cu = assertASTCanBeProduced("struct/STRUCT_01", true)
 
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val MYDS = cu.getDataDefinition("MYDS")
         val FLD1 = MYDS.getFieldByName("FLD1")
@@ -72,7 +72,7 @@ class RpgParserDataStruct {
         assertCanBeParsed("struct/STRUCT_02", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/STRUCT_02", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
@@ -81,7 +81,7 @@ class RpgParserDataStruct {
         assertCanBeParsed("struct/STRUCT_03", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/STRUCT_03", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val CURTIMSTP = cu.getDataDefinition("CURTIMSTP")
         val CURTIMDATE = CURTIMSTP.getFieldByName("CURTIMDATE")
@@ -123,7 +123,7 @@ class RpgParserDataStruct {
         assertCanBeParsed("struct/STRUCT_03", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/STRUCT_03", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
@@ -133,7 +133,7 @@ class RpgParserDataStruct {
         assertCanBeParsed("struct/STRUCT_04", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/STRUCT_04", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
@@ -145,7 +145,7 @@ class RpgParserDataStruct {
         assertCanBeParsed("struct/STRUCT_05", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/STRUCT_05", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
@@ -157,7 +157,7 @@ class RpgParserDataStruct {
         assertCanBeParsed("struct/STRUCT_06", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/STRUCT_06", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val MYDS = cu.getDataDefinition("MYDS")
 
@@ -212,7 +212,7 @@ class RpgParserDataStruct {
         assertCanBeParsed("struct/STRUCT_06", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/STRUCT_06", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         execute(cu, mapOf())
     }
 
@@ -258,7 +258,7 @@ class RpgParserDataStruct {
         assertCanBeParsed("struct/STRUCT_06", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/STRUCT_06", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())
@@ -277,7 +277,7 @@ class RpgParserDataStruct {
         assertCanBeParsed("struct/STRUCT_07", withMuteSupport = true)
 
         val cu = assertASTCanBeProduced("struct/STRUCT_07", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val interpreter = InternalInterpreter(JavaSystemInterface())
         interpreter.execute(cu, mapOf())

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserWithMuteRuntimeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserWithMuteRuntimeTest.kt
@@ -9,7 +9,7 @@ import com.smeup.rpgparser.interpreter.DummySystemInterface
 import com.smeup.rpgparser.interpreter.SimpleSystemInterface
 import com.smeup.rpgparser.parsing.parsetreetoast.ToAstConfiguration
 import com.smeup.rpgparser.parsing.parsetreetoast.injectMuteAnnotation
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.parsing.parsetreetoast.toAst
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -40,7 +40,7 @@ class RpgParserWithMuteRuntimeTest {
     @Test
     fun parseMUTE01_runtime() {
         val cu = assertASTCanBeProduced("mute/MUTE01_RUNTIME", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         DummySystemInterface.executedAnnotationInternal.clear()
         val interpreter = execute(cu, mapOf())
 
@@ -91,7 +91,7 @@ class RpgParserWithMuteRuntimeTest {
     fun parseMUTE02_runtime() {
         DummySystemInterface.executedAnnotationInternal.clear()
         val cu = assertASTCanBeProduced("mute/MUTE02_RUNTIME", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf())
 
         assertEquals(interpreter.systemInterface.getExecutedAnnotation().size, 5)
@@ -127,7 +127,7 @@ class RpgParserWithMuteRuntimeTest {
     fun parseMUTE02_runtimeWithArray() {
         DummySystemInterface.executedAnnotationInternal.clear()
         val cu = assertASTCanBeProduced("mute/MUTE02_RUNTIME_array", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = execute(cu, mapOf())
 
         assertEquals(interpreter.systemInterface.getExecutedAnnotation().size, 1)
@@ -141,7 +141,7 @@ class RpgParserWithMuteRuntimeTest {
     @Test
     fun executingFIZZBUZZTEST() {
         val cu = assertASTCanBeProduced("mute/FIZZBUZZTEST", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val si = SimpleSystemInterface(programFinders = listOf(ResourceProgramFinder("/mute/")))
 
         val interpreter = execute(cu, mapOf(), systemInterface = si)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/DataDefinitionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/DataDefinitionTest.kt
@@ -7,7 +7,7 @@ import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.parseFragmentToCompilationUnit
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
 import com.smeup.rpgparser.parsing.parsetreetoast.ToAstConfiguration
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -100,14 +100,14 @@ class DataDefinitionTest {
 
     @test fun inStatementDataDefinitionInClearIsProcessed() {
         val cu = assertASTCanBeProduced("CALCFIB", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         assertTrue(cu.hasAnyDataDefinition("dsp"))
         assertEquals(StringType(50), cu.getAnyDataDefinition("dsp").type)
     }
 
     @test fun executeJD_useOfLike() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = InternalInterpreter(DummySystemInterface)
         interpreter.simplyInitialize(cu, emptyMap())
         val dataDefinition = cu.getDataDefinition("U\$SVARSK_INI")
@@ -116,7 +116,7 @@ class DataDefinitionTest {
 
     @test fun executeJD_useOfDim() {
         val cu = assertASTCanBeProduced("JD_001", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val interpreter = InternalInterpreter(DummySystemInterface)
         interpreter.simplyInitialize(cu, emptyMap())
         val dataDefinition = cu.getDataDefinition("U\$SVARSK_INI")
@@ -171,7 +171,7 @@ class DataDefinitionTest {
     @Test
     fun deriveLengthOfFieldFromOverrideClause() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_03", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val AR01 = cu.getDataDefinition("ARDS").getFieldByName("AR01")
         val FI01 = cu.getDataDefinition("ARDS").getFieldByName("FI01")
         val FI02 = cu.getDataDefinition("ARDS").getFieldByName("FI02")
@@ -271,7 +271,7 @@ class DataDefinitionTest {
     @Test
     fun initializationValue() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_03", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val unnamedDs = cu.getDataDefinition("@UNNAMED_DS_48")
         assertEquals(DataStructureType(listOf(
                 FieldType("LOG1", StringType(14)),
@@ -295,7 +295,7 @@ class DataDefinitionTest {
     @Test
     fun initializationValueOnOverlay() {
         val cu = assertASTCanBeProduced("overlay/MUTE12_03", true)
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
 
         val AR01 = cu.getDataOrFieldDefinition("AR01") as FieldDefinition
         assertEquals(122, AR01.elementSize())

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/StatementsTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/StatementsTest.kt
@@ -5,7 +5,7 @@ import com.smeup.rpgparser.interpreter.DummyDBInterface
 import com.smeup.rpgparser.parsing.ast.DataWrapUpChoice.LR
 import com.smeup.rpgparser.parsing.ast.DataWrapUpChoice.RT
 import com.smeup.rpgparser.parsing.parsetreetoast.ToAstConfiguration
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.parsing.parsetreetoast.toAst
 import com.strumenta.kolasu.model.ReferenceByName
 import com.strumenta.kolasu.model.collectByType
@@ -281,7 +281,7 @@ class StatementsTest {
 
     @test fun plistDeclareVariable() {
         val cu = assertASTCanBeProduced("ECHO")
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val plists = cu.collectByType(PlistStmt::class.java).distinct()
         assertEquals(1, plists.size)
         assertEquals(1, plists.first().dataDefinition().size)
@@ -289,7 +289,7 @@ class StatementsTest {
 
     @test fun plistDoesNotDeclareVariable() {
         val cu = assertASTCanBeProduced("ECHO2")
-        cu.resolve(DummyDBInterface)
+        cu.resolveAndValidate(DummyDBInterface)
         val plists = cu.collectByType(PlistStmt::class.java).distinct()
         assertEquals(1, plists.size)
         assertEquals(0, plists.first().dataDefinition().size)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/testing_utils.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/testing_utils.kt
@@ -10,7 +10,7 @@ import com.smeup.rpgparser.parsing.facade.RpgParserResult
 import com.smeup.rpgparser.parsing.facade.firstLine
 import com.smeup.rpgparser.parsing.parsetreetoast.ToAstConfiguration
 import com.smeup.rpgparser.parsing.parsetreetoast.injectMuteAnnotation
-import com.smeup.rpgparser.parsing.parsetreetoast.resolve
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.parsing.parsetreetoast.toAst
 import com.smeup.rpgparser.rpginterop.RpgProgramFinder
 import com.strumenta.kolasu.model.ReferenceByName
@@ -301,7 +301,7 @@ private const val TRACE = false
 
 fun execute(programName: String, initialValues: Map<String, Value>, si: CollectorSystemInterface = ExtendedCollectorSystemInterface(), logHandlers: List<InterpreterLogHandler> = SimpleLogHandler.fromFlag(TRACE), printTree: Boolean = false): InternalInterpreter {
     val cu = assertASTCanBeProduced(programName, true, printTree = printTree)
-    cu.resolve(si.db)
+    cu.resolveAndValidate(si.db)
     si.addExtraLogHandlers(logHandlers)
     return execute(cu, initialValues, si)
 }


### PR DESCRIPTION
We disabled certain runtime checks by default.
We also add some static checks on assignments, refining some typesystem calculations on expressions.