### PR TITLE
The name of the MuteAstPerformance test for compiled rpgs was not sta…

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MutePerformanceAstTestCompiled.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MutePerformanceAstTestCompiled.kt
@@ -1,6 +1,6 @@
 package com.smeup.rpgparser.evaluation
 
-class MutePerformanceAstCompiled : MutePerformanceAstTest() {
+class MutePerformanceAstTestCompiled : MutePerformanceAstTest() {
 
     override fun useCompiledVersion() = true
 }


### PR DESCRIPTION
The name of the MuteAstPerformance test for compiled rpgs was not standard