### PR TITLE
Call error handling evaluating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,11 @@ jobs:
                     mkdir -p ~/test-results-html/
                     find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
                 when: always
-            - run: gradle assemble
+            - run: ./gradlew assemble
             - store_test_results:
                 path: ~/test-results
             - store_artifacts:
-                path: ~/test-results/junit            
+                path: ~/test-results/junit
             - store_artifacts:
                 path: ~/project/rpgJavaInterpreter-core/build/reports
                 destination: test-results-html/
@@ -31,6 +31,6 @@ jobs:
                 key: gradle-{{ checksum "build.gradle" }}
             - store_artifacts:
                 path: ~/project/rpgJavaInterpreter-core/build/libs
-                destination: libs     
+                destination: libs
 
       

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -17,9 +17,7 @@
 package com.smeup.rpgparser.evaluation
 
 import com.smeup.rpgparser.*
-import com.smeup.rpgparser.execution.Configuration
-import com.smeup.rpgparser.execution.JarikoCallback
-import com.smeup.rpgparser.execution.getProgram
+import com.smeup.rpgparser.execution.*
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
 import com.smeup.rpgparser.jvminterop.JvmProgramRaw
@@ -30,6 +28,7 @@ import com.smeup.rpgparser.utils.asInt
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
+import java.math.BigDecimal
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.test.assertEquals
@@ -1886,5 +1885,79 @@ Test 6
                 "Echo P1: INZ",
                 "Echo P2:"),
             outputOf("PGM_A", configuration = configuration))
+    }
+
+    // CALL_DIVIDE calls DIVIDE and it expects a regular execution
+    @Test
+    fun executeCALL_DIVIDE_Ok() {
+        val params = CommandLineParms(
+            mapOf(
+                "A" to DecimalValue(BigDecimal.valueOf(10)),
+                "B" to DecimalValue(BigDecimal.valueOf(10)),
+                "RESULT" to DecimalValue(BigDecimal.valueOf(0)),
+                "CATCHERR" to IntValue(0)
+            )
+        )
+        val result = executePgm(programName = "CALL_DIVIDE", params = params)
+        // 10/10 = 1
+        assertEquals(
+            expected = BigDecimal.valueOf(1).toDouble(),
+            actual = result!!.namedParams!!["RESULT"]!!.asDecimal().value.toDouble()
+        )
+    }
+
+    // CALL_DIVIDE calls DIVIDE forcing an error
+    // In this case CALL_DIVIDE program doesn't must handle any error
+    @Test
+    fun executeCALL_DIVIDE_ErrIndicatorNo() {
+        val si = JavaSystemInterface()
+        val paramsKo = CommandLineParms(
+            mapOf(
+                "A" to DecimalValue(BigDecimal.valueOf(10)),
+                // Forcing error
+                "B" to DecimalValue(BigDecimal.valueOf(0)),
+                "RESULT" to DecimalValue(BigDecimal.valueOf(0)),
+                "CATCHERR" to IntValue(0)
+            )
+        )
+        assertFailsWith<java.lang.RuntimeException> {
+            executePgm(
+                programName = "CALL_DIVIDE",
+                params = paramsKo,
+                systemInterface = si
+            )
+        }
+        // DSPLY must be executed just once
+        assertEquals(1, si.consoleOutput.size)
+    }
+
+    // CALL_DIVIDE calls DIVIDE forcing an error
+    // In this case CALL_DIVIDE program should handle the error
+    @Test
+    fun executeCALL_DIVIDE_ErrIndicatorYes() {
+        // I create JavaSystemInterface to access to the console
+        // I create Configuration and set muteSupport to true because
+        // CALL_DIVIDE.rpgle contains a mute annotation
+        val systemInterface = JavaSystemInterface()
+        val configuration = Configuration(options = Options(muteSupport = true))
+        val paramsKo = CommandLineParms(
+            mapOf(
+                "A" to DecimalValue(BigDecimal.valueOf(10)),
+                // Forcing error
+                "B" to DecimalValue(BigDecimal.valueOf(0)),
+                "RESULT" to DecimalValue(BigDecimal.valueOf(0)),
+                // Pass to 1 to handle error (view CALL_DIVIDE.rpgle implementation)
+                "CATCHERR" to IntValue(1)
+            )
+        )
+        executePgm(
+            programName = "CALL_DIVIDE",
+            params = paramsKo,
+            systemInterface = systemInterface,
+            configuration = configuration
+        )
+
+        // DSPLY must be executed twice
+        assertEquals(2, systemInterface.consoleOutput.size)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/CALL_DIVIDE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/CALL_DIVIDE.rpgle
@@ -1,0 +1,39 @@
+      *---------------------------------------------------------------
+      * TESTED FEATURES: CALL STMT ERROR HANDLING
+      * NOTES: A, B, CATCHERR ARE PASSED FROM TEST UNIT IN ORDER TO MAKE
+      *        DYNAMIC THESE TESTS
+      *---------------------------------------------------------------
+      *
+     D MSG             S             50
+     D A               S              6  2
+     D B               S              6  2
+     D CATCHERR        S              1  0
+     D RESULT          S              6  2
+      *---------------------------------------------------------------
+     C                   EVAL      MSG = 'CALLING DIVIDE'
+     C     MSG           DSPLY
+     C                   IF        CATCHERR = 0
+     C                   CALL      'DIVIDE'
+     C                   PARM                    A
+     C                   PARM                    B
+     C                   PARM                    RESULT
+     C                   ELSE
+      *---------------------------------------------------------------
+      * ON BRANCH ELSE EXECUTION I AM SURE THAT DIVIDE WILL ARISE
+      * AN ERROR FOR THIS REASON THE MUTE CHECKS ON INDICATOR
+      *---------------------------------------------------------------
+    MU* VAL1(*IN37) VAL2(*ON) COMP(EQ)
+     C                   CALL      'DIVIDE'                             37
+     C                   PARM                    A
+     C                   PARM                    B
+     C                   PARM                    RESULT
+     C                   ENDIF
+     C                   EVAL      MSG = 'DIVIDE CALLED'
+     C     MSG           DSPLY
+      *---------------------------------------------------------------
+     C     *ENTRY        PLIST
+     C                   PARM                    A
+     C                   PARM                    B
+     C                   PARM                    CATCHERR
+     C                   PARM                    RESULT
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/DIVIDE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/DIVIDE.rpgle
@@ -1,0 +1,13 @@
+      *---------------------------------------------------------------
+      * SIMPLE PROGRAM THAT CALCULATES C = A / B
+      *---------------------------------------------------------------
+     D A               S              6  2
+     D B               S              6  2
+     D RESULT          S              6  2
+     C
+     C     *ENTRY        PLIST
+     C                   PARM                    A
+     C                   PARM                    B
+     C                   PARM                    RESULT
+     C                   EVAL      RESULT = A / B
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
Added some unit tests to evaluate the correctness about the handling of  errors thrown from called programs.
Fixed an issue of "gradle assemble step" that failed during circleci integration test, the failure was due to incorrect configuration script in which gradle wrapper was not used.
Related to # (issue)

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
