### PR TITLE
Fix multiple array declaration

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -199,6 +199,7 @@ open class InternalInterpreter(
             dbFileMap.add(it)
         }
 
+        var index: Int = 0
         // Assigning initial values received from outside and consider INZ clauses
         // symboltable goes empty when program exits in LR mode so, it is always needed reinitialize, in these
         // circumstances is correct reinitialization
@@ -219,7 +220,7 @@ open class InternalInterpreter(
                         }
                         it.initializationValue != null -> eval(it.initializationValue)
                         it.isCompileTimeArray() -> toArrayValue(
-                            compilationUnit.compileTimeArray(it.name),
+                            compilationUnit.compileTimeArray(index++),
                             (it.type as ArrayType)
                         )
                         else -> blankValue(it)
@@ -253,10 +254,10 @@ open class InternalInterpreter(
                 // Fix issue on CTDATA
                 val ctdata = compilationUnit.compileTimeArray(it.name)
                 if (ctdata.name == it.name) {
-                    val xx = toArrayValue(
+                    value = toArrayValue(
                             compilationUnit.compileTimeArray(it.name),
                             (it.type as ArrayType))
-                    set(it, xx)
+                    set(it, value)
                 }
 
                 if (value != null) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
@@ -154,6 +154,13 @@ data class CompilationUnit(
         return compileTimeArrays.firstOrNull { it.name.equals(name, ignoreCase = true) } ?: firstCompileTimeArray()
     }
 
+    fun compileTimeArray(index: Int): CompileTimeArray {
+        require(compileTimeArrays.isNotEmpty()) {
+            "CompileTimeArrays is empty"
+        }
+        return compileTimeArrays[index]
+    }
+
     fun hasFileDefinition(name: String) = fileDefinitions.any { it.name.equals(name, ignoreCase = true) }
 
     fun getFileDefinition(name: String) = fileDefinitions.first { it.name.equals(name, ignoreCase = true) }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -280,7 +280,14 @@ private fun Dcl_dsContext.useLikeDs(conf: ToAstConfiguration): Boolean {
 }
 
 internal fun EndSourceContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): CompileTimeArray {
-    fun cName(s: String) = s.substringAfter("CTDATA ").replace("\\s".toRegex(), "")
+
+        fun cName(s: String) =
+            if (s.contains("**CTDATA")) {
+                s.substringAfter("**CTDATA ").replace("\\s".toRegex(), "")
+            } else {
+                s.replace(s, "")
+            }
+
     return CompileTimeArray(
         cName(this.endSourceHead().text), // TODO: change grammar to get **CTDATA name
         this.endSourceLine().map { it.endSourceLineText().text },

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
@@ -265,6 +265,26 @@ open class MuteExecutionTest : AbstractTest() {
         assertMuteExecutionSucceded("overlay/MUTE12_09")
     }
 
+    @Test
+    fun executeMUTE12_11() {
+        assertMuteExecutionSucceded("data/ds/MUTE12_11", 12)
+    }
+
+    @Test
+    fun executeMUTE12_12() {
+        assertMuteExecutionSucceded("data/ds/MUTE12_12", 4)
+    }
+
+    @Test
+    fun executeMUTE12_13() {
+        assertMuteExecutionSucceded("data/ds/MUTE12_13", 4)
+    }
+
+    @Test
+    fun executeMUTE12_14() {
+        assertMuteExecutionSucceded("data/ds/MUTE12_14", 4)
+    }
+
     @Test @Ignore
     fun executeMUTE13_26() {
         assertMuteExecutionSucceded("mute/MUTE13_26")

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/lexing/RpgLexingAcceptanceTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/lexing/RpgLexingAcceptanceTest.kt
@@ -13,7 +13,7 @@ class RpgLexingAcceptanceTest {
     @Category(AcceptanceTest::class)
     fun lexAllDataExamples() {
         var failures = 0
-        processFilesInDirectory("src/test/resources/data", 15) { rpgFile ->
+        processFilesInDirectory("src/test/resources/data", 19) { rpgFile ->
             try {
                 assertCanBeLexed(rpgFile)
             } catch (e: AssertionError) {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParsingAcceptanceTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParsingAcceptanceTest.kt
@@ -13,7 +13,7 @@ class RpgParsingAcceptanceTest {
     @Category(AcceptanceTest::class)
     fun parseAllDataExamples() {
         var failures = 0
-        processFilesInDirectory("src/test/resources/data", 15) { rpgFile ->
+        processFilesInDirectory("src/test/resources/data", 19) { rpgFile ->
             try {
                 assertCanBeParsed(rpgFile)
             } catch (e: AssertionError) {

--- a/rpgJavaInterpreter-core/src/test/resources/data/ds/MUTE12_11.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/data/ds/MUTE12_11.rpgle
@@ -1,0 +1,104 @@
+     V*=====================================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V*=====================================================================
+     V* 17/08/21  003123  BERNI Creato
+     V*=====================================================================
+     D*  OBIETTIVO
+     D*  Programma finalizzato ai test sulle schiere interne al programma
+     V*=====================================================================
+     DRESULT           S             35
+     D TXT1            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+     D TXT2            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+     D TXT3            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+      *---------------------------------------------------------------
+     D* M A I N
+      *---------------------------------------------------------------
+     C                   EXSR      ARRAY
+      *
+     C                   SETON                                        LR
+      *---------------------------------------------------------------
+     C     ARRAY         BEGSR
+      * Test sullla prima schiera
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('FIRST                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(1)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('THIRD                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(3)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('FIFTH                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(5)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('SEVENTH                           ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(7)
+      *
+      * Test sulla seconda schiera
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('ONE                               ') COMP(EQ)
+     C                   EVAL      RESULT=TXT2(1)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('THREE                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT2(3)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('FIVE                              ') COMP(EQ)
+     C                   EVAL      RESULT=TXT2(5)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('SEVEN                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT2(7)
+      *
+      * Test sulla terza schiera
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('PRIMO                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT3(1)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('TERZO                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT3(3)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('QUINTO                            ') COMP(EQ)
+     C                   EVAL      RESULT=TXT3(5)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('SETTIMO                           ') COMP(EQ)
+     C                   EVAL      RESULT=TXT3(7)
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------
+**TXT1
+FIRST
+SECOND
+THIRD
+FOURTH
+FIFTH
+SIXTH
+SEVENTH
+EIGHTH
+NINTH
+** TXT2
+ONE
+TWO
+THREE
+FOUR
+FIVE
+SIX
+SEVEN
+EIGHT
+NINE
+** TXT3
+PRIMO
+SECONDO
+TERZO
+QUARTO
+QUINTO
+SESTO
+SETTIMO
+OTTAVO
+NONO

--- a/rpgJavaInterpreter-core/src/test/resources/data/ds/MUTE12_12.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/data/ds/MUTE12_12.rpgle
@@ -1,0 +1,71 @@
+     V*=====================================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V*=====================================================================
+     V* 01/09/21  003123  BUSFIO Creazione
+     V*=====================================================================
+     D*  OBIETTIVO
+     D*  Programma finalizzato ai test sulle schiere interne al programma:
+     D*  schiere senza nome
+     V*=====================================================================
+     DRESULT           S             35
+     D TXT3            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+     D TXT2            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+     D TXT1            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+      *---------------------------------------------------------------
+     D* M A I N
+      *---------------------------------------------------------------
+     C                   EXSR      ARRAY
+      *
+     C                   SETON                                        LR
+      *---------------------------------------------------------------
+     C     ARRAY         BEGSR
+      * Test sullla prima schiera
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('PRIMO                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(1)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('THREE                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT2(3)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('FIFTH                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT3(5)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('SETTIMO                           ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(7)
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------
+**
+FIRST
+SECOND
+THIRD
+FOURTH
+FIFTH
+SIXTH
+SEVENTH
+EIGHTH
+NINTH
+**
+ONE
+TWO
+THREE
+FOUR
+FIVE
+SIX
+SEVEN
+EIGHT
+NINE
+**
+PRIMO
+SECONDO
+TERZO
+QUARTO
+QUINTO
+SESTO
+SETTIMO
+OTTAVO
+NONO

--- a/rpgJavaInterpreter-core/src/test/resources/data/ds/MUTE12_13.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/data/ds/MUTE12_13.rpgle
@@ -1,0 +1,71 @@
+     V*=====================================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V*=====================================================================
+     V* 01/09/21  003123  BUSFIO Creazione
+     V*=====================================================================
+     D*  OBIETTIVO
+     D*  Programma finalizzato ai test sulle schiere interne al programma:
+     D*  Schiere in fondo con nomi diversi rispetto alle specifiche D
+     V*=====================================================================
+     DRESULT           S             35
+     D TXT3            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+     D TXT2            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+     D TXT1            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+      *---------------------------------------------------------------
+     D* M A I N
+      *---------------------------------------------------------------
+     C                   EXSR      ARRAY
+      *
+     C                   SETON                                        LR
+      *---------------------------------------------------------------
+     C     ARRAY         BEGSR
+      * Test sullla prima schiera
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('PRIMO                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(1)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('THREE                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT2(3)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('FIFTH                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT3(5)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('SETTIMO                           ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(7)
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------
+** C
+FIRST
+SECOND
+THIRD
+FOURTH
+FIFTH
+SIXTH
+SEVENTH
+EIGHTH
+NINTH
+** CTDATA B
+ONE
+TWO
+THREE
+FOUR
+FIVE
+SIX
+SEVEN
+EIGHT
+NINE
+**
+PRIMO
+SECONDO
+TERZO
+QUARTO
+QUINTO
+SESTO
+SETTIMO
+OTTAVO
+NONO

--- a/rpgJavaInterpreter-core/src/test/resources/data/ds/MUTE12_14.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/data/ds/MUTE12_14.rpgle
@@ -1,0 +1,71 @@
+     V*=====================================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V*=====================================================================
+     V* 02/09/21  003123  BUSFIO Creazione
+     V*=====================================================================
+     D*  OBIETTIVO
+     D*  Programma finalizzato ai test sulle schiere interne al programma:
+     D*  schiere con CTDATA vengono associate per nome
+     V*=====================================================================
+     DRESULT           S             35
+     D TXT1            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+     D TXT2            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+     D TXT3            S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
+      *---------------------------------------------------------------
+     D* M A I N
+      *---------------------------------------------------------------
+     C                   EXSR      ARRAY
+      *
+     C                   SETON                                        LR
+      *---------------------------------------------------------------
+     C     ARRAY         BEGSR
+      * Test sullla prima schiera
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('PRIMO                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(1)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('THIRD                             ') COMP(EQ)
+     C                   EVAL      RESULT=TXT2(3)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('FIVE                              ') COMP(EQ)
+     C                   EVAL      RESULT=TXT3(5)
+      *
+     C                   CLEAR                   RESULT
+    MU* VAL1(RESULT) VAL2('SETTIMO                           ') COMP(EQ)
+     C                   EVAL      RESULT=TXT1(7)
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------
+**CTDATA TXT2
+FIRST
+SECOND
+THIRD
+FOURTH
+FIFTH
+SIXTH
+SEVENTH
+EIGHTH
+NINTH
+**CTDATA TXT3
+ONE
+TWO
+THREE
+FOUR
+FIVE
+SIX
+SEVEN
+EIGHT
+NINE
+**CTDATA TXT1
+PRIMO
+SECONDO
+TERZO
+QUARTO
+QUINTO
+SESTO
+SETTIMO
+OTTAVO
+NONO


### PR DESCRIPTION
Change the implementation of array's association:
- When the array's declaration is `**CTDATA`, array's association is by name.
- When the array's declation is without  `CTDATA`, array's association is by index.

## Description

Added 4 new mutes to test the multiple array declaration.
In the class `MuteExecutionTest.kt` added 4 new function to test  the new mutes.
In `misc.kt` changed the logic of substring and replace of the array's name, which it was at the end of program.
In fact, when the array contains `**CTDATA` , we leave the name of the array; otherwise we replace the content of the string with a blank content.
In the class `cu-components.kt`, added new function to return a compileTimeArray using index.
In the class `internal_interpreter.kt:` added new variable called index, that variable helps us to cont the number of time that we have an ArrayValue. This index is used when we have to obtain the element of the array (value), if it is an array declared with "**".
When the array is declared with `**CTDATA` the value (element of array)  is set using the name of array.

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
