### PR TITLE
Fix lookup bif (when using start/end indexes parameters)

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -157,9 +157,22 @@ class ExpressionEvaluation(
     override fun eval(expression: LookupExpr): Value {
         val searchValued = expression.searchedValued.evalWith(this)
         val array = expression.array.evalWith(this) as ArrayValue
-        val index = array.elements().indexOfFirst {
+        var index = array.elements().indexOfFirst {
             areEquals(it, searchValued)
         }
+        // If 'start' and/or 'length' specified (both optional)
+        // Start: is the index of array element to start search
+        // Length: is the limit number of elements to search forward
+        var start = expression.start?.evalWith(this)?.asInt()
+        start = start?.minus(1.asValue()) ?: 0.asValue()
+
+        val arrayElements = expression.array.type().numberOfElements().asValue()
+        val length = expression.length?.evalWith(this)?.asInt() ?: arrayElements
+
+        val lowerLimit = start.value
+        val upperLimit = start.plus(length).value - 1
+        if (lowerLimit > index || upperLimit < index) index = -1
+
         return if (index == -1) 0.asValue() else (index + 1).asValue()
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -31,6 +31,8 @@ import kotlinx.serialization.Serializable
 data class LookupExpr(
     var searchedValued: Expression,
     val array: Expression,
+    val start: Expression? = null,
+    val length: Expression? = null,
     override val position: Position? = null
 ) : Expression(position) {
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/bif.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/bif.kt
@@ -201,6 +201,8 @@ internal fun RpgParser.Bif_lookupContext.toAst(conf: ToAstConfiguration = ToAstC
     return LookupExpr(
             this.bif_lookupargs().arg.toAst(conf),
             this.bif_lookupargs().array.toAst(conf),
+            this.bif_lookupargs().startindex?.toAst(conf),
+            this.bif_lookupargs().numberelements?.toAst(conf),
             toPosition(conf.considerPosition))
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
@@ -276,6 +276,11 @@ open class MuteExecutionTest : AbstractTest() {
     }
 
     @Test
+    fun executeMUTE13_28() {
+        assertMuteExecutionSucceded("mute/MUTE13_28")
+    }
+
+    @Test
     fun executeMUTE15_01() {
         executePgm("mute/MUTE15_01", configuration = Configuration().apply { options = Options(muteSupport = true) })
     }

--- a/rpgJavaInterpreter-core/src/test/resources/mute/MUTE13_28.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/mute/MUTE13_28.rpgle
@@ -1,0 +1,55 @@
+     V*=====================================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V*=====================================================================
+     V* 17/08/21  003123  BERNI Creato
+     V* 18/08/21  003123  BERNI Aggiunti casi
+     V*=====================================================================
+     D*  OBIETTIVO
+     D*  Programma finalizzato ai test sulla %LOOKUP
+     V*=====================================================================
+     D  ARRAY          S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+     D  INDEX          S              2  0
+      *---------------------------------------------------------------
+     D* M A I N
+      *---------------------------------------------------------------
+     C                   EXSR      ROUTINE
+     C                   SETON                                        LR
+      *---------------------------------------------------------------
+     D* Routine
+      *---------------------------------------------------------------
+     C     ROUTINE       BEGSR
+      *
+    MU* VAL1(INDEX) VAL2(1) COMP(EQ)
+     C                   EVAL      INDEX=%LOOKUP('AAAAA':ARRAY:1:3)
+      *
+    MU* VAL1(INDEX) VAL2(2) COMP(EQ)
+     C                   EVAL      INDEX=%LOOKUP('BBBBB':ARRAY:1:3)
+      *
+    MU* VAL1(INDEX) VAL2(2) COMP(EQ)
+     C                   EVAL      INDEX=%LOOKUP('BBBBB':ARRAY:2:2)
+      *
+    MU* VAL1(INDEX) VAL2(9) COMP(EQ)
+     C                   EVAL      INDEX=%LOOKUP('IIIII':ARRAY:9:1)
+      *
+    MU* VAL1(INDEX) VAL2(0) COMP(EQ)
+     C                   EVAL      INDEX=%LOOKUP('AAAAA':ARRAY:7)
+      *
+    MU* VAL1(INDEX) VAL2(0) COMP(EQ)
+     C                   EVAL      INDEX=%LOOKUP('IIIII':ARRAY:1:3)
+      *
+    MU* VAL1(INDEX) VAL2(2) COMP(EQ)
+     C                   EVAL      INDEX=%LOOKUP('BBBBB':ARRAY:2)
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------
+** TXT1
+AAAAA
+BBBBB
+CCCCC
+DDDDD
+EEEEE
+FFFFF
+GGGGG
+HHHHH
+IIIII


### PR DESCRIPTION
## Description

Add properly handle of optional parameters in **%LOOKUP** Built In Function, used to limit search into array.

- the start parameter is used as start element index to search forward;
- the length parameter is used as "number of elements" upper limit to search;

This implementation is done to avoid lookup fails search if above parameters are specified.
Test **MUTE13_28.rpgle** check properly implementation

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
