### PR TITLE
Feature/add before copy inclusion callback

### DIFF
--- a/examples/src/main/kotlin/com/jariko/samples/CallHandlerSample.kt
+++ b/examples/src/main/kotlin/com/jariko/samples/CallHandlerSample.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jariko.samples
 
 import com.smeup.rpgparser.execution.CallProgramHandler
@@ -15,6 +31,7 @@ import com.smeup.rpgparser.parsing.ast.SourceProgram
 import com.smeup.rpgparser.parsing.facade.Copy
 import com.smeup.rpgparser.parsing.facade.CopyId
 import com.smeup.rpgparser.parsing.facade.key
+import com.smeup.rpgparser.rpginterop.CopyFileExtension
 import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
 import com.smeup.rpgparser.rpginterop.RpgProgramFinder
 import java.io.File
@@ -57,8 +74,7 @@ class UrlRpgProgramFinder(val endpoint: URL) : RpgProgramFinder {
     override fun findCopy(copyId: CopyId): Copy? {
     // runCatching is wanted because endpoint could not have my program
         return runCatching {
-            // use of source program and not bin is just because this is an example
-            val pgmUrl = URL("$endpoint/${copyId.key(SourceProgram.RPGLE)}")
+            val pgmUrl = URL("$endpoint/${copyId.key(CopyFileExtension.rpgle)}")
             pgmUrl.openStream().use {
                 println("Loading $copyId from $pgmUrl")
                 Copy.fromInputStream(it)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -19,6 +19,7 @@ package com.smeup.rpgparser.execution
 import com.smeup.dbnative.DBNativeAccessConfig
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
+import com.smeup.rpgparser.parsing.facade.CopyBlocks
 import com.smeup.rpgparser.parsing.facade.CopyId
 import com.smeup.rpgparser.parsing.facade.SourceReference
 import com.smeup.rpgparser.parsing.parsetreetoast.ToAstConfiguration
@@ -39,7 +40,7 @@ data class Configuration(
     var jarikoCallback: JarikoCallback = JarikoCallback(),
     var reloadConfig: ReloadConfig? = null,
     val defaultActivationGroupName: String = DEFAULT_ACTIVATION_GROUP_NAME,
-    var options: Options? = Options()
+    var options: Options = Options()
 ) {
     constructor(memorySliceStorage: IMemorySliceStorage?) :
             this(memorySliceStorage, JarikoCallback(), null, DEFAULT_ACTIVATION_GROUP_NAME, Options())
@@ -97,6 +98,8 @@ data class Options(
  * activation group associated to the program.
  * @param beforeCopyInclusion It is invoked before than the copy is included in the source, the default implementation
  * will return the copy source itself
+ * @param afterCopiesInclusion It is invoked after that all copies has been included in the source.
+ * **This callback will be called only if [Options.debuggingInformation] is set to true**.
  * @param beforeParsing It is invoked before the parsing. It is passed the source that will be parsed after all copy inclusion, the default implementation
  * will return source itself
  * @param exitInRT If specified, it overrides the exit mode established in program. Default null (nei seton rt od lr mode)
@@ -119,6 +122,7 @@ data class JarikoCallback(
             null
     },
     var beforeCopyInclusion: (copyId: CopyId, source: String?) -> String? = { _, source -> source },
+    var afterCopiesInclusion: (copyBlocks: CopyBlocks) -> Unit = { },
     var beforeParsing: (source: String) -> String = { source -> source },
     var exitInRT: (programName: String) -> Boolean? = { null },
     var onEnterPgm: (programName: String, symbolTable: ISymbolTable) -> Unit = { _: String, _: ISymbolTable -> },

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -61,7 +61,7 @@ data class ReloadConfig(
 
 /**
  * Options object
- * @param muteSupport Used to enable/disable scan execution of mute annotations into rpg sources)
+ * @param muteSupport Used to enable/disable scan execution of mute annotations into rpg sources
  * @param compiledProgramsDir If specified Jariko searches compiled program in this directory.
  * This property should be used just for debug, because in production environment, in which the compiled programs
  * could be found in different paths, it is preferable to use a program finder for every path
@@ -95,7 +95,9 @@ data class Options(
  * Default null it means by Configuration.
  * Parameter programName is program for which we are getting activation group, associatedActivationGroup is the current
  * activation group associated to the program.
- * @param beforeParsing It is invoked before the parsing. It is passed the source which will be parsed, the default implementation
+ * @param beforeCopyInclusion It is invoked before than the copy is included in the source, the default implementation
+ * will return the copy source itself
+ * @param beforeParsing It is invoked before the parsing. It is passed the source that will be parsed after all copy inclusion, the default implementation
  * will return source itself
  * @param exitInRT If specified, it overrides the exit mode established in program. Default null (nei seton rt od lr mode)
  * @param onEnterPgm It is invoked on program enter after symboltable initialization.
@@ -116,6 +118,7 @@ data class JarikoCallback(
     var getActivationGroup: (programName: String, associatedActivationGroup: ActivationGroup?) -> ActivationGroup? = { _: String, _: ActivationGroup? ->
             null
     },
+    var beforeCopyInclusion: (copyId: CopyId, source: String?) -> String? = { _, source -> source },
     var beforeParsing: (source: String) -> String = { source -> source },
     var exitInRT: (programName: String) -> Boolean? = { null },
     var onEnterPgm: (programName: String, symbolTable: ISymbolTable) -> Unit = { _: String, _: ISymbolTable -> },

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
@@ -29,7 +29,6 @@ import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.smeup.rpgparser.parsing.ast.SourceProgram
 import com.smeup.rpgparser.parsing.ast.createCompilationUnit
-import com.smeup.rpgparser.parsing.parsetreetoast.ToAstConfiguration
 import com.smeup.rpgparser.parsing.parsetreetoast.injectMuteAnnotation
 import com.smeup.rpgparser.parsing.parsetreetoast.setOverlayOn
 import com.smeup.rpgparser.parsing.parsetreetoast.toAst
@@ -77,7 +76,7 @@ class RpgParserResult(errors: List<Error>, root: ParseTrees, private val parser:
     fun toTreeString(): String = parseTreeToXml(root!!.rContext, parser)
 
     fun dumpError(): String {
-        return if (MainExecutionContext.getConfiguration().options?.mustDumpSource() == true) {
+        return if (MainExecutionContext.getConfiguration().options.mustDumpSource()) {
             "${errors.dumpError(root!!.copyBlocks)}\n${src.dumpSource()}"
         } else {
             errors.dumpError(root!!.copyBlocks)
@@ -116,8 +115,8 @@ typealias RpgLexerResult = ParsingResult<List<Token>>
 class RpgParserFacade {
 
     // Should be 'false' as default to avoid unnecessary search of 'mute annotation' into rpg program source.
-    var muteSupport: Boolean = MainExecutionContext.getConfiguration().options?.muteSupport ?: false
-    private var muteVerbose = MainExecutionContext.getConfiguration().options?.muteVerbose ?: false
+    var muteSupport: Boolean = MainExecutionContext.getConfiguration().options.muteSupport
+    private var muteVerbose = MainExecutionContext.getConfiguration().options.muteVerbose
 
     private val executionProgramName: String by lazy {
         getExecutionProgramNameWithNoExtension()
@@ -302,7 +301,7 @@ class RpgParserFacade {
     fun parse(inputStream: InputStream): RpgParserResult {
         val parserResult: RpgParserResult
         val errors = LinkedList<Error>()
-        val copyBlocks: CopyBlocks? = if (MainExecutionContext.getConfiguration().options?.mustCreateCopyBlocks() == true) CopyBlocks() else null
+        val copyBlocks: CopyBlocks? = if (MainExecutionContext.getConfiguration().options.mustCreateCopyBlocks()) CopyBlocks() else null
         val code = inputStream.preprocess(
             findCopy = { copyId ->
                 MainExecutionContext.getSystemInterface()?.findCopy(copyId)?.source.let { source ->
@@ -312,8 +311,11 @@ class RpgParserFacade {
             },
             onStartInclusion = { copyId, start -> copyBlocks?.onStartCopyBlock(copyId = copyId, start = start) },
             onEndInclusion = { end -> copyBlocks?.onEndCopyBlock(end = end) }
-        ).let { MainExecutionContext.getConfiguration().jarikoCallback.beforeParsing.invoke(it) }
-
+        ).apply {
+            if (copyBlocks != null) MainExecutionContext.getConfiguration().jarikoCallback.afterCopiesInclusion(copyBlocks)
+        }.let { code ->
+            MainExecutionContext.getConfiguration().jarikoCallback.beforeParsing.invoke(code)
+        }
         if (!MainExecutionContext.getParsingProgramStack().empty()) {
             MainExecutionContext.getParsingProgramStack().peek().copyBlocks = copyBlocks
             MainExecutionContext.getParsingProgramStack().peek().sourceLines = code.split("\\r\\n|\\n".toRegex())
@@ -335,7 +337,7 @@ class RpgParserFacade {
     }
 
     private fun tryToLoadCompilationUnit(): CompilationUnit? {
-        return MainExecutionContext.getConfiguration().options?.compiledProgramsDir?.let { compiledDir ->
+        return MainExecutionContext.getConfiguration().options.compiledProgramsDir?.let { compiledDir ->
             val start = System.currentTimeMillis()
             val compiledFile = File(compiledDir, "$executionProgramName.bin")
             if (compiledFile.exists()) {
@@ -375,8 +377,8 @@ class RpgParserFacade {
             MainExecutionContext.log(AstLogStart(executionProgramName))
             val elapsed = measureTimeMillis {
                 compilationUnit = result.root!!.rContext.toAst(
-                    conf = MainExecutionContext.getConfiguration().options?.toAstConfiguration ?: ToAstConfiguration(),
-                    source = if (MainExecutionContext.getConfiguration().options?.mustDumpSource() == true) {
+                    conf = MainExecutionContext.getConfiguration().options.toAstConfiguration,
+                    source = if (MainExecutionContext.getConfiguration().options.mustDumpSource()) {
                         result.src
                     } else {
                         null
@@ -566,7 +568,7 @@ class AstCreatingException(val src: String, cause: Throwable) :
         val sw = StringWriter()
         cause.printStackTrace(PrintWriter(sw))
         sw.flush()
-        if (MainExecutionContext.getConfiguration().options?.mustDumpSource() == true) {
+        if (MainExecutionContext.getConfiguration().options.mustDumpSource()) {
             "$sw\n${src.dumpSource()}"
         } else {
             "$sw"

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
@@ -304,7 +304,12 @@ class RpgParserFacade {
         val errors = LinkedList<Error>()
         val copyBlocks: CopyBlocks? = if (MainExecutionContext.getConfiguration().options?.mustCreateCopyBlocks() == true) CopyBlocks() else null
         val code = inputStream.preprocess(
-            findCopy = { copyId -> MainExecutionContext.getSystemInterface()?.findCopy(copyId)?.source },
+            findCopy = { copyId ->
+                MainExecutionContext.getSystemInterface()?.findCopy(copyId)?.source.let { source ->
+                    MainExecutionContext.getConfiguration().jarikoCallback.beforeCopyInclusion(copyId, source)
+                    source
+                }
+            },
             onStartInclusion = { copyId, start -> copyBlocks?.onStartCopyBlock(copyId = copyId, start = start) },
             onEndInclusion = { end -> copyBlocks?.onEndCopyBlock(end = end) }
         ).let { MainExecutionContext.getConfiguration().jarikoCallback.beforeParsing.invoke(it) }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
@@ -20,8 +20,8 @@ import com.andreapivetta.kolor.yellow
 import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.interpreter.PreprocessingLogEnd
 import com.smeup.rpgparser.interpreter.PreprocessingLogStart
-import com.smeup.rpgparser.parsing.ast.SourceProgram
 import com.smeup.rpgparser.parsing.parsetreetoast.fireErrorEvent
+import com.smeup.rpgparser.rpginterop.CopyFileExtension
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import java.io.BufferedReader
@@ -155,10 +155,10 @@ data class CopyId(val library: String? = null, val file: String? = null, val mem
  * file/member.ext
  * member.ext
  * */
-fun CopyId.key(sourceProgram: SourceProgram): String {
+fun CopyId.key(extension: CopyFileExtension): String {
     val key = this.file?.let {
-        "$it/$member.${sourceProgram.extension}"
-    } ?: "$member.${sourceProgram.extension}"
+        "$it/$member.$extension"
+    } ?: "$member.$extension"
     return library?.let {
         "$library/$key"
     } ?: key

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -29,6 +29,7 @@ import com.smeup.rpgparser.parsing.facade.SourceReferenceType
 import org.junit.Assert
 import java.io.StringReader
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 /**
  * Test suite to test Jariko callback features
@@ -420,6 +421,22 @@ class JarikoCallbackTest : AbstractTest() {
         }.onFailure {
             Assert.fail("Program must not exit with error")
         }
+    }
+
+    @Test
+    fun beforeCopyInclusionTest() {
+        val expectedIncludedCopies = listOf(CopyId(file = "QILEGEN", member = "TSTCPY01"))
+        val includedCopies = mutableListOf<CopyId>()
+        val configuration = Configuration().apply {
+            jarikoCallback = JarikoCallback().apply {
+                beforeCopyInclusion = { copyId, source ->
+                    includedCopies.add(copyId)
+                    source
+                }
+            }
+        }
+        executePgm(programName = "TSTCPY01", configuration = configuration)
+        assertEquals(expectedIncludedCopies, includedCopies)
     }
 
     private fun executePgmCallBackTest(pgm: String, sourceReferenceType: SourceReferenceType, sourceId: String, lines: List<Int>) {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -17,10 +17,7 @@
 package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.AbstractTest
-import com.smeup.rpgparser.execution.Configuration
-import com.smeup.rpgparser.execution.ErrorEvent
-import com.smeup.rpgparser.execution.JarikoCallback
-import com.smeup.rpgparser.execution.Options
+import com.smeup.rpgparser.execution.*
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
 import com.smeup.rpgparser.parsing.facade.Copy
 import com.smeup.rpgparser.parsing.facade.CopyId
@@ -436,6 +433,25 @@ class JarikoCallbackTest : AbstractTest() {
             }
         }
         executePgm(programName = "TSTCPY01", configuration = configuration)
+        assertEquals(expectedIncludedCopies, includedCopies)
+    }
+
+    @Test
+    fun afterCopiesInclusionTest() {
+        val program = "TSTCPY01"
+        val expectedIncludedCopies = listOf(CopyId(file = "QILEGEN", member = "TSTCPY01"))
+        lateinit var includedCopies: List<CopyId>
+        val configuration = Configuration().apply {
+            options.debuggingInformation = true
+            jarikoCallback = JarikoCallback().apply {
+                afterCopiesInclusion = { copyBlocks ->
+                    if (MainExecutionContext.getParsingProgramStack().peek().name == program) {
+                        includedCopies = copyBlocks.map { copyBlock -> copyBlock.copyId }
+                    }
+                }
+            }
+        }
+        executePgm(programName = program, configuration = configuration)
         assertEquals(expectedIncludedCopies, includedCopies)
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/CopyTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/CopyTest.kt
@@ -18,8 +18,8 @@ package com.smeup.rpgparser.parsing
 
 import com.smeup.rpgparser.execution.*
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
-import com.smeup.rpgparser.parsing.ast.SourceProgram
 import com.smeup.rpgparser.parsing.facade.*
+import com.smeup.rpgparser.rpginterop.CopyFileExtension
 import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
 import org.junit.Assert
 import org.junit.Test
@@ -161,7 +161,7 @@ class CopyTest {
         val copyDefinitions = mutableMapOf<CopyId, String>()
         pgm.byteInputStream().preprocess(
             findCopy = { copyId ->
-                File("$srcRoot/${copyId.key(SourceProgram.RPGLE)}").readText(charset = Charsets.UTF_8)
+                File("$srcRoot/${copyId.key(CopyFileExtension.rpgle)}").readText(charset = Charsets.UTF_8)
                     .apply { copyDefinitions[copyId] = this }
             }
         )


### PR DESCRIPTION
## Description

Added `JarikoCallback.beforeCopyInclusion` and `JarikoCallback.afterCopyInclusion` callback functions.
Improved the copy searching in default `DirRpgProgramFinder` implementation, now it makes attempts in base of the copy known extensions (enum `CopyFileExtension`), after that the search is by copyname.*, just like before.


## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
