### PR TITLE
Fix profiling usage instruction

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -90,7 +90,7 @@ of RPG program interpretation, jfr file path will be showed in console.
 This feature allows to evaluate bottlenecks, and improve jariko performance.  
 Usage:
 ```
-./gradlew gradlew profileRpgProgram -PrpgProgram=path_to_rpg_program
+./gradlew profileRpgProgram -PrpgProgram=path_to_rpg_program
 ```
 
 


### PR DESCRIPTION
## Description

Profiling command line instructions was wrong

Related to: none

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
