### PR TITLE
The RPGLE input stream (source or binary) was never released.

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -47,8 +47,10 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
 
     companion object {
         fun fromInputStream(inputStream: InputStream, name: String = "<UNNAMED INPUT STREAM>", sourceProgram: SourceProgram? = SourceProgram.RPGLE): RpgProgram {
-            val cu = RpgParserFacade().parseAndProduceAst(inputStream, sourceProgram)
-            return RpgProgram(cu, name)
+            inputStream.use {
+                val cu = RpgParserFacade().parseAndProduceAst(inputStream, sourceProgram)
+                return RpgProgram(cu, name)
+            }
         }
     }
 


### PR DESCRIPTION
This could cause a side effect that makes impossibile the RPGLE hot change in windows platform.

## Checklist:
- [ ] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
