### PR TITLE
standalone_mute_runner.kt can now run all tests in a directory

### DIFF
--- a/docs/mute.md
+++ b/docs/mute.md
@@ -134,6 +134,19 @@ Then run the mute test with:
 java -jar rpgJavaInterpreter-core/build/libs/rpgJavaInterpreter-core-mute-all.jar MY_TEST.rpgle
 ```
 
+You can run all the mute tests (i.e. files with suffix .rpgle) contained in a directory with:
+
+```
+java -jar rpgJavaInterpreter-core-mute-all.jar /path/to/my/dir
+```
+
+You can also collect all timeouts exception in a .csv file with
+
+```
+java -DexportCsvFile=/path/to/timeouts.csv -jar rpgJavaInterpreter-core-mute-all.jar /path/to/my/dir
+```
+
+
 ## Mute as part of the CI
 
 The utility to verify Mute annotation is run as part of the CI configuration. All Mute files contained in the directory _mutes_for_ci_ are automatically verified when running `./gradlew check`.

--- a/docs/mute.md
+++ b/docs/mute.md
@@ -134,7 +134,7 @@ Then run the mute test with:
 java -jar rpgJavaInterpreter-core/build/libs/rpgJavaInterpreter-core-mute-all.jar MY_TEST.rpgle
 ```
 
-You can run all the mute tests (i.e. files with suffix .rpgle) contained in a directory with:
+You can run all the mute tests (i.e. files with suffix rpgle) contained in a directory with:
 
 ```
 java -jar rpgJavaInterpreter-core-mute-all.jar /path/to/my/dir

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/standalone_mute_runner.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/standalone_mute_runner.kt
@@ -31,7 +31,7 @@ fun main(args: Array<String>) {
 private fun findFilesToRun(muteSource: File): FilesToRun =
     if (muteSource.isDirectory) {
         FilesToRun(muteSource, muteSource.listFiles { _, name ->
-            name.endsWith(".rpgle", true)
+            name.endsWith("rpgle", true)
         }.toList())
     } else {
         FilesToRun(muteSource.parentFile, listOf(muteSource))

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/standalone_mute_runner.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/standalone_mute_runner.kt
@@ -6,6 +6,8 @@ import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
 import com.smeup.rpgparser.rpginterop.RpgProgramFinder
 import java.io.File
 
+data class FilesToRun(val directory: File, val files: List<File>)
+
 fun main(args: Array<String>) {
     require(args.size > 0) {
         "You must specify a path to a mute program as first parameter"
@@ -14,9 +16,23 @@ fun main(args: Array<String>) {
     require(muteSource.exists()) {
         "${muteSource.canonicalPath} does not exist"
     }
-    println("Running ${muteSource.canonicalPath}")
-    val programFinders = listOf<RpgProgramFinder>(DirRpgProgramFinder(muteSource.parentFile))
-    val result =
-        executeWithMutes(muteSource.toPath(), true, null, programFinders = programFinders, output = System.out)
-    println(result)
+
+    val filesToRun = findFilesToRun(muteSource)
+    val programFinders = listOf<RpgProgramFinder>(DirRpgProgramFinder(filesToRun.directory))
+
+    filesToRun.files.forEach {
+        println("Running $it")
+        val result =
+            executeWithMutes(it.toPath(), true, null, programFinders = programFinders, output = System.out)
+        println(result)
+    }
 }
+
+private fun findFilesToRun(muteSource: File): FilesToRun =
+    if (muteSource.isDirectory) {
+        FilesToRun(muteSource, muteSource.listFiles { _, name ->
+            name.endsWith(".rpgle", true)
+        }.toList())
+    } else {
+        FilesToRun(muteSource.parentFile, listOf(muteSource))
+    }


### PR DESCRIPTION
To run MUTE tests in a directory collecting timeouts data, you can run
```
java -DexportCsvFile=/path/to/timeouts.csv -jar rpgJavaInterpreter-core-mute-all.jar /path/to/my/dir
```