### PR TITLE
Timeout messages

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,4 @@
-# Development
+``# Development
 
 This document contains information for developers who want to contribute to the the project.
 
@@ -57,6 +57,11 @@ All tests (except for performance tests) can be executed by running:
 To run performance tests (i.e. tests tagged with the annotation `@Category(PerformanceTest::class)`) run:
 ```
 ./gradlew testPerformance
+```
+
+You can collect data about failed performance tests in a .csv file using:
+```
+./gradlew testPerformance -DexportCsvFile="/some/file.csv"
 ```
 
 To run all tests:

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -119,7 +119,10 @@ test {
     }
 }
 
+//If you want to collect data about failed performance tests, run this task with:
+//gradlew testPerformance -DexportCsvFile="/some/file.csv"
 task testPerformance(type: Test) {
+    systemProperty 'exportCsvFile', System.getProperty('exportCsvFile')
     maxHeapSize = "2048m"
     testLogging {
         events "passed", "skipped", "failed"

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/control_flow_exceptions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/control_flow_exceptions.kt
@@ -1,5 +1,8 @@
 package com.smeup.rpgparser.interpreter
 
+import com.smeup.rpgparser.utils.runIfNotEmpty
+import java.io.File
+
 open class ControlFlowException() : Exception() {
     override fun fillInStackTrace(): Throwable = this
 }
@@ -13,9 +16,22 @@ class InterruptForDebuggingPurposes : ControlFlowException()
 class ReturnException(val returnValue: Value?) : ControlFlowException()
 class GotoException(val tag: String) : ControlFlowException()
 
-class InterpreterTimeoutException(val elapsed: Long, val expected: Long) : ControlFlowException() {
+class InterpreterTimeoutException(val programName: String, val elapsed: Long, val expected: Long) : ControlFlowException() {
     fun ratio(): Double = if (elapsed <= 0) 0.0 else expected.toDouble() / elapsed.toDouble()
     override fun toString(): String {
-        return "TIMEOUT. Execution took $elapsed millis, but there was a $expected millis timeout. expected/elapsed ratio: ${ratio()}"
+        writeDataToCSV()
+        return "$programName TIMEOUT. Execution took $elapsed millis, but there was a $expected millis timeout. expected/elapsed ratio: ${ratio()}"
+    }
+
+    private fun writeDataToCSV() {
+        System.getProperty("exportCsvFile").runIfNotEmpty {
+            try {
+                val file = File(this)
+                println("Printing results to $this")
+                file.appendText("$programName,$elapsed,$expected,${ratio()}\n")
+            } catch (e: Exception) {
+                System.err.println("Problems with csv file $this : $e")
+            }
+        }
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/control_flow_exceptions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/control_flow_exceptions.kt
@@ -12,3 +12,10 @@ class IterException : ControlFlowException()
 class InterruptForDebuggingPurposes : ControlFlowException()
 class ReturnException(val returnValue: Value?) : ControlFlowException()
 class GotoException(val tag: String) : ControlFlowException()
+
+class InterpreterTimeoutException(val elapsed: Long, val expected: Long) : ControlFlowException() {
+    fun ratio(): Double = if (elapsed <= 0) 0.0 else expected.toDouble() / elapsed.toDouble()
+    override fun toString(): String {
+        return "TIMEOUT. Execution took $elapsed millis, but there was a $expected millis timeout. expected/elapsed ratio: ${ratio()}"
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -242,7 +242,9 @@ class InternalInterpreter(val systemInterface: SystemInterface) : InterpreterCor
             val elapsedTime = measureTimeMillis {
                 execute(compilationUnit.main.stmts)
             }
-            if (elapsedTime > compilationUnit.minTimeOut!!) throw InterpreterTimeoutException(elapsedTime, compilationUnit.minTimeOut!!)
+            if (elapsedTime > compilationUnit.minTimeOut!!) {
+                throw InterpreterTimeoutException(interpretationContext.currentProgramName, elapsedTime, compilationUnit.minTimeOut!!)
+            }
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -15,7 +15,6 @@ import java.math.RoundingMode
 import java.nio.charset.Charset
 import java.text.SimpleDateFormat
 import java.util.*
-import java.util.concurrent.TimeoutException
 import kotlin.collections.HashMap
 import kotlin.collections.LinkedHashMap
 import kotlin.system.measureTimeMillis
@@ -243,7 +242,7 @@ class InternalInterpreter(val systemInterface: SystemInterface) : InterpreterCor
             val elapsedTime = measureTimeMillis {
                 execute(compilationUnit.main.stmts)
             }
-            if (elapsedTime > compilationUnit.minTimeOut!!) throw TimeoutException("Execution took $elapsedTime millis, but there was a ${compilationUnit.minTimeOut} millis timeout")
+            if (elapsedTime > compilationUnit.minTimeOut!!) throw InterpreterTimeoutException(elapsedTime, compilationUnit.minTimeOut!!)
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/muterunner.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/muterunner.kt
@@ -128,13 +128,14 @@ fun executeMuteAnnotations(
     programStream: InputStream,
     systemInterface: SystemInterface,
     verbose: Boolean = false,
-    parameters: Map<String, Value> = mapOf()
+    parameters: Map<String, Value> = mapOf(),
+    programName: String = "<UNKNOWN>"
 ): SortedMap<Int, MuteAnnotationExecuted>? {
     val parserResult =
         RpgParserFacade().apply { muteSupport = true }
         .parse(programStream)
     return if (parserResult.correct) {
-        parserResult.executeMuteAnnotations(verbose, systemInterface, parameters)
+        parserResult.executeMuteAnnotations(verbose, systemInterface, parameters, programName)
     } else {
         null
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
@@ -59,6 +59,11 @@ fun String.divideAtIndex(i: Int): Pair<String, String> {
 }
 
 fun String?.isEmptyTrim() = this == null || this.trim().isEmpty()
+
+inline fun String?.runIfNotEmpty(code: String.() -> Unit) {
+    if (!this.isEmptyTrim()) this?.code()
+}
+
 fun String.asLong(): Long = this.trim().toLong()
 fun String.asInt(): Int = this.trim().toInt()
 fun String?.asIntOrNull(): Int? =

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MUTEExamplesTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MUTEExamplesTest.kt
@@ -5,10 +5,7 @@ import Kute10_54
 import Kute10_55
 import Kute10_56
 import com.andreapivetta.kolor.yellow
-import com.smeup.rpgparser.CollectorSystemInterface
-import com.smeup.rpgparser.DummyProgramFinder
-import com.smeup.rpgparser.ExtendedCollectorSystemInterface
-import com.smeup.rpgparser.PerformanceTest
+import com.smeup.rpgparser.*
 import com.smeup.rpgparser.execution.RunnerCLI.programName
 import com.smeup.rpgparser.mute.color
 import com.smeup.rpgparser.mute.executeMuteAnnotations
@@ -381,7 +378,7 @@ class MUTEExamplesTest {
         require(rpgSourceInputStream != null) {
             "$programName cannot be found"
         }
-        executeMuteAnnotations(rpgSourceInputStream, si)
+        executeMuteAnnotations(rpgSourceInputStream, si, programName = programName)
 
         si.assertMutesSucceed(programName)
         withOutput?.let {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
@@ -9,7 +9,6 @@ import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.jvminterop.JvmProgramRaw
 import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import org.junit.Test
-import java.util.concurrent.TimeoutException
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -61,7 +60,7 @@ class MuteExecutionTest {
         try {
             execute(cu, emptyMap(), si)
             fail("No timeout")
-        } catch (e: TimeoutException) {
+        } catch (e: InterpreterTimeoutException) {
             assertTrue(e.toString().contains(cu.timeouts[0].timeout.toString()))
         }
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/testing_utils.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/testing_utils.kt
@@ -33,6 +33,8 @@ class Dummy
 
 interface PerformanceTest
 
+interface PerformanceTest2
+
 fun parseFragmentToCompilationUnit(
     code: String,
     toAstConfiguration: ToAstConfiguration = ToAstConfiguration(considerPosition = false)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
@@ -2,6 +2,7 @@ package com.smeup.rpgparser.utils
 
 import kotlin.test.assertEquals
 import org.junit.Test
+import kotlin.test.fail
 
 class MiscTest {
 
@@ -38,5 +39,23 @@ class MiscTest {
         assertEquals("abcab", "abc".repeatWithMaxSize(5))
         assertEquals("aaaaa", "a".repeatWithMaxSize(5))
         assertEquals("ab", "abc".repeatWithMaxSize(2))
+    }
+
+    @Test
+    fun runIfNotEmptyTest() {
+        val nullSting: String? = null
+        nullSting.runIfNotEmpty {
+            fail("Should not be executed")
+        }
+
+        " ".runIfNotEmpty {
+            fail("Should not be executed")
+        }
+
+        var result = "Lambda not invoked"
+        "some string".runIfNotEmpty {
+            result = "OK"
+        }
+        assertEquals("OK", result)
     }
 }


### PR DESCRIPTION
## Timeout error messages

Timeout error messages are now more user-friendly, including an elapsed/expected ratio

You can collect data about failed performance tests in a .csv file using:
```
./gradlew testPerformance -DexportCsvFile="/some/file.csv"
```
