### PR TITLE
Optimizing mute execution

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -286,11 +286,13 @@ class InternalInterpreter(
         } catch (e: RuntimeException) {
             throw RuntimeException(errorDescription(statement, e), e)
         } finally {
-            executeMutes(
-                statement.muteAnnotations,
-                statement.ancestor(CompilationUnit::class.java)!!,
-                statement.position.line()
-            )
+            if (statement.muteAnnotations.size > 0) {
+                executeMutes(
+                    statement.muteAnnotations,
+                    statement.ancestor(CompilationUnit::class.java)!!,
+                    statement.position.line()
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Optimizing mute execution

The line method is called only if there are mutes that need to be evaluated