### PR TITLE
Dspec inline definition - fixes and improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ FlightRecorderOptions=stackdepth=64
 kotlinVersion=1.4.10
 serializationVersion=1.0.1
 jvmVersion=1.8
-reloadVersion=development-SNAPSHOT
+reloadVersion=1.3.0
 

--- a/kolasu/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/kolasu/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.strumenta.kolasu.model
 
 import kotlinx.serialization.Serializable
@@ -12,7 +28,14 @@ open class Node(@Transient open val position: Position? = null) {
 }
 
 /**
- * This should be used for all relations which are secondary, i.e., they are calculated from other relations
+ * This should be used for all relations which are secondary, i.e., they are calculated from other relations.
+ * This annotation it needs to avoid that the [Node.process] executes multiple operations on the node.
+ * For example suppose to have a data class `MyNode` that extends `Node` and which has two property `thenBody` and `elseBody`, both
+ * collection of nodes.
+ * Suppose that you introduce a third computed property `body` which joins thenBody` and `elseBody`.
+ * If you call `myNode.process({yourOperation})` yourOperation will be called foreach node two times, first af all, for all nodes in
+ * `thenBody`, than for all nodes in `elseBody`, and finally for all nodes in `body`.
+ * To face this issue, you will annotate `body`
  */
 annotation class Derived
 

--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -1532,9 +1532,9 @@ csOUT:
 	cspec_fixed_standard_parts;
 csPARM:
 	CS_FIXED
-	BlankIndicator
-	BlankFlag 
-	BlankIndicator
+	cspec_continuedIndicators*
+	cs_controlLevel
+	indicatorsOff=onOffIndicatorsFlag indicators=cs_indicators
 	factor1=factor
 	operation=OP_PARM
 	cspec_fixed_standard_parts;

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -130,8 +130,10 @@ data class ExecuteSubroutine(var subroutine: ReferenceByName<Subroutine>, overri
 data class SelectStmt(
     var cases: List<SelectCase>,
     var other: SelectOtherClause? = null,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
-) : Statement(position), CompositeStatement {
+) : Statement(position), CompositeStatement, StatementThatCanDefineData {
+
     override fun accept(mutes: MutableMap<Int, MuteParser.MuteLineContext>, start: Int, end: Int): MutableList<MuteAnnotationResolved> {
 
         val muteAttached: MutableList<MuteAnnotationResolved> = mutableListOf()
@@ -150,6 +152,8 @@ data class SelectStmt(
 
         return muteAttached
     }
+
+    override fun dataDefinition(): List<InStatementDataDefinition> = dataDefinition?.let { listOf(it) } ?: emptyList()
 
     override fun execute(interpreter: InterpreterCore) {
         for (case in this.cases) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -171,6 +171,7 @@ data class SelectStmt(
         }
     }
 
+    @Derived
     override val body: List<Statement>
         get() {
             val result = mutableListOf<Statement>()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1438,7 +1438,15 @@ data class SortAStmt(val target: Expression, override val position: Position? = 
 }
 
 @Serializable
-data class CatStmt(val left: Expression?, val right: Expression, val target: AssignableExpression, val blanksInBetween: Int, override val position: Position? = null) : Statement(position) {
+data class CatStmt(
+    val left: Expression?,
+    val right: Expression,
+    val target: AssignableExpression,
+    val blanksInBetween: Int,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
+    override val position: Position? = null
+) : Statement(position), StatementThatCanDefineData {
+
     override fun execute(interpreter: InterpreterCore) {
         val blanksInBetween = blanksInBetween
         val blanks = StringValue.blank(blanksInBetween)
@@ -1479,6 +1487,8 @@ data class CatStmt(val left: Expression?, val right: Expression, val target: Ass
         interpreter.assign(target, result)
         interpreter.log { CatStatementExecutionLog(interpreter.getInterpretationContext().currentProgramName, this, interpreter.eval(target)) }
     }
+
+    override fun dataDefinition(): List<InStatementDataDefinition> = dataDefinition?.let { listOf(it) } ?: emptyList()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1517,8 +1517,9 @@ data class ScanStmt(
     val startPosition: Int,
     val target: AssignableExpression,
     val rightIndicators: WithRightIndicators,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
-) : Statement(position), WithRightIndicators by rightIndicators {
+) : Statement(position), WithRightIndicators by rightIndicators, StatementThatCanDefineData {
 
     override fun execute(interpreter: InterpreterCore) {
         val stringToSearch = interpreter.eval(left).asString().value.substringOfLength(leftLength)
@@ -1541,6 +1542,8 @@ data class ScanStmt(
             }
         }
     }
+
+    override fun dataDefinition() = dataDefinition?.let { listOf(it) } ?: emptyList()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -242,13 +242,16 @@ data class SubDurStmt(
 data class MoveStmt(
     val target: AssignableExpression,
     var expression: Expression,
+    val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
 ) :
-    Statement(position) {
+    Statement(position), StatementThatCanDefineData {
     override fun execute(interpreter: InterpreterCore) {
         val value = move(target, expression, interpreter)
         interpreter.log { MoveStatemenExecutionLog(interpreter.getInterpretationContext().currentProgramName, this, value) }
     }
+
+    override fun dataDefinition() = dataDefinition?.let { listOf(it) } ?: emptyList()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1028,11 +1028,15 @@ data class MultStmt(
     val halfAdjust: Boolean = false,
     val factor1: Expression?,
     val factor2: Expression,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
-) : Statement(position) {
+) : Statement(position), StatementThatCanDefineData {
+
     override fun execute(interpreter: InterpreterCore) {
         interpreter.assign(target, interpreter.mult(this))
     }
+
+    override fun dataDefinition() = dataDefinition?.let { listOf(it) } ?: emptyList()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -242,7 +242,7 @@ data class SubDurStmt(
 data class MoveStmt(
     val target: AssignableExpression,
     var expression: Expression,
-    val dataDefinition: InStatementDataDefinition? = null,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
 ) :
     Statement(position), StatementThatCanDefineData {
@@ -259,15 +259,18 @@ data class MoveAStmt(
     val operationExtender: String?,
     val target: AssignableExpression,
     var expression: Expression,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
 ) :
-    Statement(position) {
+    Statement(position), StatementThatCanDefineData {
     override fun execute(interpreter: InterpreterCore) {
         val value = movea(operationExtender, target, expression, interpreter)
         interpreter.log {
             MoveAStatemenExecutionLog(interpreter.getInterpretationContext().currentProgramName, this, value)
         }
     }
+
+    override fun dataDefinition() = dataDefinition?.let { listOf(it) } ?: emptyList()
 }
 @Serializable
 data class MoveLStmt(

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1045,11 +1045,15 @@ data class DivStmt(
     val halfAdjust: Boolean = false,
     val factor1: Expression?,
     val factor2: Expression,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
-) : Statement(position) {
+) : Statement(position), StatementThatCanDefineData {
+
     override fun execute(interpreter: InterpreterCore) {
         interpreter.assign(target, interpreter.div(this))
     }
+
+    override fun dataDefinition() = dataDefinition?.let { listOf(it) } ?: emptyList()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1265,7 +1265,15 @@ internal fun CsMULTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
     val factor2 = this.cspec_fixed_standard_parts().factor2Expression(conf) ?: throw UnsupportedOperationException("SUB operation requires factor 2: ${this.text} - ${position.atLine()}")
     this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
     val extenders = this.operationExtender?.extender?.text?.toUpperCase()?.toCharArray() ?: CharArray(0)
-    return MultStmt(DataRefExpr(ReferenceByName(result), position), 'H' in extenders, factor1, factor2, position)
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
+    return MultStmt(
+        target = DataRefExpr(ReferenceByName(result), position),
+        halfAdjust = 'H' in extenders,
+        factor1 = factor1,
+        factor2 = factor2,
+        dataDefinition = dataDefinition,
+        position = position
+    )
 }
 
 internal fun CsDIVContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): DivStmt {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1283,7 +1283,15 @@ internal fun CsDIVContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
     val factor2 = this.cspec_fixed_standard_parts().factor2Expression(conf) ?: throw UnsupportedOperationException("SUB operation requires factor 2: ${this.text} - ${position.atLine()}")
     this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
     val extenders = this.operationExtender?.extender?.text?.toUpperCase()?.toCharArray() ?: CharArray(0)
-    return DivStmt(DataRefExpr(ReferenceByName(result), position), 'H' in extenders, factor1, factor2, position)
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
+    return DivStmt(
+        target = DataRefExpr(ReferenceByName(result), position),
+        halfAdjust = 'H' in extenders,
+        factor1 = factor1,
+        factor2 = factor2,
+        dataDefinition = dataDefinition,
+        position = position
+    )
 }
 
 internal fun CsTAGContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): TagStmt {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1171,14 +1171,17 @@ internal fun CsSCANContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
     val (compareExpression, compareLength) = this.factor1Context().toIndexedExpression(conf)
     val (baseExpression, startPosition) = this.cspec_fixed_standard_parts().factor2.toIndexedExpression(conf)
     val rightIndicators = cspec_fixed_standard_parts().rightIndicators()
+    val result = this.cspec_fixed_standard_parts().result.text
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
     return ScanStmt(
-        compareExpression,
-        compareLength,
-        baseExpression,
-        startPosition ?: 1,
-        this.cspec_fixed_standard_parts()!!.result!!.toAst(conf),
-        rightIndicators,
-        position
+        left = compareExpression,
+        leftLength = compareLength,
+        right = baseExpression,
+        startPosition = startPosition ?: 1,
+        target = this.cspec_fixed_standard_parts()!!.result!!.toAst(conf),
+        rightIndicators = rightIndicators,
+        dataDefinition = dataDefinition,
+        position = position
     )
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -820,7 +820,7 @@ internal fun Cspec_fixed_standardContext.toAst(conf: ToAstConfiguration = ToAstC
     }
 }
 
-private fun Cspec_fixed_standard_partsContext.validate(stmt: Statement, conf: ToAstConfiguration): Statement {
+internal fun Cspec_fixed_standard_partsContext.validate(stmt: Statement, conf: ToAstConfiguration): Statement {
     val position = toPosition(conf.considerPosition)
     if (result.text.isNotBlank()) {
         toDataDefinition(result.text, position, conf)?.let {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1214,7 +1214,14 @@ internal fun CsMOVEAContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
     val position = toPosition(conf.considerPosition)
     val expression = this.cspec_fixed_standard_parts().factor2Expression(conf) ?: throw UnsupportedOperationException("MOVEA operation requires factor 2: ${this.text} - ${position.atLine()}")
     val resultExpression = this.cspec_fixed_standard_parts().resultExpression(conf) as AssignableExpression
-    return MoveAStmt(this.operationExtender?.text, resultExpression, expression, position)
+    val result = this.cspec_fixed_standard_parts().result.text
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
+    return MoveAStmt(
+        operationExtender = this.operationExtender?.text,
+        target = resultExpression,
+        expression = expression,
+        dataDefinition = dataDefinition,
+        position = position)
 }
 
 internal fun CsMOVEContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MoveStmt {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1495,12 +1495,15 @@ internal fun CsCATContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
         blanksInBetween = this.cspec_fixed_standard_parts().factor2.content2.children[0].toString().toInt()
     }
     val target = this.cspec_fixed_standard_parts().resultExpression(conf) as AssignableExpression
+    val result = this.cspec_fixed_standard_parts().result.text
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
     return CatStmt(
-        left,
-        right,
-        target,
-        blanksInBetween,
-        position
+        left = left,
+        right = right,
+        target = target,
+        blanksInBetween = blanksInBetween,
+        position = position,
+        dataDefinition = dataDefinition
     )
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1221,7 +1221,14 @@ internal fun CsMOVEContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
     val position = toPosition(conf.considerPosition)
     val expression = this.cspec_fixed_standard_parts().factor2Expression(conf) ?: throw UnsupportedOperationException("MOVE operation requires factor 2: ${this.text} - ${position.atLine()}")
     val resultExpression = this.cspec_fixed_standard_parts().resultExpression(conf) as AssignableExpression
-    return MoveStmt(resultExpression, expression, position)
+    val result = this.cspec_fixed_standard_parts().result.text
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
+    return MoveStmt(
+        target = resultExpression,
+        expression = expression,
+        dataDefinition = dataDefinition,
+        position = position
+    )
 }
 
 internal fun CsMOVELContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MoveLStmt {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -31,16 +31,16 @@ import java.util.*
 
 private fun CompilationUnit.findInStatementDataDefinitions() {
     // TODO could they be also annidated?
-    this.allStatements().filterIsInstance(StatementThatCanDefineData::class.java).forEach {
+    this.allStatements(preserveCompositeStatement = true).filterIsInstance(StatementThatCanDefineData::class.java).forEach {
         this.addInStatementDataDefinitions(it.dataDefinition())
     }
 }
 
-fun CompilationUnit.allStatements(): List<Statement> {
+fun CompilationUnit.allStatements(preserveCompositeStatement: Boolean = false): List<Statement> {
     val result = mutableListOf<Statement>()
-    result.addAll(this.main.stmts.explode())
+    result.addAll(this.main.stmts.explode(preserveCompositeStatement = preserveCompositeStatement))
     this.subroutines.forEach {
-        result.addAll(it.stmts.explode())
+        result.addAll(it.stmts.explode(preserveCompositeStatement = preserveCompositeStatement))
     }
     return result
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
@@ -37,7 +37,7 @@ fun RpgParser.StatementContext.toAst(conf: ToAstConfiguration = ToAstConfigurati
 internal fun BlockContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     return when {
         this.ifstatement() != null -> this.ifstatement().toAst(conf)
-        this.selectstatement()!= null -> this.selectstatement()
+        this.selectstatement() != null -> this.selectstatement()
             .let {
                 it.beginselect().csSELECT().cspec_fixed_standard_parts().validate(
                     stmt = it.toAst(conf = conf),
@@ -111,11 +111,16 @@ internal fun RpgParser.BegindoContext.toAst(
             factor2.symbolicConstants() != null -> factor2.symbolicConstants().toAst()
             else -> factor2.runParserRuleContext(conf = conf) { f2 -> f2.content.toAst(conf) }
         }
-    return DoStmt(endLimit,
-        iter,
-        blockContext.statement().map { it.toAst(conf) },
-        start,
-        position = toPosition(conf.considerPosition))
+    val position = toPosition(conf.considerPosition)
+    val dataDefinition = csDO().cspec_fixed_standard_parts().toDataDefinition(result.text, position, conf)
+    return DoStmt(
+        endLimit = endLimit,
+        index = iter,
+        body = blockContext.statement().map { it.toAst(conf) },
+        startLimit = start,
+        dataDefinition = dataDefinition,
+        position = toPosition(conf.considerPosition)
+    )
 }
 
 internal fun RpgParser.BegindowContext.toAst(

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
@@ -17,6 +17,7 @@
 package com.smeup.rpgparser.parsing.parsetreetoast
 
 import com.smeup.rpgparser.RpgParser
+import com.smeup.rpgparser.RpgParser.BegindowContext
 import com.smeup.rpgparser.RpgParser.BlockContext
 import com.smeup.rpgparser.interpreter.Evaluator
 import com.smeup.rpgparser.interpreter.Value
@@ -39,12 +40,7 @@ internal fun BlockContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
         this.ifstatement() != null -> this.ifstatement().toAst(conf)
         this.selectstatement() != null -> this.selectstatement().toAst(conf)
         this.begindo() != null -> this.begindo().toAst(blockContext = this, conf = conf)
-        this.begindow() != null -> {
-            val endExpression = this.begindow().csDOW().fixedexpression.expression().toAst(conf)
-            DowStmt(endExpression,
-                    this.statement().map { it.toAst(conf) },
-                    position = toPosition(conf.considerPosition))
-        }
+        this.begindow() != null -> this.begindow().toAst(blockContext = this, conf = conf)
         this.forstatement() != null -> this.forstatement().toAst(conf)
         this.begindou() != null -> {
             val endExpression = this.begindou().csDOU().fixedexpression.expression().toAst(conf)
@@ -114,6 +110,17 @@ internal fun RpgParser.BegindoContext.toAst(
         blockContext.statement().map { it.toAst(conf) },
         start,
         position = toPosition(conf.considerPosition))
+}
+
+internal fun BegindowContext.toAst(
+    blockContext: BlockContext,
+    conf: ToAstConfiguration = ToAstConfiguration()
+): DowStmt {
+    val endExpression = csDOW().fixedexpression.expression().toAst(conf)
+    return DowStmt(endExpression,
+        blockContext.statement().map { it.toAst(conf) },
+        position = toPosition(conf.considerPosition)
+    )
 }
 
 internal fun RpgParser.WhenstatementContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): SelectCase {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
@@ -17,7 +17,6 @@
 package com.smeup.rpgparser.parsing.parsetreetoast
 
 import com.smeup.rpgparser.RpgParser
-import com.smeup.rpgparser.RpgParser.BegindowContext
 import com.smeup.rpgparser.RpgParser.BlockContext
 import com.smeup.rpgparser.interpreter.Evaluator
 import com.smeup.rpgparser.interpreter.Value
@@ -42,12 +41,7 @@ internal fun BlockContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
         this.begindo() != null -> this.begindo().toAst(blockContext = this, conf = conf)
         this.begindow() != null -> this.begindow().toAst(blockContext = this, conf = conf)
         this.forstatement() != null -> this.forstatement().toAst(conf)
-        this.begindou() != null -> {
-            val endExpression = this.begindou().csDOU().fixedexpression.expression().toAst(conf)
-            DouStmt(endExpression,
-                    this.statement().map { it.toAst(conf) },
-                    position = toPosition(conf.considerPosition))
-        }
+        this.begindou() != null -> this.begindou().toAst(blockContext = this, conf = conf)
         else -> TODO(this.text.toString() + " " + toPosition(conf.considerPosition))
     }
 }
@@ -112,7 +106,7 @@ internal fun RpgParser.BegindoContext.toAst(
         position = toPosition(conf.considerPosition))
 }
 
-internal fun BegindowContext.toAst(
+internal fun RpgParser.BegindowContext.toAst(
     blockContext: BlockContext,
     conf: ToAstConfiguration = ToAstConfiguration()
 ): DowStmt {
@@ -121,6 +115,16 @@ internal fun BegindowContext.toAst(
         blockContext.statement().map { it.toAst(conf) },
         position = toPosition(conf.considerPosition)
     )
+}
+
+internal fun RpgParser.BegindouContext.toAst(
+    blockContext: BlockContext,
+    conf: ToAstConfiguration = ToAstConfiguration()
+): DouStmt {
+    val endExpression = csDOU().fixedexpression.expression().toAst(conf)
+    return DouStmt(endExpression,
+        blockContext.statement().map { it.toAst(conf) },
+        position = toPosition(conf.considerPosition))
 }
 
 internal fun RpgParser.WhenstatementContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): SelectCase {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
@@ -92,8 +92,15 @@ internal fun RpgParser.SelectstatementContext.toAst(conf: ToAstConfiguration = T
         }
         other = SelectOtherClause(statementsOfLastWhen.subList(indexOfOther + 1, statementsOfLastWhen.size), position = otherPosition)
     }
-
-    return SelectStmt(whenClauses, other, toPosition(conf.considerPosition))
+    val result = beginselect().csSELECT().cspec_fixed_standard_parts().result.text
+    val position = toPosition(conf.considerPosition)
+    val dataDefinition = beginselect().csSELECT().cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
+    return SelectStmt(
+        cases = whenClauses,
+        other = other,
+        dataDefinition = dataDefinition,
+        position = toPosition(conf.considerPosition)
+    )
 }
 
 internal fun RpgParser.BegindoContext.toAst(

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
@@ -37,8 +37,20 @@ fun RpgParser.StatementContext.toAst(conf: ToAstConfiguration = ToAstConfigurati
 internal fun BlockContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     return when {
         this.ifstatement() != null -> this.ifstatement().toAst(conf)
-        this.selectstatement() != null -> this.selectstatement().toAst(conf)
-        this.begindo() != null -> this.begindo().toAst(blockContext = this, conf = conf)
+        this.selectstatement()!= null -> this.selectstatement()
+            .let {
+                it.beginselect().csSELECT().cspec_fixed_standard_parts().validate(
+                    stmt = it.toAst(conf = conf),
+                    conf = conf
+                )
+            }
+        this.begindo() != null -> this.begindo()
+            .let {
+                it.csDO().cspec_fixed_standard_parts().validate(
+                    stmt = it.toAst(blockContext = this, conf = conf),
+                    conf = conf
+                )
+            }
         this.begindow() != null -> this.begindow().toAst(blockContext = this, conf = conf)
         this.forstatement() != null -> this.forstatement().toAst(conf)
         this.begindou() != null -> this.begindou().toAst(blockContext = this, conf = conf)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterSmokeTest.kt
@@ -18,10 +18,18 @@ package com.smeup.rpgparser.evaluation
 
 import com.smeup.rpgparser.AbstractTest
 import com.smeup.rpgparser.execute
+import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
+import org.junit.Before
 import org.junit.Test
 
 open class InterpreterSmokeTest : AbstractTest() {
+
+    @Before
+    fun resetDefaultConfigAttributes() {
+        // It is necessary to fix a problem where if a smoke test fails the errors are propagated to all unit tests
+        MainExecutionContext.getAttributes().clear()
+    }
 
     @Test
     fun executeJD_001() {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterSmokeTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.smeup.rpgparser.evaluation
 
 import com.smeup.rpgparser.AbstractTest
@@ -34,5 +50,11 @@ open class InterpreterSmokeTest : AbstractTest() {
         val cu = assertASTCanBeProduced("MOVEA01")
         cu.resolveAndValidate()
         execute(cu, mapOf())
+    }
+
+    @Test
+    fun executeINLINESPEC() {
+        val cu = assertASTCanBeProduced(exampleName = "INLINESPEC")
+        cu.resolveAndValidate()
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -368,7 +368,7 @@ class JarikoCallbackTest : AbstractTest() {
     @Test
     fun executeERROR08CallBackTest() {
         // Errors in block statements
-        executePgmCallBackTest("ERROR08", SourceReferenceType.Program, "ERROR08", listOf(14, 15, 8, 9, 13, 7))
+        executePgmCallBackTest("ERROR08", SourceReferenceType.Program, "ERROR08", listOf(7, 8, 9, 14, 15, 16, 21, 22))
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/CopyTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/CopyTest.kt
@@ -22,6 +22,7 @@ import com.smeup.rpgparser.parsing.facade.*
 import com.smeup.rpgparser.rpginterop.CopyFileExtension
 import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
 import org.junit.Assert
+import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 import java.nio.file.Paths
@@ -431,6 +432,11 @@ class CopyTest {
         testCpyInclusion("TSTCPY06", "I am copy with .api extension")
     }
 
+    @Test @Ignore
+    fun includeSameCopyIncludedTwice() {
+        testCpyInclusion("TSTCPY07", "I am copy with .api extension")
+    }
+
     @Test
     fun includeNotFoundCopy() {
         var catchedErrorEvent: ErrorEvent? = null
@@ -453,6 +459,7 @@ class CopyTest {
     }
 
     private fun testCpyInclusion(pgm: String, expected: String = "Hi I am QILEGEN,TSTCPY01") {
+        val includedCopyList = mutableListOf<CopyId>()
         var message = ""
         getProgram(
             nameOrSource = pgm,
@@ -460,8 +467,16 @@ class CopyTest {
             systemInterface = JavaSystemInterface().apply {
                 onDisplay = { mess, _ -> message = mess }
             }
-        ).singleCall(listOf())
+        ).singleCall(listOf(), configuration = Configuration().apply {
+            jarikoCallback = JarikoCallback().apply {
+                beforeCopyInclusion = { copyId, source ->
+                    includedCopyList.add(copyId)
+                    source
+                }
+            }
+        })
         Assert.assertEquals(expected, message)
+        Assert.assertEquals(1, includedCopyList.size)
     }
 
     private fun createCopyBlocks(): CopyBlocks {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserSmokeTest.kt
@@ -224,12 +224,14 @@ class RpgParserSmokeTest : AbstractTest() {
     }
 
     @Test
-    fun parseProgramWithCSpecFollowedByLR() {
-        val pgm = "     CLR                 IF        ££B£20 = '1'\n" +
-                "     CLR                 CALL      £EXCMD\n" +
-                "     CLR                 PARM      'RCLRSC'      £RCLRS            6\n" +
-                "     CLR                 PARM      6             NNN155_OLD       15 5\n" +
-                "     CLR                 ENDIF"
+    fun parseProgramWithControlLevelIndicatorFollowedByPARM() {
+        // the issue was at line 2 and 3
+        val pgm =
+            "1    CLR                 IF        ££B£20 = '1'\n" +
+            "2    CLR                 CALL      £EXCMD\n" +
+            "3    CLR                 PARM      'RCLRSC'      £RCLRS            6\n" +
+            "4    CLR                 PARM      6             NNN155_OLD       15 5\n" +
+            "5    CLR                 ENDIF"
         val inputStream = pgm.byteInputStream()
         assertCanBeParsed(inputStream = inputStream, false)
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/RpgParserSmokeTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.smeup.rpgparser.parsing
 
 import com.smeup.rpgparser.AbstractTest
@@ -205,5 +221,16 @@ class RpgParserSmokeTest : AbstractTest() {
     fun parseMUTE13_13_indicatorsWithParenthesis() {
         assertCanBeParsed("mute/MUTE13_13")
         assertASTCanBeProduced("mute/MUTE13_13", true)
+    }
+
+    @Test
+    fun parseProgramWithCSpecFollowedByLR() {
+        val pgm = "     CLR                 IF        ££B£20 = '1'\n" +
+                "     CLR                 CALL      £EXCMD\n" +
+                "     CLR                 PARM      'RCLRSC'      £RCLRS            6\n" +
+                "     CLR                 PARM      6             NNN155_OLD       15 5\n" +
+                "     CLR                 ENDIF"
+        val inputStream = pgm.byteInputStream()
+        assertCanBeParsed(inputStream = inputStream, false)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/performance/Kute10_50.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/performance/Kute10_50.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.smeup.rpgparser.performance
 
 import com.smeup.rpgparser.interpreter.*
@@ -47,14 +63,14 @@ class Kute10_50 : Kute() {
     fun performanceComparing(doAsserts: Boolean): Array<String> {
 
         // Variables declaration-instantiation
-        var factor1Ref: DataDefinition = DataDefinition("FACTOR1", StringType(6, false))
-        var factor1DataRefExpr = DataRefExpr(ReferenceByName("FACTOR1", factor1Ref))
+        val factor1Ref = DataDefinition("FACTOR1", StringType(6, false))
+        val factor1DataRefExpr = DataRefExpr(ReferenceByName("FACTOR1", factor1Ref))
 
-        var factor2Ref: DataDefinition = DataDefinition("FACTOR2", StringType(10, false))
-        var factor2DataRefExpr = DataRefExpr(ReferenceByName("FACTOR2", factor2Ref))
+        val factor2Ref = DataDefinition("FACTOR2", StringType(10, false))
+        val factor2DataRefExpr = DataRefExpr(ReferenceByName("FACTOR2", factor2Ref))
 
-        var resultRef: DataDefinition = DataDefinition("RESULT", StringType(20, false))
-        var resultDataRefExpr = DataRefExpr(ReferenceByName("RESULT", resultRef))
+        val resultRef = DataDefinition("RESULT", StringType(20, false))
+        val resultDataRefExpr = DataRefExpr(ReferenceByName("RESULT", resultRef))
 
         // Variables evaluation-storing
         globalSymbolTable[factor1Ref] = StringValue("HELLO")
@@ -62,11 +78,10 @@ class Kute10_50 : Kute() {
         globalSymbolTable[resultRef] = StringValue("XXXXXXXXXXXXXXXXXXXX")
 
         // Statement creation (similar to 'toAst' does)
-        var statement = catStmt(factor1DataRefExpr, factor2DataRefExpr, resultDataRefExpr, 0, null)
-        var actualElapsedTimeInMillisec = 0L
+        val statement = catStmt(factor1DataRefExpr, factor2DataRefExpr, resultDataRefExpr, 0, null)
 
         // Perform a pure kotlin loop
-        actualElapsedTimeInMillisec = measureTimeMillis {
+        var actualElapsedTimeInMillisec: Long = measureTimeMillis {
             loopCounter = 0L
             while (loopCounter < expectedIterations) {
                 exec_CAT(statement)
@@ -74,8 +89,8 @@ class Kute10_50 : Kute() {
             }
         }
         // Results
-        var message1 = "(Kotlin pure loop) Expected execution of 10000000 iterations, actual is $loopCounter iterations."
-        var message2 = "(Kotlin pure loop) Expected execution of 10000000 iterations ($loopCounter done) takes less or same to " +
+        val message1 = "(Kotlin pure loop) Expected execution of 10000000 iterations, actual is $loopCounter iterations."
+        val message2 = "(Kotlin pure loop) Expected execution of 10000000 iterations ($loopCounter done) takes less or same to " +
                 "$expectedElapsedTimeInMillisec ms. Actual is $actualElapsedTimeInMillisec ms. (CAT result is ${globalSymbolTable[resultRef].asString()})"
         if (doAsserts) {
             assertEquals(expectedIterations, loopCounter, message1)
@@ -92,8 +107,8 @@ class Kute10_50 : Kute() {
         }
 
         // Results
-        var message3 = "(Jariko DO loop) Expected execution of ${endLimitExpression.value} iterations, actual is $loopCounter iterations."
-        var message4 = "(Jariko DO loop) Expected execution of ${endLimitExpression.value} iterations ($loopCounter done) takes less or same to " +
+        val message3 = "(Jariko DO loop) Expected execution of ${endLimitExpression.value} iterations, actual is $loopCounter iterations."
+        val message4 = "(Jariko DO loop) Expected execution of ${endLimitExpression.value} iterations ($loopCounter done) takes less or same to " +
                 "$expectedElapsedTimeInMillisec ms. Actual is $actualElapsedTimeInMillisec ms. (CAT result is ${globalSymbolTable[resultRef].asString()})"
         if (doAsserts) {
             assertEquals(endLimitExpression.value, loopCounter, message3)
@@ -123,7 +138,7 @@ class Kute10_50 : Kute() {
         val factor2 = eval(statement.right)
         var result = eval(statement.target)
         val resultLen = result.asString().length()
-        var concatenatedFactors: Value
+        val concatenatedFactors: Value
 
         if (null != statement.left) {
             val factor1 = eval(statement.left!!)
@@ -158,14 +173,14 @@ class Kute10_50 : Kute() {
 
     private fun catStmt(left: Expression?, right: Expression, target: AssignableExpression, blanksInBetween: Int, position: Position? = null): CatStmt {
         return CatStmt(
-                left,
-                right,
-                target,
-                blanksInBetween,
-                position)
+                left = left,
+                right = right,
+                target = target,
+                blanksInBetween = blanksInBetween,
+                position = position)
     }
 }
 
-fun main(args: Array<String>) {
+fun main() {
     Kute10_50().performanceComparing().forEach { println(it) }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR08.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR08.rpgle
@@ -9,9 +9,16 @@
      C     *IN36         PARM      AAAA          £C£F36            1
      C                   ENDIF
      C                   ENDSR
+
      C                   IF        '1' = '1'
      C                   CALL      £G90PG                               37      B£G90G
      C     *IN35         PARM      AAAA          £G9035            1
      C     *IN36         PARM      AAAA          £C£F36            1
      C                   ENDIF
+
+     C                   SELECT
+     C                   WHEN     1 = 1
+     C                   CALL      £G90PG
+     C                   PARM      BBBB          £G9035            1
+     C                   ENDSL
       *--------------------------------------------------------------*

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -8,7 +8,7 @@
      C     'A'           CAT       'A'           CATA             10
      C     CATA          DSPLY
       ** MOVE
-     C     'A'           CAT       'A'           MOVEA            10
+     C     'A'           MOVE      'A'           MOVEA            10
      C     MOVEA         DSPLY
       *
       * Test IF

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -1,20 +1,39 @@
-
+      * Evaluate the correctness of data reference resolution for statements that support inline dspec definition
+      * Test IF
      C                   IF        1 = 1
+      ** Test PARAM in branch THEN
      C                   CALL      'MYPGMB'
      C                   PARM      *BLANKS       MYPGMB           10
      C     MYPGMB        DSPLY
+      ** Test CAT in branch THEN
+     C     'A'           CAT       'A'           CATB             10
+     C     CATB          DSPLY
+      ** Test PARAM in branch ELSE
      C                   ELSE
      C                   CALL      'MYPGMC'
      C                   PARM      *BLANKS       MYPGMC           10
      C     MYPGMC        DSPLY
+      ** Test CAT in branch ELSE
+     C     'A'           CAT       'A'           CATC             10
+     C     CATC          DSPLY
      C                   ENDIF
+      * Test SELECT
      C                   SELECT
      C                   WHEN     1 = 1
+      ** Test PARAM in branch WHEN
      C                   CALL      'MYPGMD'
      C                   PARM      *BLANKS       MYPGMD           10
      C     MYPGMD        DSPLY
+      ** Test CAT in branch WHEN
+     C     'A'           CAT       'A'           CATD             10
+     C     CATD          DSPLY
      C                   WHEN     1 = 2
+      ** Test PARAM in second branch WHEN
      C                   CALL      'MYPGME'
      C                   PARM      *BLANKS       MYPGME           10
+      ** Test CAT in second branch WHEN
+     C     'A'           CAT       'A'           CATE             10
+     C     CATE          DSPLY
      C     MYPGME        DSPLY
+      *
      C                   ENDSL

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -23,6 +23,10 @@
      C     1             MULT      1             MULTA            1  0
      C     MULTA         DSPLY
       *
+      ** DIV
+     C     1             DIV       1             DIVA             1  0
+     C     DIVA          DSPLY
+      *
       * Test IF
      C                   IF        1 = 1
       ** Test in branch THEN

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -1,0 +1,10 @@
+
+     C                   IF        1 = 1
+     C                   CALL      'MYPGMB'
+     C                   PARM      *BLANKS       MYPGMB           10
+     C     MYPGMB        DSPLY
+     C                   ELSE
+     C                   CALL      'MYPGMC'
+     C                   PARM      *BLANKS       MYPGMC           10
+     C     MYPGMC        DSPLY
+     C                   ENDIF

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -8,3 +8,13 @@
      C                   PARM      *BLANKS       MYPGMC           10
      C     MYPGMC        DSPLY
      C                   ENDIF
+     C                   SELECT
+     C                   WHEN     1 = 1
+     C                   CALL      'MYPGMD'
+     C                   PARM      *BLANKS       MYPGMD           10
+     C     MYPGMD        DSPLY
+     C                   WHEN     1 = 2
+     C                   CALL      'MYPGME'
+     C                   PARM      *BLANKS       MYPGME           10
+     C     MYPGME        DSPLY
+     C                   ENDSL

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -15,6 +15,10 @@
      C     'A'           MOVEA     'A'           MOVEAA           10
      C     MOVEAA        DSPLY
       *
+      ** SCAN
+     C     'A'           SCAN      'A'           SCANA            1  0
+     C     SCANA         DSPLY
+      *
       * Test IF
      C                   IF        1 = 1
       ** Test in branch THEN

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -19,6 +19,10 @@
      C     'A'           SCAN      'A'           SCANA            1  0
      C     SCANA         DSPLY
       *
+      ** MULT
+     C     1             MULT      1             MULTA            1  0
+     C     MULTA         DSPLY
+      *
       * Test IF
      C                   IF        1 = 1
       ** Test in branch THEN

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -27,7 +27,14 @@
      C     1             DIV       1             DIVA             1  0
      C     DIVA          DSPLY
       *
-      * Test IF
+      ** DO
+     C     1             DO        2             DOA             1  0
+     C     DOA           DSPLY
+     C                   ENDDO
+      *
+      *
+      *
+      * Test in-line DSPEC in IF
      C                   IF        1 = 1
       ** Test in branch THEN
      C                   CALL      'MYPGMB'
@@ -40,7 +47,7 @@
      C     MYPGMC        DSPLY
      C                   ENDIF
       *
-      * Test SELECT
+      * Test in-line DSPEC in SELECT
      C                   SELECT
      C                   WHEN     1 = 1
       ** Test in first branch WHEN

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -1,39 +1,34 @@
       * Evaluate the correctness of data reference resolution for statements that support inline dspec definition
+      * Test in body
+      ** CALL
+     C                   CALL      'MYPGMA'
+     C                   PARM      *BLANKS       MYPGMA           10
+     C     MYPGMA        DSPLY
+      ** CAT
+     C     'A'           CAT       'A'           CATA             10
+     C     CATA          DSPLY
+      ** MOVE
+     C     'A'           CAT       'A'           MOVEA            10
+     C     MOVEA         DSPLY
+      *
       * Test IF
      C                   IF        1 = 1
-      ** Test PARAM in branch THEN
+      ** Test in branch THEN
      C                   CALL      'MYPGMB'
      C                   PARM      *BLANKS       MYPGMB           10
      C     MYPGMB        DSPLY
-      ** Test CAT in branch THEN
-     C     'A'           CAT       'A'           CATB             10
-     C     CATB          DSPLY
-      ** Test PARAM in branch ELSE
+      ** Test in branch ELSE
      C                   ELSE
      C                   CALL      'MYPGMC'
      C                   PARM      *BLANKS       MYPGMC           10
      C     MYPGMC        DSPLY
-      ** Test CAT in branch ELSE
-     C     'A'           CAT       'A'           CATC             10
-     C     CATC          DSPLY
      C                   ENDIF
+      *
       * Test SELECT
      C                   SELECT
      C                   WHEN     1 = 1
-      ** Test PARAM in branch WHEN
+      ** Test in first branch WHEN
      C                   CALL      'MYPGMD'
      C                   PARM      *BLANKS       MYPGMD           10
      C     MYPGMD        DSPLY
-      ** Test CAT in branch WHEN
-     C     'A'           CAT       'A'           CATD             10
-     C     CATD          DSPLY
-     C                   WHEN     1 = 2
-      ** Test PARAM in second branch WHEN
-     C                   CALL      'MYPGME'
-     C                   PARM      *BLANKS       MYPGME           10
-      ** Test CAT in second branch WHEN
-     C     'A'           CAT       'A'           CATE             10
-     C     CATE          DSPLY
-     C     MYPGME        DSPLY
-      *
      C                   ENDSL

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -28,9 +28,15 @@
      C     DIVA          DSPLY
       *
       ** DO
-     C     1             DO        2             DOA             1  0
+     C     1             DO        2             DOA              1  0
      C     DOA           DSPLY
      C                   ENDDO
+      *
+      ** SELECT
+     C                   SELECT                  SELA             1  0
+     C                   WHEN     1 = 1
+     C     SELA          DSPLY
+     C                   ENDSL
       *
       *
       *

--- a/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INLINESPEC.rpgle
@@ -11,6 +11,10 @@
      C     'A'           MOVE      'A'           MOVEA            10
      C     MOVEA         DSPLY
       *
+      ** MOVEA
+     C     'A'           MOVEA     'A'           MOVEAA           10
+     C     MOVEAA        DSPLY
+      *
       * Test IF
      C                   IF        1 = 1
       ** Test in branch THEN

--- a/rpgJavaInterpreter-core/src/test/resources/TSTCPY07.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/TSTCPY07.rpgle
@@ -1,0 +1,6 @@
+     V* ==============================================================
+     D* Copy that includes another copy twice
+     V* ==============================================================
+     D MSGCPY          S             30
+  T > /COPY QILEGEN,TSTCPY02
+  T > /COPY QILEGEN,TSTCPY02


### PR DESCRIPTION
## Description
Fixed issue where in the ELSE and ELSEIF branches the reference defined inline is ignored.

Added support of dspec inline definition for:
- CAT
- MOVE
- MOVEA
- SCAN
- MULT
- DIV
- DO
- SELECT

Fixed parsing error in case of level indicator in statements containing opcode PARM


## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
