### PR TITLE
A D spec can't define a variable with the same name twice

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -10,7 +10,7 @@ import java.lang.RuntimeException
  * This is a very limited interpreter used at compile time, mainly
  * while examining data definitions.
  *
- * It should consider only statically evaluatable elements.
+ * It should consider only statically evaluable elements.
  */
 interface CompileTimeInterpreter {
     fun evaluate(rContext: RpgParser.RContext, expression: Expression): Value

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -17,6 +17,22 @@ import kotlin.test.assertTrue
 class InterpreterTest {
 
     @Test
+    fun doubleVarDefinitionWithDifferentTypeShouldThrowAnError() {
+        val systemInterface = JavaSystemInterface()
+
+        val source = """
+|     D n               S              1  0 inz(00)
+|     D n               S              1  0 inz(00)
+|     C                   SETON                                          LR
+        """.trimMargin()
+
+        val program = getProgram(source, systemInterface)
+        assertFailsWith(IllegalArgumentException::class) {
+            program.singleCall(listOf())
+        }
+    }
+
+    @Test
     fun executeCALCFIB_initialDeclarations_dec() {
         val cu = assertASTCanBeProduced("CALCFIB_1", true)
         cu.resolveAndValidate(DummyDBInterface)

--- a/rpgJavaInterpreter-core/src/test/resources/mute/MUTE01_SYNTAX.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/mute/MUTE01_SYNTAX.rpgle
@@ -7,7 +7,6 @@
      DCOUNT            S              8  0
      DA                S              8  0 INZ(0)
      DB                S              8  0 INZ(1)
-     DB                S              8  0 INZ(1)
      DAR1              S              3S 0 DIM(10)
       *
      C                   CLEAR                   FIELD1


### PR DESCRIPTION
## A D spec can't define a variable with the same name twice

This program should not compile:
```
     D n               S              1  0 inz(00)
     D n               S              1  0 inz(00)
     C                   SETON                                          LR
```