### PR TITLE
The "fatjar" task fails

### DIFF
--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -214,7 +214,8 @@ task fatJar(type: Jar) {
     }
     archiveBaseName = project.name + '-all'
     archiveVersion = ''
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
 
@@ -225,7 +226,8 @@ task fatMuteJar(type: Jar) {
     }
     archiveBaseName = project.name + '-mute-all'
     archiveVersion = ''
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
 


### PR DESCRIPTION
## Description
Regression caused by gradle updating.
The error occurred was:  Could not get unknown property 'compile' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer.

This problem also caused the failure of the Jenkins job "Jariko-Develop-Continuum."


## Checklist:
- [ ] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
