### PR TITLE
When next instruction was previous of the current one onEnterCopy and onExitCopy did not work properly

### DIFF
--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -360,5 +360,19 @@ tasks.withType(JavaExec) {
     systemProperty 'jrkReloadConfig', System.getProperty('jrkReloadConfig')
 }
 
+task javadocJar(type: Jar) {
+    archiveClassifier.set("javadoc")
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    archiveClassifier.set("sources")
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
 check.dependsOn compileAllMutes,runMutes
 testPerformance.dependsOn compilePerformanceMutes

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -36,7 +36,6 @@ import java.math.BigDecimal
 import java.math.MathContext
 import java.math.RoundingMode
 import java.util.*
-import kotlin.collections.HashMap
 import kotlin.system.measureTimeMillis
 
 object InterpreterConfiguration {
@@ -445,9 +444,9 @@ open class InternalInterpreter(
         if (!MainExecutionContext.getProgramStack().empty() &&
             MainExecutionContext.getConfiguration().options?.mustCreateCopyBlocks() == true) {
             val copyBlocks = MainExecutionContext.getProgramStack().peek().cu.copyBlocks!!
-            val previousStatementLine = (MainExecutionContext.getAttributes()[prevStmtAttributeMame()] ?: 1) as Int
+            val previousStatementLine = (MainExecutionContext.getAttributes()[prevStmtAttributeMame()] ?: 0) as Int
             copyBlocks.observeTransitions(
-                from = previousStatementLine,
+                from = previousStatementLine + 1,
                 to = currentStatementLine,
                 onEnter = { copyBlock -> MainExecutionContext.getConfiguration().jarikoCallback.onEnterCopy.invoke(copyBlock.copyId) },
                 onExit = { copyBlock -> MainExecutionContext.getConfiguration().jarikoCallback.onExitCopy.invoke(copyBlock.copyId) }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -446,7 +446,7 @@ open class InternalInterpreter(
             val copyBlocks = MainExecutionContext.getProgramStack().peek().cu.copyBlocks!!
             val previousStatementLine = (MainExecutionContext.getAttributes()[prevStmtAttributeMame()] ?: 0) as Int
             copyBlocks.observeTransitions(
-                from = previousStatementLine + 1,
+                from = previousStatementLine + if (currentStatementLine > previousStatementLine) 1 else -1,
                 to = currentStatementLine,
                 onEnter = { copyBlock -> MainExecutionContext.getConfiguration().jarikoCallback.onEnterCopy.invoke(copyBlock.copyId) },
                 onExit = { copyBlock -> MainExecutionContext.getConfiguration().jarikoCallback.onExitCopy.invoke(copyBlock.copyId) }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
@@ -297,14 +297,16 @@ class CopyBlocks : Iterable<CopyBlock> {
         onEnter: (copyBlock: CopyBlock) -> Unit,
         onExit: (copyBlock: CopyBlock) -> Unit
     ) {
-        copyBlocks.forEach { copyBlock ->
-            if (copyBlock.start in from + 1..to) {
-                onEnter.invoke(copyBlock)
-            }
-        }
-        revertOrderedCopyBlocks.forEach { copyBlock ->
-            if (copyBlock.end in from + 1..to) {
-                onExit.invoke(copyBlock)
+
+        val myFrom = if (from <= to) from else 1
+        for (line in myFrom..to) {
+            copyBlocks.forEach { copyBlock ->
+                if (line == copyBlock.start) {
+                    onEnter.invoke(copyBlock)
+                }
+                if (line == copyBlock.end) {
+                    onExit.invoke(copyBlock)
+                }
             }
         }
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
@@ -298,14 +298,26 @@ class CopyBlocks : Iterable<CopyBlock> {
         onExit: (copyBlock: CopyBlock) -> Unit
     ) {
 
-        val myFrom = if (from <= to) from else 1
-        for (line in myFrom..to) {
-            copyBlocks.forEach { copyBlock ->
-                if (line == copyBlock.start) {
-                    onEnter.invoke(copyBlock)
+        if (from <= to) {
+            for (line in from..to) {
+                copyBlocks.forEach { copyBlock ->
+                    if (line == copyBlock.start) {
+                        onEnter.invoke(copyBlock)
+                    }
+                    if (line == copyBlock.end) {
+                        onExit.invoke(copyBlock)
+                    }
                 }
-                if (line == copyBlock.end) {
-                    onExit.invoke(copyBlock)
+            }
+        } else {
+            for (line in from downTo to) {
+                revertOrderedCopyBlocks.forEach { copyBlock ->
+                    if (line == copyBlock.end - 1) {
+                        onEnter.invoke(copyBlock)
+                    }
+                    if (line == copyBlock.start - 1) {
+                        onExit.invoke(copyBlock)
+                    }
                 }
             }
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -172,8 +172,8 @@ class JarikoCallbackTest : AbstractTest() {
             }
         }
         executePgm(programName = "TSTCPY01", configuration = configuration)
-        Assert.assertEquals(1, entered)
-        Assert.assertEquals(1, exited)
+        Assert.assertEquals(2, entered)
+        Assert.assertEquals(2, exited)
     }
 
     private fun executeInlinePgmContainingCopy(

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/CopyTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/CopyTest.kt
@@ -269,8 +269,8 @@ class CopyTest {
         entered = 0
         exited = 0
         copyBlocks.observeTransitions(
-            from = 3,
-            to = 4,
+            from = 4,
+            to = 5,
             onEnter = { copyBlock ->
                 entered++
                 enteredCopyBlock = copyBlock
@@ -280,19 +280,11 @@ class CopyTest {
         Assert.assertEquals(1, entered)
         Assert.assertEquals(cpy1, enteredCopyBlock)
 
-        copyBlocks.observeTransitions(
-            from = 4,
-            to = 5,
-            onEnter = { Assert.fail() },
-            onExit = { Assert.fail() }
-        )
-        Assert.assertEquals(1, entered)
-
-        exited = 0
+        entered = 0
         exited = 0
         copyBlocks.observeTransitions(
-            from = 5,
-            to = 6,
+            from = 6,
+            to = 7,
             onEnter = { Assert.fail() },
             onExit = { copyBlock ->
                 exited++
@@ -301,13 +293,6 @@ class CopyTest {
         )
         Assert.assertEquals(1, exited)
         Assert.assertEquals(cpy1, exitedCopyBlock)
-
-        copyBlocks.observeTransitions(
-            from = 6,
-            to = 7,
-            onEnter = { Assert.fail() },
-            onExit = { Assert.fail() }
-        )
 
         copyBlocks.observeTransitions(
             from = 7,
@@ -331,37 +316,31 @@ class CopyTest {
         Assert.assertEquals(cpy2, enteredCopyBlock!!)
 
         entered = 0
+        exited = 0
         enteredCopyBlock = null
+        exitedCopyBlock = null
         copyBlocks.observeTransitions(
-            from = 9,
-            to = 10,
+            from = 10,
+            to = 11,
             onEnter = { copyBlock ->
                 entered++
                 enteredCopyBlock = copyBlock
             },
-            onExit = { Assert.fail() }
-        )
-        Assert.assertEquals(1, entered)
-        Assert.assertEquals(cpy21, enteredCopyBlock!!)
-
-        exited = 0
-        copyBlocks.observeTransitions(
-            from = 10,
-            to = 11,
-            onEnter = { Assert.fail() },
             onExit = { copyBlock ->
                 exited++
                 exitedCopyBlock = copyBlock
             }
         )
+        Assert.assertEquals(1, entered)
         Assert.assertEquals(1, exited)
+        Assert.assertEquals(cpy21, enteredCopyBlock!!)
         Assert.assertEquals(cpy21, exitedCopyBlock!!)
 
         exited = 0
         exitedCopyBlock = null
         copyBlocks.observeTransitions(
-            from = 11,
-            to = 12,
+            from = 12,
+            to = 13,
             onEnter = { Assert.fail() },
             onExit = { copyBlock ->
                 exited++
@@ -372,10 +351,30 @@ class CopyTest {
         Assert.assertEquals(cpy2, exitedCopyBlock!!)
 
         copyBlocks.observeTransitions(
-            from = 13,
-            to = 13,
+            from = 14,
+            to = 15,
             onEnter = { Assert.fail() },
             onExit = { Assert.fail() }
+        )
+    }
+
+    @Test
+    fun copyBlocksObserveBackardTransitions() {
+        val copyBlocks = createCopyBlocks()
+        val cpy1 = copyBlocks[0]
+        val cpy2 = copyBlocks[1]
+        val cpy21 = copyBlocks[2]
+        copyBlocks.observeTransitions(
+            from = 12,
+            to = 4,
+            onEnter = { copyBlock -> Assert.assertEquals(cpy1, copyBlock) },
+            onExit = { Assert.fail() }
+        )
+        copyBlocks.observeTransitions(
+            from = 11,
+            to = 10,
+            onEnter = { println("onEnter $it") },
+            onExit = { println("onExit $it") }
         )
     }
 

--- a/rpgJavaInterpreter-core/src/test/resources/TSTCPY01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/TSTCPY01.rpgle
@@ -3,6 +3,12 @@
      V* ==============================================================
      D MSG             S             50
      D MSGCPY          S             30
+      *--------------------------------------------------------------*
+     C     MYSUB         BEGSR
+     C                   EVAL      MSG='I am a mysub'
+     C     MSG           DSPLY
+     C                   ENDSR
+      *--------------------------------------------------------------*
      C                   EVAL      MSG='Hi I am TSTCPY01 and I want ' +
      C                             'to include a copy'
      C     MSG           DSPLY
@@ -10,3 +16,6 @@
      C                   EVAL      MSG='Copy included'
      C                   CALL      'CAL01'
      C     MSG           DSPLY
+     C                   EVAL      MSG='Exec mysub'
+     C     MSG           DSPLY
+     C                   EXSR      MYSUB


### PR DESCRIPTION
Fixed also another issue for which if instruction pointer passed through more than one copy (for example: cp1, cp2, and cp3), the `onEnterCopy` and `onExitCopy` were called in wrong order, first of all `onEnterCopy` for cp1, cp2, cp3 and later `onExitCopy` for cp1, cp2, cp3.
Revised the algorithm used by `observeTransitions` function, now is simpler, surely less fast, but much more clear to understand.
Revised also several tests regarding `observeTransitions` function because was born bad.

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
