### PR TITLE
Fixed reload integration compilation issue.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -19,8 +19,8 @@ buildscript {
 }
 
 dependencies {
-  compile project(":rpgJavaInterpreter-core")
-  testCompile "org.jetbrains.kotlin:kotlin-test:$kotlinVersion".toString()
-  testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion".toString()
-  testCompile 'junit:junit:4.12'
+    implementation project(":rpgJavaInterpreter-core")
+    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlinVersion".toString()
+    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion".toString()
+    testCompile 'junit:junit:4.12'
 }

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     compile 'commons-io:commons-io:2.6'
     compile 'com.github.ajalt:clikt:2.1.0'
-    compile 'com.github.smeup:reload:master-SNAPSHOT'
+    api 'com.github.smeup:reload:-SNAPSHOT'
 
     compile 'com.github.ziggy42:kolor:0.0.2'
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/db.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/db.kt
@@ -1,9 +1,9 @@
 package com.smeup.rpgparser.interpreter
 
-import com.smeup.dbnative.model.CharacterType
 import com.smeup.dbnative.model.Field
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -101,7 +101,7 @@ fun FileMetadata.toReloadMetadata(): com.smeup.dbnative.model.FileMetadata {
         tableName = this.tableName,
         recordFormat = this.recordFormat,
         fields = fields.map {
-            Field(it.fieldName, CharacterType(112))
+            Field(it.fieldName)
         },
         fileKeys = accessFields
     )


### PR DESCRIPTION
Changed reload dependency from compile to api because compile dependency has been deprecated and if we want to expose reload as api to the projects dependant from jariko, api dependency is the right mode.

## Checklist:
- [ ] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
