### PR TITLE
Feature/update tech stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,8 @@ version: 2.0
 jobs:
     build:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: circleci/openjdk:11-jdk
         steps:
             - checkout
-            - run: ./gradlew ktlintCheck
             - run: ./gradlew check
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,6 @@ jobs:
             - image: circleci/openjdk:11-jdk
         steps:
             - checkout
+            - run: ./gradlew ktlintCheck
             - run: ./gradlew check
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Checking kotlin formatting
       run: ./gradlew ktlintCheck
     - name: Compiling and test

--- a/.github/workflows/publish-smeup.yml
+++ b/.github/workflows/publish-smeup.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       # save private key to file (private.gpg)
       - run: echo "${{ secrets.GPG_KEY_BASE64 }}" | base64 -d > ~/private.gpg
       # create gradle.properties file

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       # save private key to file (private.gpg)
       - run: echo "${{ secrets.GPG_KEY_BASE64 }}" | base64 -d > ~/private.gpg
       # create gradle.properties file

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ project.version = jarikoVersion
 subprojects {
     apply plugin: 'kotlin'
     apply plugin: 'java'
-    apply plugin: 'maven'
+    apply plugin: 'maven-publish'
     apply plugin: 'idea'
     apply plugin: 'org.jlleitschuh.gradle.ktlint'
     apply plugin: 'kotlinx-serialization'

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,9 @@ subprojects {
         tasks.publishMavenJavaPublicationToSmeupRepository{
             dependsOn project.tasks.signArchives
         }
+        tasks.publishMavenJavaPublicationToMavenLocal{
+            dependsOn project.tasks.signArchives
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ project.version = jarikoVersion
 subprojects {
     apply plugin: 'kotlin'
     apply plugin: 'java'
-    apply plugin: 'maven-publish'
     apply plugin: 'idea'
     apply plugin: 'org.jlleitschuh.gradle.ktlint'
     apply plugin: 'kotlinx-serialization'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -20,9 +20,9 @@ buildscript {
 
 dependencies {
     implementation project(":rpgJavaInterpreter-core")
-    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlinVersion".toString()
-    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion".toString()
-    testCompile 'junit:junit:4.12'
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
+    testImplementation 'junit:junit:4.12'
 }
 
 // deploy

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -25,6 +25,20 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
+task javadocJar(type: Jar) {
+    archiveClassifier.set("javadoc")
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    archiveClassifier.set("sources")
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
 // deploy
 publishing {
     publications {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -75,3 +75,8 @@ publishing {
         }
     }
 }
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 FlightRecorderOptions=stackdepth=64
 kotlinVersion=1.4.10
 serializationVersion=1.0.1
-jvmVersion=1.8
+jvmVersion=11
 reloadVersion=develop-SNAPSHOT
 jarikoGroupId=io.github.smeup.jariko
 jarikoVersion=develop-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,3 @@ jvmVersion=11
 reloadVersion=develop-SNAPSHOT
 jarikoGroupId=io.github.smeup.jariko
 jarikoVersion=develop-SNAPSHOT
-
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@
 
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 FlightRecorderOptions=stackdepth=64
-kotlinVersion=1.4.10
-serializationVersion=1.0.1
+kotlinVersion=1.8.20
+serializationVersion=1.5.0
 jvmVersion=11
 reloadVersion=develop-SNAPSHOT
 jarikoGroupId=io.github.smeup.jariko

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -15,7 +15,7 @@
 #
 
 #Tue Oct 22 14:17:50 CEST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,21 @@
+#
+# Copyright 2019 Sme.UP S.p.A.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #Tue Oct 22 14:17:50 CEST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/kolasu/build.gradle
+++ b/kolasu/build.gradle
@@ -23,7 +23,6 @@ buildscript {
 
 apply plugin: 'kotlin'
 apply plugin: 'java'
-apply plugin: 'antlr'
 apply plugin: 'maven-publish'
 apply plugin: 'idea'
 
@@ -34,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    antlr "org.antlr:antlr4:$antlr_version"
+    implementation "org.antlr:antlr4:$antlr_version"
     implementation "org.antlr:antlr4-runtime:$antlr_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"

--- a/kolasu/build.gradle
+++ b/kolasu/build.gradle
@@ -60,7 +60,7 @@ task javadocJar(type: Jar) {
 }
 
 task sourcesJar(type: Jar) {
-    archiveClassifier.set("javadoc")
+    archiveClassifier.set("sources")
     from sourceSets.main.allSource
 }
 

--- a/kolasu/build.gradle
+++ b/kolasu/build.gradle
@@ -24,9 +24,8 @@ buildscript {
 apply plugin: 'kotlin'
 apply plugin: 'java'
 apply plugin: 'antlr'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'idea'
-apply plugin: 'kotlinx-serialization'
 
 repositories {
     mavenLocal()
@@ -36,17 +35,17 @@ repositories {
 
 dependencies {
     antlr "org.antlr:antlr4:$antlr_version"
-    compile "org.antlr:antlr4-runtime:$antlr_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
-    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testCompile 'junit:junit:4.12'
+    implementation "org.antlr:antlr4-runtime:$antlr_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
+    testImplementation 'junit:junit:4.12'
 
-    compile 'com.fifesoft:rsyntaxtextarea:2.5.8'
-    compile 'com.fifesoft:autocomplete:2.5.8'
-    compile "org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion"
-    compile "org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion"
+    implementation 'com.fifesoft:rsyntaxtextarea:2.5.8'
+    implementation 'com.fifesoft:autocomplete:2.5.8'
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion"
 
 }
 
@@ -57,12 +56,12 @@ task version {
 }
 
 task javadocJar(type: Jar) {
-    classifier = 'javadoc'
+    archiveClassifier.set("javadoc")
     from javadoc
 }
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier.set("javadoc")
     from sourceSets.main.allSource
 }
 

--- a/kolasu/build.gradle
+++ b/kolasu/build.gradle
@@ -117,3 +117,8 @@ publishing {
         }
     }
 }
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -102,7 +102,7 @@ compileTestKotlin {
     targetCompatibility = "$jvmVersion"
     kotlinOptions.freeCompilerArgs += ["-Xuse-experimental=kotlin.ExperimentalUnsignedTypes"]
     kotlinOptions.jvmTarget = "$jvmVersion"
-    dependsOn generateGrammarSource
+    dependsOn generateTestGrammarSource
 }
 
 compileKotlin {

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -100,7 +100,6 @@ compileJava {
 compileTestKotlin {
     sourceCompatibility = "$jvmVersion"
     targetCompatibility = "$jvmVersion"
-    kotlinOptions.freeCompilerArgs += ["-Xuse-experimental=kotlin.ExperimentalUnsignedTypes"]
     kotlinOptions.jvmTarget = "$jvmVersion"
     dependsOn generateTestGrammarSource
 }
@@ -109,7 +108,6 @@ compileKotlin {
     sourceCompatibility = "$jvmVersion"
     targetCompatibility = "$jvmVersion"
     source generatedMainFile, sourceSets.main.java, sourceSets.main.kotlin
-    kotlinOptions.freeCompilerArgs += ["-Xuse-experimental=kotlin.ExperimentalUnsignedTypes"]
     kotlinOptions.jvmTarget = "$jvmVersion"
     dependsOn generateGrammarSource
 }

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -423,3 +423,8 @@ publishing {
         }
     }
 }
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -47,36 +47,35 @@ def generatedMainFile = file(generatedMain)
 
 dependencies {
     antlr "org.antlr:antlr4:$antlr_version"
-    compile "org.antlr:antlr4-runtime:$antlr_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    compile project(":kolasu")
+    implementation "org.antlr:antlr4-runtime:$antlr_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    api project(":kolasu")
 
-    compile "org.apache.logging.log4j:log4j-api-kotlin:1.0.0"
-    compile "org.apache.logging.log4j:log4j-api:2.15.0"
-    compile "org.apache.logging.log4j:log4j-core:2.15.0"
+    implementation "org.apache.logging.log4j:log4j-api-kotlin:1.0.0"
+    implementation "org.apache.logging.log4j:log4j-api:2.15.0"
+    implementation "org.apache.logging.log4j:log4j-core:2.15.0"
 
-    compile 'commons-io:commons-io:2.6'
-    compile 'com.github.ajalt:clikt:2.1.0'
-    // I cannot set api scope, as suggested, because for a reason I still have to dig into,
-    // the dependency is not propagated
-    compile "io.github.smeup.reload:base:$reloadVersion"
-    implementation "io.github.smeup.reload:sql:$reloadVersion"
-    implementation "io.github.smeup.reload:nosql:$reloadVersion"
-    implementation "io.github.smeup.reload:manager:$reloadVersion"
-    implementation "io.github.smeup.reload:jt400:$reloadVersion"
+    implementation 'commons-io:commons-io:2.6'
+    implementation 'com.github.ajalt:clikt:2.1.0'
 
-    compile 'com.github.ziggy42:kolor:0.0.2'
+    api "io.github.smeup.reload:base:$reloadVersion"
+    api "io.github.smeup.reload:sql:$reloadVersion"
+    api "io.github.smeup.reload:nosql:$reloadVersion"
+    api "io.github.smeup.reload:manager:$reloadVersion"
+    api "io.github.smeup.reload:jt400:$reloadVersion"
 
-    compile "org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion"
-    compile "org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion"
+    implementation 'com.github.ziggy42:kolor:0.0.2'
 
-    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
-    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hsqldb:hsqldb:2.5.0'
-    testCompile 'io.mockk:mockk:1.9'
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion"
+
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hsqldb:hsqldb:2.5.0'
+    testImplementation 'io.mockk:mockk:1.9'
 }
 
 configurations.all() {

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -102,6 +102,7 @@ compileTestKotlin {
     targetCompatibility = "$jvmVersion"
     kotlinOptions.freeCompilerArgs += ["-Xuse-experimental=kotlin.ExperimentalUnsignedTypes"]
     kotlinOptions.jvmTarget = "$jvmVersion"
+    dependsOn generateGrammarSource
 }
 
 compileKotlin {
@@ -111,6 +112,10 @@ compileKotlin {
     kotlinOptions.freeCompilerArgs += ["-Xuse-experimental=kotlin.ExperimentalUnsignedTypes"]
     kotlinOptions.jvmTarget = "$jvmVersion"
     dependsOn generateGrammarSource
+}
+
+ktlintTestSourceSetCheck {
+    dependsOn generateTestGrammarSource
 }
 
 clean {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -298,13 +298,14 @@ data class IntValue(val value: Long) : NumberValue() {
 
     override fun assignableTo(expectedType: Type): Boolean {
         // TODO check decimals
-        when (expectedType) {
-            is NumberType -> return true
+        return when (expectedType) {
+            is NumberType -> true
             is ArrayType -> {
-                return expectedType.element is NumberType
+                expectedType.element is NumberType
+            } else -> {
+                false
             }
         }
-        return false
     }
 
     override fun asInt() = this
@@ -398,16 +399,17 @@ data class DecimalValue(@Contextual val value: BigDecimal) : NumberValue() {
     override fun asDecimal(): DecimalValue = this
 
     override fun assignableTo(expectedType: Type): Boolean {
-        when (expectedType) {
+        return when (expectedType) {
             is NumberType -> {
                 val expectedTypePrecision = expectedType.entireDigits + expectedType.decimalDigits
-                return expectedTypePrecision >= value.precision()
+                expectedTypePrecision >= value.precision()
             }
             is ArrayType -> {
-                return expectedType.element is NumberType
+                expectedType.element is NumberType
+            } else -> {
+                false
             }
         }
-        return false
     }
 
     fun isPositive(): Boolean {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -323,7 +323,7 @@ private fun getFakeProcedures(
                 }
                 // Add only 'real fake prototype', if any RPG procedure exists yet
                 // the 'fake prototype' with same name mustn't be added.
-                if (null == procedures || (!procedures.contains(fakePrototypeName))) {
+                if (null == procedures || (!procedures.map { cu -> cu.procedureName }.contains(fakePrototypeName))) {
                     fakePrototypeNames.put(fakePrototypeName, fakePrototypeDataDefinitions)
                 }
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/rpgcompiler.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/rpgcompiler.kt
@@ -226,6 +226,7 @@ fun doCompilationAtRuntime(
     when (format) {
         Format.BIN -> out.use { it.write(cu.encodeToByteArray()) }
         Format.JSON -> out.use { it.write(cu.encodeToString().toByteArray(Charsets.UTF_8)) }
+        else -> error("$format not handled")
     }
     cu.resolveAndValidate()
     println("... done.")


### PR DESCRIPTION
## Description

Updated the following tecnologic stack:
- java: 8 -> 11
- kotlin: 1.4.10 -> 1.8.20
- kotlin serialization: 1.0.1 -> 1.5.0
- gradle: 5.4.1 -> 8.0

Fixed creating of sources and javadocs jar on publishToMavenLocal, this issue prevented  debugging of jariko when used as external library


## Checklist:
- [ ] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
