### PR TITLE
Bugfix/nw23000322 fix like def in parm

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
@@ -20,6 +20,7 @@ import com.smeup.rpgparser.AbstractTest
 import com.smeup.rpgparser.interpreter.DataStructureType
 import com.smeup.rpgparser.interpreter.Scope
 import com.smeup.rpgparser.parsing.parsetreetoast.DSFieldInitKeywordType
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import org.junit.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -334,6 +335,14 @@ open class ToAstSmokeTest : AbstractTest() {
                 assertEquals(18, this.endOffset)
                 assertTrue { this.initializationValue is StatusExpr }
             }
+        }
+    }
+
+    @Test
+    fun buildAstForLIKEDEFINE02() {
+        assertASTCanBeProduced(exampleName = "LIKEDEFINE02", printTree = false).apply {
+            // this function must not throw "Data definition §§ORA was not found"
+            resolveAndValidate()
         }
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/LIKEDEFINE02.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/LIKEDEFINE02.rpgle
@@ -1,0 +1,14 @@
+     C     £G54          BEGSR
+     C                   CALL      'B£G54G'
+      * cause: £G54HR defined inline inside a subroutine
+     C                   PARM                    £G54HR            6 0
+     C                   ENDSR
+
+     C     ESE_P5A       BEGSR
+     C                   EXSR      £G54
+     C     £G54HR        DSPLY
+      * symptom: Data reference not resolved: §§ORA
+     C     §§ORA         DSPLY
+     C                   ENDSR
+      * evaluation: See implementation of com.smeup.rpgparser.parsing.ast.DefineStmt
+     C     *LIKE         DEFINE    £G54HR        §§ORA


### PR DESCRIPTION
## Description

Fixed the usage of `LIKE DEFINE` whose factor 1 is not a D specification but an inline variable defined in `PARM` inside a subroutine.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
