### PR TITLE
fix: ignore continuation line token in D spec comment

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgLexer.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgLexer.g4
@@ -822,7 +822,7 @@ mode FIXED_DefSpec;
 BLANK_SPEC :  
 	'                                                                           ' 
 	{getCharPositionInLine()==81}?;
-CONTINUATION_NAME : {getCharPositionInLine()<21}? [ ]* NAMECHAR+ CONTINUATION {setText(getText().substring(0,getText().length()-3).trim());} -> pushMode(CONTINUATION_ELIPSIS) ;
+CONTINUATION_NAME : {getCharPositionInLine()<21 && getCharPositionInLine()>=81}? [ ]* NAMECHAR+ CONTINUATION {setText(getText().substring(0,getText().length()-3).trim());} -> pushMode(CONTINUATION_ELIPSIS) ;
 CONTINUATION : '...' ;
 NAME : NAME5 NAME5 NAME5 {getCharPositionInLine()==21}? {setText(getText().trim());};
 EXTERNAL_DESCRIPTION: [eE ] {getCharPositionInLine()==22}? ;

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/DataDefinitionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/DataDefinitionTest.kt
@@ -76,6 +76,11 @@ open class DataDefinitionTest : AbstractTest() {
         cu.assertDataDefinitionIsPresent("U\$FUNZ", ArrayType(StringType(10), 200))
     }
 
+    @test fun variableWithContinuationLineTokenInComment() {
+        val cu = parseFragmentToCompilationUnit("DVAR              S             10                                         ...")
+        cu.assertDataDefinitionIsPresent("VAR", StringType(length = 10))
+    }
+
     @test fun singleDSParsing() {
         val cu = parseFragmentToCompilationUnit("D £G49SI          DS          1024")
         val dataDefinition = cu.getDataDefinition("£G49SI")


### PR DESCRIPTION
## Description

Ignore continuation line token in D spec comment

Related to # (issue)

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
