### PR TITLE
Program compilation fails when compile function is called during the interpretation

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
@@ -163,6 +163,11 @@ object MainExecutionContext {
      * Get source parsing stack.
      * */
     fun getParsingProgramStack() = context.get()?.parsingProgramStack ?: noParsingProgramStack
+
+    /**
+     * @return true if context is already created
+     * */
+    fun isCreated() = context.get() != null
 }
 
 data class Context(


### PR DESCRIPTION
Added the doCompilationAtRuntime  function that should be used to compile, for example, a called program at run time.


## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
