### PR TITLE
Removed an unuseful panic message

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
@@ -17,6 +17,7 @@
 package com.smeup.rpgparser.execution
 
 import com.smeup.dbnative.manager.DBFileFactory
+import com.smeup.rpgparser.experimental.ExperimentalFeaturesFactory
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.parsing.facade.CopyBlocks
 import java.util.*
@@ -92,12 +93,14 @@ object MainExecutionContext {
         return if (context.get() != null) {
             context.get().idProvider.getAndIncrement()
         } else {
-            // In many tests, the parsing is called outside of the execution context
+            // In many tests, the parsing is called outside the execution context
             // It's not too wrong assume that over 32000 it can be reset idProvider
             // In this way doesn't fail the variables assignment when involved the experimental
             // symbol table
             if (noContextIdProvider.get() == 32000) {
-                Exception("Reset idProvider").printStackTrace()
+                if (FeaturesFactory.newInstance() is ExperimentalFeaturesFactory) {
+                    Exception("Reset idProvider").printStackTrace()
+                }
                 noContextIdProvider.set(0)
             }
             noContextIdProvider.getAndIncrement()

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/execution/MainExecutionContextTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/execution/MainExecutionContextTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smeup.rpgparser.execution
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.assertFalse
+
+class MainExecutionContextTest {
+
+    private lateinit var defaultErr: PrintStream
+    private lateinit var byteArrayOutputStream: ByteArrayOutputStream
+
+    @Before
+    fun setup() {
+        defaultErr = System.err
+        byteArrayOutputStream = ByteArrayOutputStream(1024)
+        val printStream = PrintStream(byteArrayOutputStream)
+        System.setErr(printStream)
+    }
+
+    @After
+    fun teardown() {
+        System.setErr(defaultErr)
+        System.err.println(byteArrayOutputStream.toByteArray())
+    }
+
+    @Test
+    fun `it has never to show the message Reset idProvider with the default SymbolTable`() {
+        for (i in 1..33000) {
+            MainExecutionContext.newId()
+        }
+        assertFalse { String(byteArrayOutputStream.toByteArray()).contains("Reset idProvider") }
+    }
+}


### PR DESCRIPTION
The error message "Reset idProvider" now is showed only in case of use of the deprecated experimental symbol table

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
