### PR TITLE
fixed: kotlinx.serialization.SerializationException: Class 'UnlimiteStringValue' is not registered

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/serialization/serialization_options.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/serialization/serialization_options.kt
@@ -40,6 +40,7 @@ private val module = SerializersModule {
         subclass(ConcreteArrayValue::class)
         subclass(DataStructValue::class)
         subclass(OccurableDataStructValue::class)
+        subclass(UnlimitedStringValue::class)
     }
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/serialization/SerializationTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/serialization/SerializationTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.smeup.rpgparser.interpreter.serialization
 
 import com.smeup.rpgparser.interpreter.*
@@ -104,5 +120,15 @@ class SerializationTest {
             "eighth" to dsValue
         )
         checkValueSerialization(originalMap, printValues = true)
+    }
+
+    @Test
+    fun `DataStructValue with UnlimitedStringType can be serialized to Json`() {
+        val rawStringValue = " Hello world 123 "
+        val dsValue = DataStructValue(rawStringValue)
+        val fieldDefinition = FieldDefinition(name = "myField", type = UnlimitedStringType, explicitStartOffset = -1, explicitEndOffset = -1)
+        val value = UnlimitedStringValue("myValue")
+        dsValue.set(fieldDefinition, value)
+        checkValueSerialization(dsValue, true)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/ACTGRP_FIX.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ACTGRP_FIX.rpgle
@@ -1,6 +1,7 @@
      H ACTGRP('MYACT')
      D X               S              1  0
      D Msg             S             12
+     D UnlMsg          S               0
      C                   EVAL      X = X + 1
      C                   EVAL      Msg = %CHAR(X)
      C     msg           dsply


### PR DESCRIPTION
## Description

Fixed this issue:

```
kotlinx.serialization.SerializationException: Class 'UnlimiteStringValue' is not registeredStringValue' is not registered for polymorphic serialization in the scope of 'Value'.

       To be registered automatically, class 'UnlimitedStringValue' has to be '@Serializable', and the base class 'Value' has to be sealed and '@Serializable'.
       Alternatively, register the serializer for 'UnlimitedStringValue' explicitly in a corresponding SerializersModule.
```

Include a summary of the change.

Related to # (issue)

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
