### PR TITLE
Fix test named 'testCallProgramHandler' 

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/execution/RunnerTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/execution/RunnerTest.kt
@@ -144,8 +144,7 @@ class RunnerTest : AbstractTest() {
             handleCall = { programName: String, _: SystemInterface, _: LinkedHashMap<String, Value> ->
                 if (programName == "TRANSLATE") {
                     listOf(
-                        StringValue(value = "Ciao!!!", varying = false
-                        )
+                        StringValue(value = "Ciao!!!", varying = false)
                     )
                 } else {
                     null


### PR DESCRIPTION
Fix test named 'testCallProgramHandler'  due to avoid failure caused by broken public '3th part mock' web service.

## Description

Include a summary of the change.

Related to # (issue)

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
