### PR TITLE
Resolving name clash of the main function in com.smeup.rpgparser.mute

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/standalone_mute_runner.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/mute/standalone_mute_runner.kt
@@ -1,4 +1,3 @@
-@file:JvmName("StandaloneMuteRunner")
 
 package com.smeup.rpgparser.mute
 
@@ -8,23 +7,26 @@ import java.io.File
 
 data class FilesToRun(val directory: File, val files: List<File>)
 
-fun main(args: Array<String>) {
-    require(args.size > 0) {
-        "You must specify a path to a mute program as first parameter"
-    }
-    val muteSource = File(args[0])
-    require(muteSource.exists()) {
-        "${muteSource.canonicalPath} does not exist"
-    }
+object StandaloneMuteRunner {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        require(args.size > 0) {
+            "You must specify a path to a mute program as first parameter"
+        }
+        val muteSource = File(args[0])
+        require(muteSource.exists()) {
+            "${muteSource.canonicalPath} does not exist"
+        }
 
-    val filesToRun = findFilesToRun(muteSource)
-    val programFinders = listOf<RpgProgramFinder>(DirRpgProgramFinder(filesToRun.directory))
+        val filesToRun = findFilesToRun(muteSource)
+        val programFinders = listOf<RpgProgramFinder>(DirRpgProgramFinder(filesToRun.directory))
 
-    filesToRun.files.forEach {
-        println("Running $it")
-        val result =
-            executeWithMutes(it.toPath(), true, null, programFinders = programFinders, output = System.out)
-        println(result)
+        filesToRun.files.forEach {
+            println("Running $it")
+            val result =
+                executeWithMutes(it.toPath(), true, null, programFinders = programFinders, output = System.out)
+            println(result)
+        }
     }
 }
 


### PR DESCRIPTION
## Resolving name clash of the main function in com.smeup.rpgparser.mute
Now you can run the main function in standalone_mute_runner from Kotlin this way:

` StandaloneMuteRunner.main(args)`
