### PR TITLE
Feature/nw23000670 log as callback

### DIFF
--- a/examples/src/main/java/com/jariko/samples/java/CallJarikoWithParams.java
+++ b/examples/src/main/java/com/jariko/samples/java/CallJarikoWithParams.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jariko.samples.java;
 
 import com.smeup.rpgparser.execution.CommandLineParms;
@@ -30,8 +46,9 @@ public class CallJarikoWithParams {
         final JavaSystemInterface systemInterface = new JavaSystemInterface();
         systemInterface.setLoggingConfiguration(LoggingKt.consoleLoggingConfiguration(LoggingKt.PERFORMANCE_LOGGER));
         CommandLineProgram program = RunnerKt.getProgram(name, systemInterface, programFinders);
-        final Configuration configuration = new  Configuration();
-        configuration.getJarikoCallback().setLogInfo(message -> {
+        final Configuration configuration = new Configuration();
+        configuration.getJarikoCallback().setLogInfo((channel, message) -> {
+            System.out.println(channel);
             System.out.println(message);
             return Unit.INSTANCE;
         });

--- a/examples/src/main/java/com/jariko/samples/java/CallJarikoWithParams.java
+++ b/examples/src/main/java/com/jariko/samples/java/CallJarikoWithParams.java
@@ -8,8 +8,10 @@ import com.smeup.rpgparser.interpreter.DataStructValue;
 import com.smeup.rpgparser.interpreter.StringValue;
 import com.smeup.rpgparser.interpreter.Value;
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface;
+import com.smeup.rpgparser.logging.LoggingKt;
 import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder;
 import com.smeup.rpgparser.rpginterop.RpgProgramFinder;
+import kotlin.Unit;
 
 import java.io.File;
 import java.util.Arrays;
@@ -25,8 +27,15 @@ public class CallJarikoWithParams {
     public static CommandLineParms execPgm(String name, CommandLineParms inputParams) {
         File srcDir = new File(CallJarikoWithParams.class.getResource("/rpg").getPath());
         List<RpgProgramFinder> programFinders = Arrays.asList(new DirRpgProgramFinder(srcDir));
-        CommandLineProgram program = RunnerKt.getProgram(name, new JavaSystemInterface(), programFinders);
-        return program.singleCall(inputParams, new Configuration());
+        final JavaSystemInterface systemInterface = new JavaSystemInterface();
+        systemInterface.setLoggingConfiguration(LoggingKt.consoleLoggingConfiguration(LoggingKt.PERFORMANCE_LOGGER));
+        CommandLineProgram program = RunnerKt.getProgram(name, systemInterface, programFinders);
+        final Configuration configuration = new  Configuration();
+        configuration.getJarikoCallback().setLogInfo(message -> {
+            System.out.println(message);
+            return Unit.INSTANCE;
+        });
+        return program.singleCall(inputParams, configuration);
     }
 
     public static void execWithListOfString() {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -117,6 +117,7 @@ data class Options(
  * @param onEnterFunction It is invoked on function enter after symboltable initialization.
  * @param onExitFunction It is invoked on function exit, only if the function does not throw any error
  * @param onError It is invoked in case of errors. The default implementation writes error event in stderr
+ * @param logInfo If specified it is invoked to log information messages
  * */
 data class JarikoCallback(
     var getActivationGroup: (programName: String, associatedActivationGroup: ActivationGroup?) -> ActivationGroup? = { _: String, _: ActivationGroup? ->
@@ -145,7 +146,8 @@ data class JarikoCallback(
     var onExitFunction: (functionName: String, returnValue: Value) -> Unit = { _: String, _: Value -> },
     var onError: (errorEvent: ErrorEvent) -> Unit = { errorEvent ->
         System.err.println(errorEvent)
-    }
+    },
+    var logInfo: ((message: String) -> Unit)? = null
 )
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -118,6 +118,7 @@ data class Options(
  * @param onExitFunction It is invoked on function exit, only if the function does not throw any error
  * @param onError It is invoked in case of errors. The default implementation writes error event in stderr
  * @param logInfo If specified it is invoked to log information messages
+ * @param channelLoggingEnabled If specified it tests if the channel is enabled for logging
  * */
 data class JarikoCallback(
     var getActivationGroup: (programName: String, associatedActivationGroup: ActivationGroup?) -> ActivationGroup? = { _: String, _: ActivationGroup? ->
@@ -147,7 +148,8 @@ data class JarikoCallback(
     var onError: (errorEvent: ErrorEvent) -> Unit = { errorEvent ->
         System.err.println(errorEvent)
     },
-    var logInfo: ((message: String) -> Unit)? = null
+    var logInfo: ((channel: String, message: String) -> Unit)? = null,
+    var channelLoggingEnabled: ((channel: String) -> Boolean)? = null
 )
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -117,8 +117,10 @@ data class Options(
  * @param onEnterFunction It is invoked on function enter after symboltable initialization.
  * @param onExitFunction It is invoked on function exit, only if the function does not throw any error
  * @param onError It is invoked in case of errors. The default implementation writes error event in stderr
- * @param logInfo If specified it is invoked to log information messages
- * @param channelLoggingEnabled If specified it tests if the channel is enabled for logging
+ * @param logInfo If specified, it is invoked to log information messages, for all channel enabled
+ * @param channelLoggingEnabled If specified, it allows to enable programmatically the channel logging.
+ * For instance, you can enable all channels by using [consoleVerboseConfiguration] but you can decide, through
+ * the implementation of this callback, which channel you want to log.
  * */
 data class JarikoCallback(
     var getActivationGroup: (programName: String, associatedActivationGroup: ActivationGroup?) -> ActivationGroup? = { _: String, _: ActivationGroup? ->

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/logging/handlers_for_channels.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/logging/handlers_for_channels.kt
@@ -1,9 +1,11 @@
 package com.smeup.rpgparser.logging
 
+import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.parsing.ast.LogicalAndExpr
 import com.smeup.rpgparser.parsing.ast.LogicalOrExpr
 import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 
 class ExpressionLogHandler(level: LogLevel, sep: String) : LogHandler(level, sep), InterpreterLogHandler {
     val logger = LogManager.getLogger(EXPRESSION_LOGGER)
@@ -18,7 +20,7 @@ class ExpressionLogHandler(level: LogLevel, sep: String) : LogHandler(level, sep
                 is ExpressionEvaluationLogEntry -> {
                     // Avoid expression
                     if (logEntry.expression.parent !is LogicalAndExpr && logEntry.expression.parent !is LogicalOrExpr) {
-                        logger.info(render(logEntry))
+                        logger.fireLogInfo(render(logEntry))
                     }
                 }
             }
@@ -38,19 +40,19 @@ class PerformanceLogHandler(level: LogLevel, sep: String) : LogHandler(level, se
 
         if (logger.isInfoEnabled) {
             when (logEntry) {
-                is SubroutineExecutionLogEnd -> logger.info(render(logEntry))
-                is ForStatementExecutionLogEnd -> logger.info(render(logEntry))
-                is DoStatemenExecutionLogEnd -> logger.info(render(logEntry))
-                is DowStatemenExecutionLogEnd -> logger.info(render(logEntry))
-                is CallEndLogEntry -> logger.info(render(logEntry))
-                is ProgramInterpretationLogEnd -> logger.info(render(logEntry))
-                is SymbolTableIniLogEnd -> logger.info(render(logEntry))
-                is SymbolTableLoadLogEnd -> logger.info(render(logEntry))
-                is SymbolTableStoreLogEnd -> logger.info(render(logEntry))
-                is SetLogEnd -> logger.info(render(logEntry))
-                is ReadLogEnd -> logger.info(render(logEntry))
-                is ReadEqualLogEnd -> logger.info(render(logEntry))
-                is StoreLogEnd -> logger.info(render(logEntry))
+                is SubroutineExecutionLogEnd -> logger.fireLogInfo(render(logEntry))
+                is ForStatementExecutionLogEnd -> logger.fireLogInfo(render(logEntry))
+                is DoStatemenExecutionLogEnd -> logger.fireLogInfo(render(logEntry))
+                is DowStatemenExecutionLogEnd -> logger.fireLogInfo(render(logEntry))
+                is CallEndLogEntry -> logger.fireLogInfo(render(logEntry))
+                is ProgramInterpretationLogEnd -> logger.fireLogInfo(render(logEntry))
+                is SymbolTableIniLogEnd -> logger.fireLogInfo(render(logEntry))
+                is SymbolTableLoadLogEnd -> logger.fireLogInfo(render(logEntry))
+                is SymbolTableStoreLogEnd -> logger.fireLogInfo(render(logEntry))
+                is SetLogEnd -> logger.fireLogInfo(render(logEntry))
+                is ReadLogEnd -> logger.fireLogInfo(render(logEntry))
+                is ReadEqualLogEnd -> logger.fireLogInfo(render(logEntry))
+                is StoreLogEnd -> logger.fireLogInfo(render(logEntry))
             }
         }
     }
@@ -69,77 +71,77 @@ class StatementLogHandler(level: LogLevel, sep: String) : LogHandler(level, sep)
 
         if (logger.isInfoEnabled) {
             when (logEntry) {
-                is RpgLoadLogStart -> logger.info(render(logEntry))
-                is RpgLoadLogEnd -> logger.info(render(logEntry))
-                is PreprocessingLogStart -> logger.info(render(logEntry))
-                is PreprocessingLogEnd -> logger.info(render(logEntry))
-                is LexerLogStart -> logger.info(render(logEntry))
-                is LexerLogEnd -> logger.info(render(logEntry))
-                is ParserLogStart -> logger.info(render(logEntry))
-                is ParserLogEnd -> logger.info(render(logEntry))
-                is RContextLogStart -> logger.info(render(logEntry))
-                is RContextLogEnd -> logger.info(render(logEntry))
-                is CheckParseTreeLogStart -> logger.info(render(logEntry))
-                is CheckParseTreeLogEnd -> logger.info(render(logEntry))
-                is FindMutesLogStart -> logger.info(render(logEntry))
-                is FindMutesLogEnd -> logger.info(render(logEntry))
-                is AstLogStart -> logger.info(render(logEntry))
-                is AstLogEnd -> logger.info(render(logEntry))
-                is ParamListStatemenExecutionLog -> logger.info(render(logEntry))
-                is SelectCaseExecutionLogEntry -> logger.info(render(logEntry))
-                is SelectOtherExecutionLogEntry -> logger.info(render(logEntry))
-                is SubroutineExecutionLogStart -> logger.info(render(logEntry))
-                is SubroutineExecutionLogEnd -> logger.info(render(logEntry))
-                is ProgramInterpretationLogStart -> logger.info(render(logEntry))
-                is ProgramInterpretationLogEnd -> logger.info(render(logEntry))
-                is IfExecutionLogEntry -> logger.info(render(logEntry))
-                is ElseIfExecutionLogEntry -> logger.info(render(logEntry))
-                is ClearStatemenExecutionLog -> logger.info(render(logEntry))
-                is MoveStatemenExecutionLog -> logger.info(render(logEntry))
-                is LeaveStatemenExecutionLog -> logger.info(render(logEntry))
-                is IterStatemenExecutionLog -> logger.info(render(logEntry))
-                is ElseExecutionLogEntry -> logger.info(render(logEntry))
-                is CallExecutionLogEntry -> logger.info(render(logEntry))
-                is CallEndLogEntry -> logger.info(render(logEntry))
-                is EvaluationLogEntry -> logger.info(render(logEntry))
+                is RpgLoadLogStart -> logger.fireLogInfo(render(logEntry))
+                is RpgLoadLogEnd -> logger.fireLogInfo(render(logEntry))
+                is PreprocessingLogStart -> logger.fireLogInfo(render(logEntry))
+                is PreprocessingLogEnd -> logger.fireLogInfo(render(logEntry))
+                is LexerLogStart -> logger.fireLogInfo(render(logEntry))
+                is LexerLogEnd -> logger.fireLogInfo(render(logEntry))
+                is ParserLogStart -> logger.fireLogInfo(render(logEntry))
+                is ParserLogEnd -> logger.fireLogInfo(render(logEntry))
+                is RContextLogStart -> logger.fireLogInfo(render(logEntry))
+                is RContextLogEnd -> logger.fireLogInfo(render(logEntry))
+                is CheckParseTreeLogStart -> logger.fireLogInfo(render(logEntry))
+                is CheckParseTreeLogEnd -> logger.fireLogInfo(render(logEntry))
+                is FindMutesLogStart -> logger.fireLogInfo(render(logEntry))
+                is FindMutesLogEnd -> logger.fireLogInfo(render(logEntry))
+                is AstLogStart -> logger.fireLogInfo(render(logEntry))
+                is AstLogEnd -> logger.fireLogInfo(render(logEntry))
+                is ParamListStatemenExecutionLog -> logger.fireLogInfo(render(logEntry))
+                is SelectCaseExecutionLogEntry -> logger.fireLogInfo(render(logEntry))
+                is SelectOtherExecutionLogEntry -> logger.fireLogInfo(render(logEntry))
+                is SubroutineExecutionLogStart -> logger.fireLogInfo(render(logEntry))
+                is SubroutineExecutionLogEnd -> logger.fireLogInfo(render(logEntry))
+                is ProgramInterpretationLogStart -> logger.fireLogInfo(render(logEntry))
+                is ProgramInterpretationLogEnd -> logger.fireLogInfo(render(logEntry))
+                is IfExecutionLogEntry -> logger.fireLogInfo(render(logEntry))
+                is ElseIfExecutionLogEntry -> logger.fireLogInfo(render(logEntry))
+                is ClearStatemenExecutionLog -> logger.fireLogInfo(render(logEntry))
+                is MoveStatemenExecutionLog -> logger.fireLogInfo(render(logEntry))
+                is LeaveStatemenExecutionLog -> logger.fireLogInfo(render(logEntry))
+                is IterStatemenExecutionLog -> logger.fireLogInfo(render(logEntry))
+                is ElseExecutionLogEntry -> logger.fireLogInfo(render(logEntry))
+                is CallExecutionLogEntry -> logger.fireLogInfo(render(logEntry))
+                is CallEndLogEntry -> logger.fireLogInfo(render(logEntry))
+                is EvaluationLogEntry -> logger.fireLogInfo(render(logEntry))
                 is ForStatementExecutionLogStart -> {
-                    logger.info(render(logEntry))
+                    logger.fireLogInfo(render(logEntry))
                     this.inLoop++
                 }
                 is ForStatementExecutionLogEnd -> {
-                    logger.info(render(logEntry))
+                    logger.fireLogInfo(render(logEntry))
                     this.inLoop--
                 }
                 is DoStatemenExecutionLogStart -> {
-                    logger.info(render(logEntry))
+                    logger.fireLogInfo(render(logEntry))
                     this.inLoop++
                 }
                 is DoStatemenExecutionLogEnd -> {
-                    logger.info(render(logEntry))
+                    logger.fireLogInfo(render(logEntry))
                     this.inLoop--
                 }
                 is DowStatemenExecutionLogStart -> {
-                    logger.info(render(logEntry))
+                    logger.fireLogInfo(render(logEntry))
                     this.inLoop++
                 }
                 is DowStatemenExecutionLogEnd -> {
-                    logger.info(render(logEntry))
+                    logger.fireLogInfo(render(logEntry))
                     this.inLoop--
                 }
-                is SymbolTableIniLogStart -> logger.info(render(logEntry))
-                is SymbolTableIniLogEnd -> logger.info(render(logEntry))
-                is SymbolTableLoadLogStart -> logger.info(render(logEntry))
-                is SymbolTableLoadLogEnd -> logger.info(render(logEntry))
-                is SymbolTableStoreLogStart -> logger.info(render(logEntry))
-                is SymbolTableStoreLogEnd -> logger.info(render(logEntry))
-                is SetLogStart -> logger.info(render(logEntry))
-                is SetLogEnd -> logger.info(render(logEntry))
-                is ReadLogStart -> logger.info(render(logEntry))
-                is ReadLogEnd -> logger.info(render(logEntry))
-                is ReadEqualLogStart -> logger.info(render(logEntry))
-                is ReadEqualLogEnd -> logger.info(render(logEntry))
-                is StoreLogStart -> logger.info(render(logEntry))
-                is StoreLogEnd -> logger.info(render(logEntry))
+                is SymbolTableIniLogStart -> logger.fireLogInfo(render(logEntry))
+                is SymbolTableIniLogEnd -> logger.fireLogInfo(render(logEntry))
+                is SymbolTableLoadLogStart -> logger.fireLogInfo(render(logEntry))
+                is SymbolTableLoadLogEnd -> logger.fireLogInfo(render(logEntry))
+                is SymbolTableStoreLogStart -> logger.fireLogInfo(render(logEntry))
+                is SymbolTableStoreLogEnd -> logger.fireLogInfo(render(logEntry))
+                is SetLogStart -> logger.fireLogInfo(render(logEntry))
+                is SetLogEnd -> logger.fireLogInfo(render(logEntry))
+                is ReadLogStart -> logger.fireLogInfo(render(logEntry))
+                is ReadLogEnd -> logger.fireLogInfo(render(logEntry))
+                is ReadEqualLogStart -> logger.fireLogInfo(render(logEntry))
+                is ReadEqualLogEnd -> logger.fireLogInfo(render(logEntry))
+                is StoreLogStart -> logger.fireLogInfo(render(logEntry))
+                is StoreLogEnd -> logger.fireLogInfo(render(logEntry))
             }
         }
     }
@@ -156,7 +158,7 @@ class DataLogHandler(level: LogLevel, sep: String) : LogHandler(level, sep), Int
     override fun handle(logEntry: LogEntry) {
         if (logger.isInfoEnabled) {
             when (logEntry) {
-                is AssignmentLogEntry -> logger.info(render(logEntry))
+                is AssignmentLogEntry -> logger.fireLogInfo(render(logEntry))
             }
         }
     }
@@ -173,12 +175,12 @@ class LoopLogHandler(level: LogLevel, sep: String) : LogHandler(level, sep), Int
     override fun handle(logEntry: LogEntry) {
         if (logger.isInfoEnabled) {
             when (logEntry) {
-                is ForStatementExecutionLogStart -> logger.info(render(logEntry))
-                is ForStatementExecutionLogEnd -> logger.info(render(logEntry))
-                is DoStatemenExecutionLogStart -> logger.info(render(logEntry))
-                is DoStatemenExecutionLogEnd -> logger.info(render(logEntry))
-                is DowStatemenExecutionLogStart -> logger.info(render(logEntry))
-                is DowStatemenExecutionLogEnd -> logger.info(render(logEntry))
+                is ForStatementExecutionLogStart -> logger.fireLogInfo(render(logEntry))
+                is ForStatementExecutionLogEnd -> logger.fireLogInfo(render(logEntry))
+                is DoStatemenExecutionLogStart -> logger.fireLogInfo(render(logEntry))
+                is DoStatemenExecutionLogEnd -> logger.fireLogInfo(render(logEntry))
+                is DowStatemenExecutionLogStart -> logger.fireLogInfo(render(logEntry))
+                is DowStatemenExecutionLogEnd -> logger.fireLogInfo(render(logEntry))
             }
         }
     }
@@ -195,10 +197,10 @@ class ResolutionLogHandler(level: LogLevel, sep: String) : LogHandler(level, sep
     override fun handle(logEntry: LogEntry) {
         if (logger.isInfoEnabled) {
             when (logEntry) {
-                is SubroutineExecutionLogStart -> logger.info(render(logEntry))
-                is CallExecutionLogEntry -> logger.info(render(logEntry))
-                is FindProgramLogEntry -> logger.info(render(logEntry))
-                is RpgProgramFinderLogEntry -> logger.info(render(logEntry))
+                is SubroutineExecutionLogStart -> logger.fireLogInfo(render(logEntry))
+                is CallExecutionLogEntry -> logger.fireLogInfo(render(logEntry))
+                is FindProgramLogEntry -> logger.fireLogInfo(render(logEntry))
+                is RpgProgramFinderLogEntry -> logger.fireLogInfo(render(logEntry))
             }
         }
     }
@@ -216,15 +218,21 @@ class ParsingLogHandler(level: LogLevel, sep: String) : LogHandler(level, sep), 
 
         if (logger.isInfoEnabled) {
             when (logEntry) {
-                is RpgLoadLogEnd -> logger.info(render(logEntry))
-                is PreprocessingLogEnd -> logger.info(render(logEntry))
-                is LexerLogEnd -> logger.info(render(logEntry))
-                is ParserLogEnd -> logger.info(render(logEntry))
-                is RContextLogEnd -> logger.info(render(logEntry))
-                is CheckParseTreeLogEnd -> logger.info(render(logEntry))
-                is FindMutesLogEnd -> logger.info(render(logEntry))
-                is AstLogEnd -> logger.info(render(logEntry))
+                is RpgLoadLogEnd -> logger.fireLogInfo(render(logEntry))
+                is PreprocessingLogEnd -> logger.fireLogInfo(render(logEntry))
+                is LexerLogEnd -> logger.fireLogInfo(render(logEntry))
+                is ParserLogEnd -> logger.fireLogInfo(render(logEntry))
+                is RContextLogEnd -> logger.fireLogInfo(render(logEntry))
+                is CheckParseTreeLogEnd -> logger.fireLogInfo(render(logEntry))
+                is FindMutesLogEnd -> logger.fireLogInfo(render(logEntry))
+                is AstLogEnd -> logger.fireLogInfo(render(logEntry))
             }
         }
     }
+}
+
+fun Logger.fireLogInfo(message: String) {
+    MainExecutionContext.getConfiguration().jarikoCallback.logInfo?.apply {
+        this.invoke(message)
+    } ?: this.info(message)
 }


### PR DESCRIPTION
## Description

Added the two callbacks: `JarikoCallback.channelLoggingEnabled` and `JarikoCallback.logInfo` that allow to override the default jariko logging, [see example](https://github.com/smeup/jariko/blob/772ff9ba4f6d7884efc7c46e1ab1a664b83c7b0c/examples/src/main/java/com/jariko/samples/java/CallJarikoWithParams.java#L50C8-L50C8).

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
