### PR TITLE
Fixed shell issue with character £

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/SimpleShell.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/SimpleShell.kt
@@ -18,15 +18,12 @@ package com.smeup.rpgparser.execution
 
 import com.smeup.rpgparser.utils.measureAndPrint
 import java.io.BufferedReader
-import java.io.InputStream
 import java.io.InputStreamReader
 
 // TODO describe what this program does
 // TODO support option to add element to rpg program finders
 object SimpleShell {
     private val exitCommands = hashSetOf("exit", "quit", "signoff", "off")
-
-    var inputStream: InputStream = System.`in`
 
     private val interactiveCommands = setOf("play", "run")
 
@@ -46,11 +43,11 @@ You can type (@<rpgle_file_path> <args>|play|stop|exit):
  - help this help message
 rpg>
 """
-    private const val INTERACTIVE_MODE_MSG = "Interactive mode on, write or copy your code and then type run to execute program or stop if you want to return to console"
+    private const val INTERACTIVE_MODE_MSG = "Interactive mode on, write or copy your code and then type run or / to execute program or stop if you want to return to console"
 
     fun repl(r: (programName: String, programArgs: List<String>) -> Unit) {
         var commandLine: String
-        val console = BufferedReader(InputStreamReader(inputStream))
+        val console = BufferedReader(System.console()?.reader() ?: InputStreamReader(System.`in`))
         var interactiveMode: Boolean? = null
         val content = StringBuilder()
         println()
@@ -102,7 +99,7 @@ rpg>
                             print("rpg>")
                         }
                     } else {
-                        if (commandLine == "run") {
+                        if (commandLine == "run" || commandLine == "/") {
                             if (content.isEmpty()) {
                                 println("Type or paste your code")
                             } else {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/execution/RunnerCliTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/execution/RunnerCliTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.smeup.rpgparser.execution
 
 import com.smeup.rpgparser.AbstractTest
@@ -14,7 +30,7 @@ class RunnerCliTest : AbstractTest() {
 
     @Test
     fun withNoArgsReplIsStarted() {
-        SimpleShell.inputStream = ReaderInputStream(StringReader("signoff"), Charset.defaultCharset())
+        System.setIn(ReaderInputStream(StringReader("signoff"), Charset.defaultCharset()))
         val out = StringOutputStream()
         System.setOut(PrintStream(out))
 


### PR DESCRIPTION
## Description

On window platform, if you paste rpgle code containing char £ into the interactive shell, it always gets errors due to bad character encoding.