### PR TITLE
Reduce errorlog verbosity

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,3 +1,2 @@
 # default code owners
-*          marco.lanari@smeup.com franco.parodi@smeup.com marco.benetti@smeup.com
-
+*          marco.lanari@smeup.com marco.benetti@smeup.com

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -68,7 +68,7 @@ data class ReloadConfig(
  * @param callProgramHandler If specified allows to override program call handling logic.
  * @param dumpSourceOnExecutionError If true, program source is dumped on execution error. Default false.
  * @param debuggingInformation If true, adds debugging information. Default false.
- * This propertty is necessary to enable some features useful when jariko must be debugged, for example some callback functions
+ * This property is necessary to enable some features useful when jariko must be debugged, for example some callback functions
  * such as onEnter and onExit copies or statements, just for performance reasons, will be invoked only when this property
  * is true.
  * */

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -67,9 +67,10 @@ data class ReloadConfig(
  * @param toAstConfiguration Creating ast configuration
  * @param callProgramHandler If specified allows to override program call handling logic.
  * @param dumpSourceOnExecutionError If true, program source is dumped on execution error. Default false.
- * @param debuggingInformation If true add debugging information, for example program source will be dumped in case of errors.
- * Setting this property to true causes a little overhead in AST serialization and deserialization due the fact
- * the source is CompilationUnit property
+ * @param debuggingInformation If true, adds debugging information. Default false.
+ * This propertty is necessary to enable some features useful when jariko must be debugged, for example some callback functions
+ * such as onEnter and onExit copies or statements, just for performance reasons, will be invoked only when this property
+ * is true.
  * */
 data class Options(
     var muteSupport: Boolean = false,
@@ -77,11 +78,10 @@ data class Options(
     var muteVerbose: Boolean = false,
     var toAstConfiguration: ToAstConfiguration = ToAstConfiguration(),
     var callProgramHandler: CallProgramHandler? = null,
-    @Deprecated(replaceWith = ReplaceWith(expression = "debuggingInformation"), message = "This property will be deleted in the next releases")
     var dumpSourceOnExecutionError: Boolean? = false,
     var debuggingInformation: Boolean? = false
 ) {
-    internal fun mustDumpSource() = dumpSourceOnExecutionError == true || debuggingInformation == true
+    internal fun mustDumpSource() = dumpSourceOnExecutionError == true
     internal fun mustCreateCopyBlocks() = debuggingInformation == true
     internal fun mustInvokeOnStatementCallback() = debuggingInformation == true
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
@@ -76,7 +76,11 @@ class RpgParserResult(errors: List<Error>, root: ParseTrees, private val parser:
     fun toTreeString(): String = parseTreeToXml(root!!.rContext, parser)
 
     fun dumpError(): String {
-        return "${errors.dumpError(root!!.copyBlocks)}\n${src.dumpSource()}"
+        return if (MainExecutionContext.getConfiguration().options?.mustDumpSource() == true) {
+            "${errors.dumpError(root!!.copyBlocks)}\n${src.dumpSource()}"
+        } else {
+            errors.dumpError(root!!.copyBlocks)
+        }
     }
 
     internal fun fireErrorEvents() {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -90,7 +90,10 @@ class JarikoCallbackTest : AbstractTest() {
         lateinit var pgm: String
         lateinit var postProcessed: String
         val configuration = Configuration().apply {
-            options = Options().apply { debuggingInformation = true }
+            options = Options().apply {
+                debuggingInformation = true
+                dumpSourceOnExecutionError = true
+            }
             jarikoCallback = JarikoCallback().apply {
                 afterAstCreation = { ast -> postProcessed = ast.source!! }
                 onEnterStatement = { lineNumber: Int, sourceReference: SourceReference ->

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
@@ -24,7 +24,9 @@ import com.smeup.rpgparser.parsing.facade.preprocess
 import org.apache.commons.io.FileUtils
 import org.junit.Assert
 import org.junit.Test
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.PrintStream
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -200,12 +202,22 @@ class MiscTest {
         """
         val configuration = Configuration()
         configuration.options = Options()
-        configuration.options!!.debuggingInformation = true
+        configuration.options!!.dumpSourceOnExecutionError = true
         kotlin.runCatching {
             getProgram(nameOrSource = pgm).singleCall(emptyList(), configuration)
         }.onFailure {
             // Exception message must contain src code
             Assert.assertTrue(it.message!!.indexOf("D MSG             S             20") > 0)
+        }.onSuccess {
+            Assert.fail()
+        }
+        // restore default
+        configuration.options = Options()
+        kotlin.runCatching {
+            getProgram(nameOrSource = pgm).singleCall(emptyList(), configuration)
+        }.onFailure {
+            // Exception message does not must contain src code
+            Assert.assertFalse(it.message!!.indexOf("D MSG             S             20") > 0)
         }.onSuccess {
             Assert.fail()
         }
@@ -220,12 +232,22 @@ class MiscTest {
         """
         val configuration = Configuration()
         configuration.options = Options()
-        configuration.options!!.debuggingInformation = true
+        configuration.options!!.dumpSourceOnExecutionError = true
         kotlin.runCatching {
             getProgram(nameOrSource = pgm).singleCall(emptyList(), configuration)
         }.onFailure {
             // Exception message must contain src code
             Assert.assertTrue(it.message!!.indexOf("MSG             S             20") > 0)
+        }.onSuccess {
+            Assert.fail()
+        }
+        // restore default options
+        configuration.options = Options()
+        kotlin.runCatching {
+            getProgram(nameOrSource = pgm).singleCall(emptyList(), configuration)
+        }.onFailure {
+            // Exception message does not must contain src code
+            Assert.assertFalse(it.message!!.indexOf("MSG             S             20") > 0)
         }.onSuccess {
             Assert.fail()
         }
@@ -238,15 +260,44 @@ class MiscTest {
      C                   EVAL      VAR = 0/0
         """
         val configuration = Configuration()
-        configuration.options = Options()
-        configuration.options!!.debuggingInformation = true
-        kotlin.runCatching {
-            getProgram(nameOrSource = pgm).singleCall(emptyList(), configuration)
-        }.onFailure {
-            // Exception message must contain src code
-            Assert.assertTrue(it.message!!.indexOf("D VAR             S              5  0 ") > 0)
-        }.onSuccess {
-            Assert.fail()
+        val defaultErr = System.err
+        var err: ByteArrayOutputStream
+        var ps: PrintStream
+        try {
+            err = ByteArrayOutputStream()
+            ps = PrintStream(err)
+            println("Redirecting stderr")
+            System.setErr(ps)
+            configuration.options = Options()
+            configuration.options!!.dumpSourceOnExecutionError = true
+            kotlin.runCatching {
+                getProgram(nameOrSource = pgm).singleCall(emptyList(), configuration)
+            }.onFailure {
+                ps.flush()
+                // Error stream must contain src
+                Assert.assertTrue(err.toString().indexOf("2    D VAR             S              5  0   ") > 0)
+            }.onSuccess {
+                Assert.fail()
+            }
+            // reset stream
+            err = ByteArrayOutputStream()
+            ps = PrintStream(err)
+            System.setErr(ps)
+            // restore default options
+            configuration.options = Options()
+            kotlin.runCatching {
+                getProgram(nameOrSource = pgm).singleCall(emptyList(), configuration)
+            }.onFailure {
+                ps.flush()
+                // Error stream must not contain src
+                Assert.assertFalse(err.toString().indexOf("2    D VAR             S              5  0   ") > 0)
+            }.onSuccess {
+                Assert.fail()
+            }
+        } finally {
+            println("Restoring stderr")
+            System.setErr(defaultErr)
+            System.err.println("Stderr restored")
         }
     }
 }


### PR DESCRIPTION
## Description
Now in case of errors, the dump of the rpg source content will be dumped only if `Options.dumpSourceOnExecutionError=true` 

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
