### PR TITLE
Fixed I do not know how to handle UnlimitedStringValue(value=nnn) with %INT

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -498,6 +498,8 @@ class ExpressionEvaluation(
                 IntValue(cleanNumericString(value.value).asLong())
             is DecimalValue ->
                 value.asInt()
+            is UnlimitedStringValue ->
+                IntValue(cleanNumericString(value.value).asLong())
             else -> throw UnsupportedOperationException("I do not know how to handle $value with %INT")
         }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -826,7 +826,7 @@ Test 6
 
     @Test
     fun executeUNLIMIT_DS() {
-        var expected = listOf(
+        val expected = listOf(
             "",
             "UnlInited",
             "",
@@ -841,6 +841,17 @@ Test 6
             "DS1 = DS2"
         )
         assertEquals(expected, outputOf("UNLIMIT_DS"))
+    }
+
+    @Test
+    fun executeUNLIMIT_BIF() {
+        val expected = listOf(
+            "%INT",
+            "1234",
+            "%DEC",
+            "1.5"
+        )
+        assertEquals(expected, outputOf("UNLIMIT_BIF"))
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/resources/UNLIMIT_BIF.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/UNLIMIT_BIF.rpgle
@@ -1,0 +1,26 @@
+     V* ==============================================================
+     D* Purpose of this program is to test UnlimitedStringType
+     D* with the BIFs
+     V* ==============================================================
+
+     D INTEGER         S             10  0
+     D DECIMAL         S              5  2
+     D UNL_STR         S               0
+     D MSG             S             50A   VARYING
+
+
+      * %INT test ****************************************************
+     C                   EVAL      MSG='%INT'
+     C                   EVAL      UNL_STR='1234'
+     C                   EVAL      INTEGER=%INT(UNL_STR)
+     C     MSG           DSPLY
+     C     INTEGER       DSPLY
+      ****************************************************************
+
+      * %DEC test ****************************************************
+     C                   EVAL      MSG='%DEC'
+     C                   EVAL      UNL_STR='1.5'
+     C                   EVAL      DECIMAL=%DEC(UNL_STR:5:2)
+     C     MSG           DSPLY
+     C     DECIMAL       DSPLY
+      ****************************************************************


### PR DESCRIPTION
## Description

Related to #TKIC315552

# Notes
All test cases related the problem of UnlimitedStringValue when passed as parameter to BIFs must be placed in `UNLIMIT_BIF.rpgle`

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
