### PR TITLE
Fixed a potential issue that can occur if the same program is called twice and others little interesting things

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -2,6 +2,7 @@ package com.smeup.rpgparser.execution
 
 import com.smeup.rpgparser.interpreter.ActivationGroup
 import com.smeup.rpgparser.interpreter.IMemorySliceStorage
+import com.smeup.rpgparser.interpreter.ISymbolTable
 
 /**
  * Configuration object
@@ -18,9 +19,13 @@ data class Configuration(
  * Sometimes we have to gain control of Jariko, this is the right place.
  * It was primarily intended for future use.
  * @param getActivationGroup If specified, it overrides the activation group associated to the program. Default null (no activation group)
- * @param exitInRT If specified, it overrides the exit mode established in program. Default null (no seton rt od lr mode)
+ * @param exitInRT If specified, it overrides the exit mode established in program. Default null (nei seton rt od lr mode)
+ * @param onEnterPgm It is invoked on program enter after symboltable initialization.
+ * @param onExitPgm It is invoked on program exit
  * */
 data class JarikoCallback(
     val getActivationGroup: (programName: String) -> ActivationGroup? = { null },
-    val exitInRT: (programName: String) -> Boolean? = { null }
+    val exitInRT: (programName: String) -> Boolean? = { null },
+    val onEnterPgm: (programName: String, symbolTable: ISymbolTable) -> Unit = { _: String, _: ISymbolTable -> },
+    val onExitPgm: (programName: String, symbolTable: ISymbolTable, error: Throwable?) -> Unit = { _: String, _: ISymbolTable, _: Throwable? -> }
 )

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -282,8 +282,20 @@ class InternalInterpreter(
                     if (i < 0 || i >= statements.size) throw e
                 }
             }
+            MainExecutionContext.getConfiguration().jarikoCallback.onExitPgm.invoke(
+                interpretationContext.currentProgramName,
+                globalSymbolTable,
+                null
+            )
         } catch (e: ReturnException) {
             // TODO use return value
+        } catch (t: Throwable) {
+            MainExecutionContext.getConfiguration().jarikoCallback.onExitPgm.invoke(
+                interpretationContext.currentProgramName,
+                globalSymbolTable,
+                t
+            )
+            throw t
         }
     }
 
@@ -769,6 +781,10 @@ class InternalInterpreter(
                 MainExecutionContext.getAttributes()[MEMORY_SLICE_ATTRIBUTE] = it.associate(memorySliceId, globalSymbolTable)
             }
         }
+        MainExecutionContext.getConfiguration().jarikoCallback.onEnterPgm.invoke(
+            interpretationContext.currentProgramName,
+            globalSymbolTable
+        )
     }
 
     private fun isExitingInRTMode(): Boolean {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/symbol_table_storaging.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/symbol_table_storaging.kt
@@ -85,17 +85,18 @@ class MemorySliceMgr(private val storage: IMemorySliceStorage) {
 
     /**
      * Associate a symbol table to a memory slice.
-     * At first time association, symbol table will be initialized by loading of persistent data through IMemorySliceStorage
+     * In every case the association (and initialization of symbol table) is always followed by storage load invocation, for this reason, caching optimization
+     * should be handled in IMemorySliceStorage implementation.
      * */
     fun associate(memorySliceId: MemorySliceId, symbolTable: ISymbolTable): MemorySlice {
-        return memorySlices.computeIfAbsent(memorySliceId) {
-            storage.load(it).forEach() { nameToValue ->
-                getDataDefinition(nameToValue.key, symbolTable).let { dataDef ->
-                    symbolTable[dataDef!!] = nameToValue.value
-                }
+        val memorySlice = MemorySlice(memorySliceId = memorySliceId, symbolTable = symbolTable)
+        memorySlices[memorySliceId] = memorySlice
+        storage.load(memorySliceId).forEach() { nameToValue ->
+            getDataDefinition(nameToValue.key, symbolTable).let { dataDef ->
+                symbolTable[dataDef!!] = nameToValue.value
             }
-            MemorySlice(memorySliceId = memorySliceId, symbolTable = symbolTable)
         }
+        return memorySlice
     }
 
     /**

--- a/rpgJavaInterpreter-core/src/test/resources/ACTGRP_FIX.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ACTGRP_FIX.rpgle
@@ -1,4 +1,4 @@
-     H ACTGRP('MyAct')
+     H ACTGRP('MYACT')
      D X               S              1  0
      D Msg             S             12
      C                   EVAL      X = X + 1


### PR DESCRIPTION
## Description
 * Fixed a potential issue that can occur if the same program is called three or more times and the first time comes out in RT while the others comes out in LR. On the third call, the symbol table is not initialized correctly.

 * Added JarikoCallback.onEnterPgm and JarikoCallback.onExitPgm in order to inspect  memory, before and after program execution.

 * Improved and added some unit test.


## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
