### PR TITLE
Improved logging in case of errors

### DIFF
--- a/examples/src/main/kotlin/com/jariko/samples/SmeUPSample.kt
+++ b/examples/src/main/kotlin/com/jariko/samples/SmeUPSample.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jariko.samples
+
+import com.smeup.rpgparser.execution.Configuration
+import com.smeup.rpgparser.execution.Options
+import com.smeup.rpgparser.execution.getProgram
+import com.smeup.rpgparser.interpreter.*
+import com.smeup.rpgparser.jvminterop.JavaSystemInterface
+import com.smeup.rpgparser.parsing.ast.CompilationUnit
+import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
+import com.smeup.rpgparser.utils.compile
+import java.io.File
+
+data class Fun(val program: String, val function: String, val method: String) {
+    constructor(program: String) : this(program, "", "")
+}
+
+fun Fun.dsEntries(): Map<String, Value> {
+    return mapOf(
+        "£UIBPG" to StringValue(program, false),
+        "£UIBFU" to StringValue(function, false),
+        "£UIBME" to StringValue(method, false)
+    )
+}
+
+data class SmeupObj(val type: String, val parameter: String, val code: String)
+
+fun SmeupObj.dsEntries(): Map<String, Value> {
+    return mapOf(
+        "£UIBPG" to StringValue(type, false),
+        "£UIBFU" to StringValue(parameter, false),
+        "£UIBME" to StringValue(code, false)
+    )
+}
+
+class DopedProgram(
+    val params: List<ProgramParam>,
+    private val execute: (systemInterface: SystemInterface, params: LinkedHashMap<String, Value>) -> List<Value>
+) : Program {
+
+    override fun params(): List<ProgramParam> {
+        return params
+    }
+
+    override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
+        return execute.invoke(systemInterface, params)
+    }
+}
+
+fun AbstractDataDefinition.toProgramParam() = ProgramParam(name = name, type = type)
+
+fun Type.toProgramParam(name: String) = ProgramParam(name = name, type = this)
+
+private class MockSystemInterface : JavaSystemInterface() {
+
+    lateinit var cu: CompilationUnit
+
+    override fun findProgram(name: String): Program? {
+        return when (name) {
+            "B£INZ0" -> DopedProgram(params = listOf(
+                StringType(10).toProgramParam("£INZFU"),
+                StringType(10).toProgramParam("£INZME"),
+                cu.getDataOrFieldDefinition("£INZDS").toProgramParam(),
+                StringType(10).toProgramParam("£INZCO")
+            )) { _, _ ->
+                emptyList()
+            }
+            "£JAX_IMP0" -> DopedProgram(params = listOf()) { _, _ ->
+                emptyList()
+            }
+            "£JAX_ADDO" -> DopedProgram(params = listOf(
+                StringType(length = 2).toProgramParam("£JAXT1"),
+                StringType(length = 10).toProgramParam("£JAXP1"),
+                StringType(length = 1000).toProgramParam("£JAXK1"),
+                StringType(length = 1000).toProgramParam("£JAXD1"),
+                StringType(length = 1000).toProgramParam("£JAXOP"),
+                StringType(length = 10).toProgramParam("£JAXEN")
+            )) { _, _ ->
+                emptyList()
+            }
+            "£JAX_FIN0" -> DopedProgram(params = listOf()) { _, _ ->
+                emptyList()
+            }
+            else -> super.findProgram(name)
+        }
+    }
+}
+
+fun main() {
+    val program = "TST_PGMA"
+    val srcDir: File? = null
+    require(srcDir != null) { "srcDir is mandatory" }
+    val `fun` = Fun(program = program)
+    val param = SmeupObj(type = "", parameter = "", code = "Autunno")
+    // val srcDir = File("C:\\dev\\java\\smeup\\kokos\\testinstall\\kokos1-dsl\\rpg")
+    val compiledProgramsDir = File(System.getProperty("java.io.tmpdir"))
+    val config = Configuration().apply { options = Options().apply { dumpSourceOnExecutionError = true } }
+    compile(src = srcDir, compiledProgramsDir = compiledProgramsDir, force = true, configuration = config)
+    val programFinders = listOf(DirRpgProgramFinder(File(System.getProperty("java.io.tmpdir"))))
+    val systemInterface = MockSystemInterface()
+    getProgram(program, systemInterface = systemInterface, programFinders = programFinders).singleCall(parmsProducer = {
+            compilationUnit ->
+        systemInterface.cu = compilationUnit
+        val datastructFiels = `fun`.dsEntries() + param.dsEntries()
+        mapOf("£UIBDS" to DataStructValue.createInstance(
+            compilationUnit = compilationUnit, dataStructName = "£UIBDS", values = datastructFiels)
+        )
+    })
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -20,6 +20,7 @@ import com.smeup.rpgparser.interpreter.AbstractDataDefinition
 import com.smeup.rpgparser.interpreter.DataDefinition
 import com.smeup.rpgparser.interpreter.type
 import com.smeup.rpgparser.parsing.ast.*
+import com.smeup.rpgparser.parsing.facade.AstCreatingException
 import com.smeup.rpgparser.utils.enrichPossibleExceptionWith
 import com.strumenta.kolasu.model.*
 import com.strumenta.kolasu.validation.Error
@@ -97,8 +98,14 @@ fun MuteAnnotation.resolveAndValidate(cu: CompilationUnit) {
  *
  */
 fun CompilationUnit.resolveAndValidate(raiseException: Boolean = true): List<Error> {
-    this.resolve()
-    return this.validate(raiseException)
+    kotlin.runCatching {
+        this.resolve()
+        return this.validate(raiseException)
+    }.onFailure {
+        this.source?.let { source ->
+            throw AstCreatingException(source, it)
+        }
+    }.getOrThrow()
 }
 
 class SemanticErrorsException(val errors: List<Error>) : RuntimeException("Semantic errors found: $errors")

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
@@ -189,7 +189,7 @@ class MiscTest {
     }
 
     @Test
-    fun dumpSrcOnError() {
+    fun dumpSrcOnAstResolvingError() {
         val pgm = """
      D MSG             S             20   
      C                   EVAL      MSG = 'Hi guy how are you?'
@@ -206,12 +206,42 @@ class MiscTest {
         }.onSuccess {
             Assert.fail()
         }
-        configuration.options!!.dumpSourceOnExecutionError = false
+    }
+
+    @Test
+    fun dumpSrcOnParsingError() {
+        val pgm = """
+       MSG             S             20   
+     C                   EVAL      MSG = 'Hi guy how are you?'
+     C     MSG           DSPLY
+        """
+        val configuration = Configuration()
+        configuration.options = Options()
+        configuration.options!!.dumpSourceOnExecutionError = true
         kotlin.runCatching {
             getProgram(nameOrSource = pgm).singleCall(emptyList(), configuration)
         }.onFailure {
-            // Exception message doesn't must contain src code
-            Assert.assertTrue(it.message!!.indexOf("D MSG             S             20") < 0)
+            // Exception message must contain src code
+            Assert.assertTrue(it.message!!.indexOf("MSG             S             20") > 0)
+        }.onSuccess {
+            Assert.fail()
+        }
+    }
+
+    @Test
+    fun dumpSrcOnRuntimeError() {
+        val pgm = """
+     D VAR             S              5  0   
+     C                   EVAL      VAR = 0/0
+        """
+        val configuration = Configuration()
+        configuration.options = Options()
+        configuration.options!!.dumpSourceOnExecutionError = true
+        kotlin.runCatching {
+            getProgram(nameOrSource = pgm).singleCall(emptyList(), configuration)
+        }.onFailure {
+            // Exception message must contain src code
+            Assert.assertTrue(it.message!!.indexOf("D VAR             S              5  0 ") > 0)
         }.onSuccess {
             Assert.fail()
         }


### PR DESCRIPTION
## Description
Now, even for the compiled programs, can be dumped the rpgle source in case of errors.
You can enable this feature  by passing to the  `compile `function an instance of `Configuration `with _options.dumpSourceOnExecutionError_ set to _true_.
Obviously, the same configuration setting must be passed even before of the program interpretation.

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
