### PR TITLE
Added full support for DurationCode in SUBDUR opcode.

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -307,16 +307,44 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: DiffExpr): Value {
-        // TODO expression.durationCode
         val v1 = expression.value1.evalWith(this)
         val v2 = expression.value2.evalWith(this)
         return when (expression.durationCode) {
-            is DurationInMSecs -> DecimalValue(BigDecimal(v1.asTimeStamp().value.time - v2.asTimeStamp().value.time))
-            is DurationInDays -> DecimalValue(BigDecimal(
+            is DurationInMSecs -> IntValue(
+                ChronoUnit.MICROS.between(
+                    v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
+                )
+            )
+            is DurationInDays -> IntValue(
                 ChronoUnit.DAYS.between(
                     v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
                 )
-            ))
+            )
+            is DurationInSecs -> IntValue(
+                ChronoUnit.SECONDS.between(
+                    v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
+                )
+            )
+            is DurationInMinutes -> IntValue(
+                ChronoUnit.MINUTES.between(
+                    v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
+                )
+            )
+            is DurationInHours -> IntValue(
+                ChronoUnit.HOURS.between(
+                    v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
+                )
+            )
+            is DurationInMonths -> IntValue(
+                ChronoUnit.MONTHS.between(
+                    v2.asTimeStamp().localDate, v1.asTimeStamp().localDate
+                )
+            )
+            is DurationInYears -> IntValue(
+                ChronoUnit.YEARS.between(
+                    v2.asTimeStamp().localDate, v1.asTimeStamp().localDate
+                )
+            )
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -135,7 +135,7 @@ data class DecExpr(
     override val position: Position? = null
 ) : Expression(position) {
     override fun render(): String {
-        return "${this.value.render()}"
+        return this.value.render()
     }
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
@@ -147,9 +147,7 @@ data class IntExpr(
     override val position: Position? = null
 ) :
     Expression(position) {
-    override fun render(): String {
-        return "${this.value.render()}"
-    }
+    override fun render(): String = "${this.value.render()}"
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
 
@@ -158,7 +156,7 @@ data class IntExpr(
 data class SqrtExpr(var value: Expression, override val position: Position? = null) :
         Expression(position) {
     override fun render(): String {
-        return "${this.value.render()}"
+        return this.value.render()
     }
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
@@ -263,11 +261,19 @@ data class ReplaceExpr(
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
 
-// TODO Move and handle different types of duration
-// TODO document what a duration code is
 @Serializable
 sealed class DurationCode
 @Serializable
 object DurationInMSecs : DurationCode()
 @Serializable
 object DurationInDays : DurationCode()
+@Serializable
+object DurationInSecs : DurationCode()
+@Serializable
+object DurationInMinutes : DurationCode()
+@Serializable
+object DurationInHours : DurationCode()
+@Serializable
+object DurationInMonths : DurationCode()
+@Serializable
+object DurationInYears : DurationCode()

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
@@ -251,7 +251,7 @@ open class MuteExecutionTest : AbstractTest() {
         assertMuteExecutionSucceded("mute/MUTE13_26")
     }
 
-    @Test @Ignore
+    @Test
     fun executeMUTE13_27() {
         assertMuteExecutionSucceded("mute/MUTE13_27")
     }

--- a/rpgJavaInterpreter-core/src/test/resources/mute/MUTE13_27.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/mute/MUTE13_27.rpgle
@@ -26,12 +26,12 @@
      C                   EVAL      XTIMEN='2021-03-29-16.44.01.538000'
      C                   EVAL      $TIMEN=%TIMESTAMP(XTIMEN)
       * Elapsed time
-    MU* VAL1($TIMMS) VAL2('45813000  ') COMP(EQ)
+    MU* VAL1($TIMMS) VAL2(45813000) COMP(EQ)
      C     $TIMEN        SUBDUR    $TIMST        $TIMMS:*MS
       *
       * Calculate the number of Seconds between two time
       * Elapsed time
-    MU* VAL1($TIMSS) VAL2('45        ') COMP(EQ)
+    MU* VAL1($TIMSS) VAL2(45) COMP(EQ)
      C     $TIMEN        SUBDUR    $TIMST        $TIMSS:*S
       *
       * Calculate the number of Minutes between two time
@@ -40,12 +40,12 @@
      C                   EVAL      XTIMEN='2021-03-29-16.44.01.538000'
      C                   EVAL      $TIMEN=%TIMESTAMP(XTIMEN)
       * Elapsed time
-    MU* VAL1($TIMMN) VAL2('240       ') COMP(EQ)
+    MU* VAL1($TIMMN) VAL2(240) COMP(EQ)
      C     $TIMEN        SUBDUR    $TIMST        $TIMMN:*MN
       *
       * Calculate the number of Hours between two time
       * Elapsed time
-    MU* VAL1($TIMHR) VAL2('4         ') COMP(EQ)
+    MU* VAL1($TIMHR) VAL2(4) COMP(EQ)
      C     $TIMEN        SUBDUR    $TIMST        $TIMHR:*H
       *
       * Calculate the number of Days between two time
@@ -54,17 +54,17 @@
      C                   EVAL      XTIMEN='2021-03-29-16.44.01.538000'
      C                   EVAL      $TIMEN=%TIMESTAMP(XTIMEN)
       * Elapsed time
-    MU* VAL1($TIMDY) VAL2('731       ') COMP(EQ)
+    MU* VAL1($TIMDY) VAL2(731) COMP(EQ)
      C     $TIMEN        SUBDUR    $TIMST        $TIMDY:*D
       *
       * Calculate the number of Months between two time
       * Elapsed time
-    MU* VAL1($TIMMT) VAL2('24        ') COMP(EQ)
+    MU* VAL1($TIMMT) VAL2(24) COMP(EQ)
      C     $TIMEN        SUBDUR    $TIMST        $TIMMT:*M
       *
       * Calculate the number of Years between two time
       * Elapsed time
-    MU* VAL1($TIMYS) VAL2('2         ') COMP(EQ)
+    MU* VAL1($TIMYS) VAL2(2) COMP(EQ)
      C     $TIMEN        SUBDUR    $TIMST        $TIMYS:*Y
       *
      C                   SETON                                        LR


### PR DESCRIPTION
## Description
Moved the DurationCode logic to DiffExpression to make the code cleaner and easier to handle.
Some types of errors that might arise on AST creation have been made clearer.
Fixed mute assertions which weren't properly coded.

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
