### PR TITLE
Feature/nw23001440/move statement string to integer

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -26,13 +26,11 @@ private fun coerceBlanks(type: Type): Value {
         is StringType -> {
             blankString(type.length)
         }
-
         is ArrayType -> {
             createArrayValue(type.element, type.nElements) {
                 type.element.blank()
             }
         }
-
         is NumberType -> {
             if (type.integer) {
                 IntValue.ZERO
@@ -40,28 +38,22 @@ private fun coerceBlanks(type: Type): Value {
                 DecimalValue.ZERO
             }
         }
-
         is DataStructureType -> {
             type.blank()
         }
-
         is OccurableDataStructureType -> {
             type.blank()
         }
-
         is BooleanType -> {
             BooleanValue.FALSE
         }
-
         is CharacterType -> {
             blankString(type.nChars)
             // TODO Use CharacterValue(Array(this.nChars) { ' ' })
         }
-
         is UnlimitedStringType -> {
             UnlimitedStringValue("")
         }
-
         else -> TODO("Converting BlanksValue to $type")
     }
 }
@@ -94,7 +86,6 @@ private fun coerceString(value: StringValue, type: Type): Value {
 
             // return StringValue(value.value, type.varying)
         }
-
         is ArrayType -> {
             if (type.element is StringType) {
                 // We are coercing a String into an array of Strings
@@ -113,7 +104,6 @@ private fun coerceString(value: StringValue, type: Type): Value {
                 }
             }
         }
-
         is NumberType -> {
             if (type.integer) {
                 when {
@@ -166,7 +156,6 @@ private fun coerceString(value: StringValue, type: Type): Value {
                 }
             }
         }
-
         is BooleanType -> {
             if ("1" == value.value.trim()) {
                 BooleanValue.TRUE
@@ -174,7 +163,6 @@ private fun coerceString(value: StringValue, type: Type): Value {
                 BooleanValue.FALSE
             }
         }
-
         is DataStructureType -> {
             if (value.isBlank()) {
                 type.blank()
@@ -182,15 +170,12 @@ private fun coerceString(value: StringValue, type: Type): Value {
                 DataStructValue(value.value)
             }
         }
-
         is CharacterType -> {
             return StringValue(value.value)
         }
-
         is UnlimitedStringType -> {
             return UnlimitedStringValue(value.value)
         }
-
         else -> TODO("Converting String to $type")
     }
 }
@@ -201,11 +186,9 @@ fun coerce(value: Value, type: Type): Value {
         is BlanksValue -> {
             coerceBlanks(type)
         }
-
         is StringValue -> {
             coerceString(value, type)
         }
-
         is ArrayValue -> {
             return when (type) {
                 is StringType -> {
@@ -219,7 +202,6 @@ fun coerce(value: Value, type: Type): Value {
                 else -> TODO("Converting ArrayValue to $type")
             }
         }
-
         is DecimalValue -> {
             when (type) {
                 is NumberType -> {
@@ -234,37 +216,29 @@ fun coerce(value: Value, type: Type): Value {
                 else -> TODO("Converting DecimalValue to $type")
             }
         }
-
         is HiValValue -> {
             return type.hiValue()
         }
-
         is LowValValue -> {
             return type.lowValue()
         }
-
         is AllValue -> {
             when (type) {
                 is NumberType -> {
                     return coerce(StringValue(value.charsToRepeat.repeatWithMaxSize(type.size)), type)
                 }
-
                 is StringType -> {
                     return StringValue(value.charsToRepeat.repeatWithMaxSize(type.length))
                 }
-
                 is ArrayType -> {
                     return StringValue(value.charsToRepeat.repeatWithMaxSize(type.size))
                 }
-
                 is BooleanType -> {
                     if (value.charsToRepeat == "1") BooleanValue.TRUE else BooleanValue.FALSE
                 }
-
                 else -> TODO("Converting $value to $type")
             }
         }
-
         is IntValue -> {
             when (type) {
                 // Add missing blank spaces
@@ -275,11 +249,9 @@ fun coerce(value: Value, type: Type): Value {
                         varying = type.varying
                     )
                 }
-
                 else -> value
             }
         }
-
         else -> value
     }
 }
@@ -289,15 +261,12 @@ fun Type.lowValue(): Value {
         is NumberType -> {
             return computeLowValue(this)
         }
-
         is StringType -> {
             return computeLowValue(this)
         }
-
         is ArrayType -> {
             return createArrayValue(this.element, this.nElements) { coerce(LowValValue, this.element) }
         }
-
         else -> TODO("Converting LowValValue to $this")
     }
 }
@@ -307,15 +276,12 @@ fun Type.hiValue(): Value {
         is NumberType -> {
             return computeHiValue(this)
         }
-
         is StringType -> {
             return computeHiValue(this)
         }
-
         is ArrayType -> {
             return createArrayValue(this.element, this.nElements) { coerce(HiValValue, this.element) }
         }
-
         else -> TODO("Converting HiValValue to $this")
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -113,17 +113,14 @@ private fun coerceString(value: StringValue, type: Type): Value {
                         val intValue = decodeBinary(value.value.toNumberSize(type.size), type.size)
                         IntValue(intValue.longValueExact())
                     }
-
                     type.rpgType == RpgType.INTEGER.rpgType -> {
                         val intValue = decodeInteger(value.value.toNumberSize(type.size), type.size)
                         IntValue(intValue.longValueExact())
                     }
-
                     type.rpgType == RpgType.UNSIGNED.rpgType -> {
                         val intValue = decodeUnsigned(value.value.toNumberSize(type.size), type.size)
                         IntValue(intValue.longValueExact())
                     }
-
                     type.rpgType == RpgType.ZONED.rpgType -> {
                         if (!value.isBlank()) {
                             val intValue = decodeFromZoned(value.value.trim(), type.entireDigits, type.decimalDigits)
@@ -132,7 +129,6 @@ private fun coerceString(value: StringValue, type: Type): Value {
                             DecimalValue(BigDecimal.ZERO)
                         }
                     }
-
                     else -> {
                         if (!value.isBlank()) {
                             val intValue = decodeFromDS(value.value.trim(), type.entireDigits, type.decimalDigits)
@@ -194,11 +190,9 @@ fun coerce(value: Value, type: Type): Value {
                 is StringType -> {
                     value.asString()
                 }
-
                 is ArrayType -> {
                     value
                 }
-
                 else -> TODO("Converting ArrayValue to $type")
             }
         }
@@ -212,7 +206,6 @@ fun coerce(value: Value, type: Type): Value {
                     }
                     return value
                 }
-
                 else -> TODO("Converting DecimalValue to $type")
             }
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -269,9 +269,9 @@ fun coerce(value: Value, type: Type): Value {
             when (type) {
                 // Add missing blank spaces
                 is StringType -> {
-                    val blank = " ".repeat(type.size - value.asString().value.length)
+                    val zeros = "0".repeat(type.size - value.asString().value.length)
                     return StringValue(
-                        "$blank${value.asString().value}",
+                        "$zeros${value.asString().value}",
                         varying = type.varying
                     )
                 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -162,25 +162,21 @@ open class InterpreterTest : AbstractTest() {
         cu.resolveAndValidate()
         val si = CollectorSystemInterface()
         val logHandler = ListLogHandler()
-        si.programs["CALCFIB"] =
-            object : JvmProgramRaw("CALCFIB", listOf(ProgramParam("ppdat", StringType(8, false)))) {
-                override fun execute(
-                    systemInterface: SystemInterface,
-                    params: LinkedHashMap<String, Value>
-                ): List<Value> {
-                    val n = params["ppdat"]!!.asString().value.asInt()
-                    var t1 = 0
-                    var t2 = 1
+        si.programs["CALCFIB"] = object : JvmProgramRaw("CALCFIB", listOf(ProgramParam("ppdat", StringType(8, false)))) {
+            override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
+                val n = params["ppdat"]!!.asString().value.asInt()
+                var t1 = 0
+                var t2 = 1
 
-                    for (i in 1..n) {
-                        val sum = t1 + t2
-                        t1 = t2
-                        t2 = sum
-                    }
-                    systemInterface.display("FIBONACCI OF: $n IS: $t1")
-                    return listOf(params["ppdat"]!!)
+                for (i in 1..n) {
+                    val sum = t1 + t2
+                    t1 = t2
+                    t2 = sum
                 }
+                systemInterface.display("FIBONACCI OF: $n IS: $t1")
+                return listOf(params["ppdat"]!!)
             }
+        }
         execute(cu, mapOf("ppdat" to StringValue("10")), si, listOf(logHandler))
         assertEquals(listOf("FIBONACCI OF: 10 IS: 55"), si.displayed)
         assertEquals(logHandler.getExecutedSubroutines().size, 0)
@@ -237,17 +233,15 @@ open class InterpreterTest : AbstractTest() {
 
     @Test
     fun executeLEN() {
-        assertEquals(
-            listOf(
-                "Hello World! 23",
-                "%LEN(B_01) is 1",
-                "%LEN(B_02) is 20",
-                "%LEN(B_03) is 0",
-                "%LEN(B_03) is 1",
-                "%LEN(B_03) is 5",
-                "%LEN(B_04) is 0"
-            ), outputOf("LEN")
-        )
+        assertEquals(listOf(
+            "Hello World! 23",
+            "%LEN(B_01) is 1",
+            "%LEN(B_02) is 20",
+            "%LEN(B_03) is 0",
+            "%LEN(B_03) is 1",
+            "%LEN(B_03) is 5",
+            "%LEN(B_04) is 0"
+        ), outputOf("LEN"))
     }
 
     @Test
@@ -262,29 +256,20 @@ open class InterpreterTest : AbstractTest() {
 
     @Test
     fun executeSETONSETOF() {
-        assertEquals(
-            listOf(
-                "Before",
-                "56=off57=off",
-                "After set",
-                "56=on",
-                "After off",
-                "56=off57=off"
-            ), outputOf("SETONOF01")
-        )
+        assertEquals(listOf("Before",
+            "56=off57=off",
+            "After set",
+            "56=on",
+            "After off",
+            "56=off57=off"), outputOf("SETONOF01"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeSETOFLF() {
-        assertEquals(
-            listOf(
-                "Before",
-                "LR Of",
-                "After set",
-                "LR Off"
-            ), outputOf("SETOFLR")
-        )
+        assertEquals(listOf("Before",
+            "LR Of",
+            "After set",
+            "LR Off"), outputOf("SETOFLR"))
     }
 
     @Test
@@ -373,8 +358,7 @@ open class InterpreterTest : AbstractTest() {
         assertEquals(listOf("40208"), outputOf("DIFFTEST2"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeDAYOFWEEK() {
         val currentDayOfWeek = SimpleDateFormat("u").format(Date())
         assertEquals(listOf(currentDayOfWeek), outputOf("DAYOFWEEK"))
@@ -443,40 +427,32 @@ open class InterpreterTest : AbstractTest() {
 
     @Test
     fun executeMOVEAMUT13() {
-        assertEquals(
-            listOf(
-                "ABCDEFGHIL         1",
-                "BBBBBBBBBBBBBBBBBBBB",
-                "AAAAAAAAAAAAAAAAAAAA",
-                "  ABCDEFGHILMNOPQRST",
-                "  ABCDEFGHILMNOPQRST",
-                "XXXXXXXXXXXXXXXXXXXX",
-                "XXXXXXXXXXXXXXXXXXXX",
-                "XXXXXXXXXXXXXXXXXXXX",
-                "XXXXXXXXXXXXXXXXXXXX",
-                "XXXXXXXXXXXXXXXXXXXX"
-            ),
-            outputOf("MOVEAMUT13")
-        )
+        assertEquals(listOf("ABCDEFGHIL         1",
+            "BBBBBBBBBBBBBBBBBBBB",
+            "AAAAAAAAAAAAAAAAAAAA",
+            "  ABCDEFGHILMNOPQRST",
+            "  ABCDEFGHILMNOPQRST",
+            "XXXXXXXXXXXXXXXXXXXX",
+            "XXXXXXXXXXXXXXXXXXXX",
+            "XXXXXXXXXXXXXXXXXXXX",
+            "XXXXXXXXXXXXXXXXXXXX",
+            "XXXXXXXXXXXXXXXXXXXX"),
+            outputOf("MOVEAMUT13"))
     }
 
     @Test
     fun executeMOVEAP0904_p_with_chars() {
-        assertEquals(
-            listOf(
-                "ABCDEFGHIL",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ),
-            outputOf("MOVEAP0904")
-        )
+        assertEquals(listOf("ABCDEFGHIL",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            ""),
+            outputOf("MOVEAP0904"))
     }
 
     @Test
@@ -549,8 +525,7 @@ open class InterpreterTest : AbstractTest() {
         assertEquals(listOf("XXXXX", "YYYYY"), outputOf("MOVELDECLA"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeRESULTTARG_resultAsExpressionRefenecingArray() {
         assertEquals(listOf("15.3"), outputOf("RESULTTARG"))
     }
@@ -611,11 +586,9 @@ open class InterpreterTest : AbstractTest() {
         assertEquals(listOf("0", "1", "4", "5", "6", "8", "9"), outputOf("SORTANUM"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeLOOKUP_OPCODE() {
-        assertEquals(
-            """
+        assertEquals("""
 Test 1
 68 OFF
 69 ON-
@@ -641,8 +614,7 @@ Test 6
 69 ON- 
  7               
         """.trimIndent().lines().map(String::trim),
-            outputOf("LOOKUP_OP1")
-        )
+            outputOf("LOOKUP_OP1"))
     }
 
     @Test
@@ -655,11 +627,9 @@ Test 6
         assertEquals(listOf("68 ON-", "69 OFF"), outputOf("LOOKUP_OP3"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeLOOKUP_OPCODE_GoodArray() {
-        assertEquals(
-            """
+        assertEquals("""
 Test 1
 68 ON-
 69 OFF
@@ -685,12 +655,10 @@ Test 6
 69 OFF
  1    
         """.trimIndent().lines().map(String::trim),
-            outputOf("LOOKUP_OP9")
-        )
+            outputOf("LOOKUP_OP9"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeSCANARRAY() {
         assertEquals(listOf("4"), outputOf("SCANARRAY"))
     }
@@ -736,33 +704,28 @@ Test 6
 
     @Test
     fun executeCALLER_CALLED_pgm_with_RT() {
-        assertEquals(
-            listOf(
-                "Executing CALLER",
-                "x initialized at: 18",
-                "x is now: 6",
-                "Calling CALLED",
-                "Executing CALLED",
-                "x initialized at: 9",
-                "x is now: 3",
-                "Calling CALLED",
-                "Executing CALLED",
-                "x initialized at: 3",
-                "x is now: 1"
-            ),
-            outputOf("CALLER")
-        )
+        assertEquals(listOf(
+            "Executing CALLER",
+            "x initialized at: 18",
+            "x is now: 6",
+            "Calling CALLED",
+            "Executing CALLED",
+            "x initialized at: 9",
+            "x is now: 3",
+            "Calling CALLED",
+            "Executing CALLED",
+            "x initialized at: 3",
+            "x is now: 1"
+        ),
+            outputOf("CALLER"))
     }
 
     @Test
     fun executeCAL01_callingJavaPgm() {
         val si = CollectorSystemInterface()
         var javaPgmCalled = false
-        si.programs["CAL02"] = object : JvmProgramRaw(
-            "CAL02", listOf(
-                ProgramParam("NBR", NumberType(8, 0))
-            )
-        ) {
+        si.programs["CAL02"] = object : JvmProgramRaw("CAL02", listOf(
+            ProgramParam("NBR", NumberType(8, 0)))) {
             override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
                 javaPgmCalled = true
                 val nbr = params["NBR"]
@@ -827,14 +790,12 @@ Test 6
         assertEquals(listOf("Body"), outputOf("DO_TST02"))
     }
 
-    @Test
-    @Category(PerformanceTest::class)
+    @Test @Category(PerformanceTest::class)
     fun executeDOW_PERF() {
         assertEquals(outputOf("DOW_PERF"), listOf("COUNTER IS NOW 100000001"))
     }
 
-    @Test
-    @Category(PerformanceTest::class)
+    @Test @Category(PerformanceTest::class)
     fun executeDOW_LEAVE_PERF() {
         assertEquals(outputOf("DOW_LEAVE_PERF"), listOf("COUNTER IS NOW 100000001"))
     }
@@ -923,18 +884,8 @@ Test 6
 
     @Test
     fun executeREPLACEBIF() {
-        assertEquals(
-            listOf(
-                "Pippo world!",
-                "Hello Pippo!",
-                "Hello Pippoorld!",
-                "Hello Pippold!",
-                "Hello Pippoworld!",
-                "%20 ef",
-                "abc%20ef"
-            ),
-            outputOf("REPLACEBIF")
-        )
+        assertEquals(listOf("Pippo world!", "Hello Pippo!", "Hello Pippoorld!", "Hello Pippold!", "Hello Pippoworld!", "%20 ef", "abc%20ef"),
+            outputOf("REPLACEBIF"))
     }
 
     @Test
@@ -949,64 +900,43 @@ Test 6
 
     @Test
     fun executeBIFEDITC_2() {
-        assertEquals(
-            listOf(
-                "x   123,456   123,456  1,234.56X",
-                "x  1,234.56          X",
-                "x  1,234.50X"
-            ),
-            outputOf("BIFEDITC_2")
-        )
+        assertEquals(listOf("x   123,456   123,456  1,234.56X",
+            "x  1,234.56          X",
+            "x  1,234.50X"),
+            outputOf("BIFEDITC_2"))
     }
 
     @Test
     fun executeBIFEDITC_3() {
-        assertEquals(
-            listOf(
-                "x  123456  123456  1234.56X",
-                "x  1234.56      .00X",
-                "x  1234.50X"
-            ),
-            outputOf("BIFEDITC_3")
-        )
+        assertEquals(listOf("x  123456  123456  1234.56X",
+            "x  1234.56      .00X",
+            "x  1234.50X"),
+            outputOf("BIFEDITC_3"))
     }
-
     @Test
     fun executeBIFEDITC_4() {
-        assertEquals(
-            listOf(
-                "x  123456  123456  1234.56X",
-                "x  1234.56         X",
-                "x  1234.50X"
-            ),
-            outputOf("BIFEDITC_4")
-        )
+        assertEquals(listOf("x  123456  123456  1234.56X",
+            "x  1234.56         X",
+            "x  1234.50X"),
+            outputOf("BIFEDITC_4"))
     }
 
     @Test
     fun executeBIFEDITC_J() {
-        assertEquals(
-            listOf(
-                "x   123,456   123,456-  1,234.56X",
-                "x  1,234.56-       .00X",
-                "x  1,234.50X"
-            ),
-            outputOf("BIFEDITC_J")
-        )
+        assertEquals(listOf("x   123,456   123,456-  1,234.56X",
+            "x  1,234.56-       .00X",
+            "x  1,234.50X"),
+            outputOf("BIFEDITC_J"))
     }
 
     @Test
     @Ignore // we are working on DECEDIT
     fun executeBIFEDITC_Y() {
-        assertEquals(
-            listOf(
-                "x  12/34/56  12/34/56  12/34/56X",
-                "x  12/34/56   0/00/00X",
-                "x  12/34/50 12/34/5678  0/00/12X",
-                "x   1/23/45X"
-            ),
-            outputOf("BIFEDITC_Y")
-        )
+        assertEquals(listOf("x  12/34/56  12/34/56  12/34/56X",
+            "x  12/34/56   0/00/00X",
+            "x  12/34/50 12/34/5678  0/00/12X",
+            "x   1/23/45X"),
+            outputOf("BIFEDITC_Y"))
     }
 
     @Test
@@ -1031,100 +961,90 @@ Test 6
 
     @Test
     fun executeCTDATA() {
-        assertEquals(
-            expected =
-            ("001\n" +
-                    "d01\n" +
-                    "A01\n" +
-                    "c01\n" +
-                    "B01\n" +
-                    "b01\n" +
-                    "C01\n" +
-                    "901\n" +
-                    "101\n" +
-                    "D01\n" +
-                    "H01\n" +
-                    "E01\n" +
-                    "201\n" +
-                    "e01\n" +
-                    "a01\n" +
-                    "x01\n" +
-                    "X01").lines(),
-            actual = outputOf("CTDATA").map(String::trim)
-        )
+        assertEquals(expected =
+        ("001\n" +
+                "d01\n" +
+                "A01\n" +
+                "c01\n" +
+                "B01\n" +
+                "b01\n" +
+                "C01\n" +
+                "901\n" +
+                "101\n" +
+                "D01\n" +
+                "H01\n" +
+                "E01\n" +
+                "201\n" +
+                "e01\n" +
+                "a01\n" +
+                "x01\n" +
+                "X01").lines(),
+            actual = outputOf("CTDATA").map(String::trim))
     }
 
     @Test
     fun executeARRAY02_arrayWithComments() {
-        assertEquals(
-            expected =
-            ("abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "xxx").lines(),
-            actual = outputOf("ARRAY02").map(String::trim)
-        )
+        assertEquals(expected =
+        ("abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "xxx").lines(),
+            actual = outputOf("ARRAY02").map(String::trim))
     }
 
     @Test
     fun executeARRAY03_arrayWithCommentsPERRCD_1() {
-        assertEquals(
-            expected =
-            ("abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "xxx").lines(),
-            actual = outputOf("ARRAY02").map(String::trim)
-        )
+        assertEquals(expected =
+        ("abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "xxx").lines(),
+            actual = outputOf("ARRAY02").map(String::trim))
     }
 
     @Test
     fun executeARRAY04_arrayWithCommentsAndDataReference() {
-        assertEquals(
-            expected =
-            ("abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "123\n" +
-                    "abc\n" +
-                    "xxx").lines(),
-            actual = outputOf("ARRAY04").map(String::trim)
-        )
+        assertEquals(expected =
+        ("abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "123\n" +
+                "abc\n" +
+                "xxx").lines(),
+            actual = outputOf("ARRAY04").map(String::trim))
     }
 
     @Test
     fun executeARRAY05NAM_namedCompileTimeArrays() {
-        assertEquals(
-            expected =
-            ("100\n" +
-                    "100\n" +
-                    "100\n" +
-                    "100\n" +
-                    "100").lines(),
-            actual = outputOf("ARRAY05NAM").map(String::trim)
-        )
+        assertEquals(expected =
+        ("100\n" +
+                "100\n" +
+                "100\n" +
+                "100\n" +
+                "100").lines(),
+            actual = outputOf("ARRAY05NAM").map(String::trim))
     }
 
     @Test
@@ -1204,8 +1124,7 @@ Test 6
     }
 
     // TODO implement DataStructureType coercion
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeDSCHARS() {
         assertEquals(listOf("Result is: X 1Y 2"), outputOf("DSCHARS"))
     }
@@ -1237,18 +1156,14 @@ Test 6
 
     @Test
     fun executeDS_CALLED_with_String_parameter() {
-        assertEquals(
-            listOf("James", "Bond", "007"),
-            outputOf("DS_CALLED", initialValues = mapOf("P1" to StringValue("JamesBond   7")))
-        )
+        assertEquals(listOf("James", "Bond", "007"),
+            outputOf("DS_CALLED", initialValues = mapOf("P1" to StringValue("JamesBond   7"))))
     }
 
     @Test
     fun executeDS_CALLED_with_DS_parameter() {
-        assertEquals(
-            listOf("James", "Bond", "007"),
-            outputOf("DS_CALLED", initialValues = mapOf("P1" to DataStructValue("JamesBond   7")))
-        )
+        assertEquals(listOf("James", "Bond", "007"),
+            outputOf("DS_CALLED", initialValues = mapOf("P1" to DataStructValue("JamesBond   7"))))
     }
 
     @Test
@@ -1280,11 +1195,7 @@ Test 6
 
     @Test
     fun executeASSIGNSUBS() {
-        assertEquals(
-            listOf("-xyz--", "-xyz", "-xyz -"),
-            outputOf("ASSIGNSUBS"),
-            message = "We can't handle %SUBST(X)=Y"
-        )
+        assertEquals(listOf("-xyz--", "-xyz", "-xyz -"), outputOf("ASSIGNSUBS"), message = "We can't handle %SUBST(X)=Y")
     }
 
     @Test
@@ -1293,11 +1204,9 @@ Test 6
     }
 
     // TODO understand why this test does not pass
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeJCODFISD() {
-        val parms = mapOf(
-            "CFDS" to StringValue("LNZNLN09B63H501J"),
+        val parms = mapOf("CFDS" to StringValue("LNZNLN09B63H501J"),
             "FISICA" to BooleanValue(false),
             "OMONIM" to BooleanValue(false),
             "SINTAX" to BooleanValue(false),
@@ -1378,10 +1287,7 @@ Test 6
 
     @Test
     fun executeFCONSTRES() {
-        assertEquals(
-            listOf("FLAG=ON", "FLAG=OFF", "IN34=OFF", "IN34=ON", "STR=BLANK", "STR=NOBLANK", "IN35=OFF"),
-            outputOf(programName = "FCONSTRES")
-        )
+        assertEquals(listOf("FLAG=ON", "FLAG=OFF", "IN34=OFF", "IN34=ON", "STR=BLANK", "STR=NOBLANK", "IN35=OFF"), outputOf(programName = "FCONSTRES"))
     }
 
     @Test
@@ -1409,8 +1315,7 @@ Test 6
         assertEquals(listOf("10", "No Error", "Got Error"), outputOf("ERRCALLER"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeRTCALLER_lrIndicatorOnCall() {
         assertEquals(listOf("End LR", "End RT"), outputOf("RTCALLER"))
     }
@@ -1427,25 +1332,17 @@ Test 6
 
     @Test
     fun executeFIZZBUZZ() {
-        assertEquals(
-            listOf("7"),
-            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("7"), "RESULT" to StringValue("")))
-        )
+        assertEquals(listOf("7"),
+            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("7"), "RESULT" to StringValue(""))))
 
-        assertEquals(
-            listOf("FIZZ"),
-            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("3"), "RESULT" to StringValue("")))
-        )
+        assertEquals(listOf("FIZZ"),
+            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("3"), "RESULT" to StringValue(""))))
 
-        assertEquals(
-            listOf("BUZZ"),
-            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("5"), "RESULT" to StringValue("")))
-        )
+        assertEquals(listOf("BUZZ"),
+            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("5"), "RESULT" to StringValue(""))))
 
-        assertEquals(
-            listOf("FIZZBUZZ"),
-            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("30"), "RESULT" to StringValue("")))
-        )
+        assertEquals(listOf("FIZZBUZZ"),
+            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("30"), "RESULT" to StringValue(""))))
     }
 
     @Test
@@ -1522,8 +1419,7 @@ Test 6
         assertEquals(listOf("Hello world!", "Hello worl", "Hello world"), outputOf("TRIMR"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeELEM() {
         assertEquals(listOf("10", "20", "30"), outputOf("ELEM"))
     }
@@ -1533,14 +1429,12 @@ Test 6
         assertEquals(listOf("20.1", "19.9", "2.0", "200.0"), outputOf("SUMDIVMULT"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeACTGRP_CAL() {
         assertEquals(listOf("1", "2", "3", "1", "1", "1"), outputOf("ACTGRP_CAL"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeCLEARDS() {
         assertEquals(listOf("0000"), outputOf("CLEARDS"))
     }
@@ -1575,8 +1469,7 @@ Test 6
                 "                      ",
                 "                      "
             ),
-            outputOf("CLEARARRAY")
-        )
+            outputOf("CLEARARRAY"))
     }
 
     @Test
@@ -1600,8 +1493,7 @@ Test 6
                 " ",
                 " "
             ),
-            outputOf("CLEARARRAY1")
-        )
+            outputOf("CLEARARRAY1"))
     }
 
     @Test
@@ -1666,26 +1558,15 @@ Test 6
                                 dsDataDefinition = dataDefinition
                                 dataDefinition.fields.forEach {
                                     when (it.name) {
-                                        "\$UIBPG" -> {
-                                            dsValue.set(it, StringValue("EXP", false))
-                                        }
-
-                                        "\$UIBFU" -> {
-                                            dsValue.set(it, StringValue("X1X2110", false))
-                                        }
-
-                                        "\$UIBME" -> {
-                                            dsValue.set(it, StringValue("FIB", false))
-                                        }
-
-                                        "\$UIBD1" -> {
-                                            dsValue.set(it, StringValue("NUM(10)", false))
-                                        }
+                                        "\$UIBPG" -> { dsValue.set(it, StringValue("EXP", false)) }
+                                        "\$UIBFU" -> { dsValue.set(it, StringValue("X1X2110", false)) }
+                                        "\$UIBME" -> { dsValue.set(it, StringValue("FIB", false)) }
+                                        "\$UIBD1" -> { dsValue.set(it, StringValue("NUM(10)", false)) }
                                     }
                                 }
                             }
                             /* no-op */
-                            else -> {}
+                            else -> { }
                         }
                     }
                 },
@@ -1705,12 +1586,10 @@ Test 6
     fun executeFREE_HELLO() {
         assertEquals(
             expected = "Hello world, Hello world in Chinese: 你好世界, number1 * number2 = 15".split(Regex(", ")),
-            actual = outputOf("FREE_HELLO")
-        )
+            actual = outputOf("FREE_HELLO"))
     }
 
-    @Test
-    @Ignore
+    @Test @Ignore
     fun executeLOSER_PR() {
         executePgm("LOSER_PR")
     }
@@ -1736,8 +1615,7 @@ Test 6
     @Test
     fun executePROCEDURE_C() {
         assertEquals(
-            expected = listOf(
-                "p received must be 11, is:11",
+            expected = listOf("p received must be 11, is:11",
                 "q received must be 22, is:22",
                 "r received must be 0, is:0",
                 "r=p+q must be 33, is:33",
@@ -1776,15 +1654,13 @@ Test 6
     @Test
     fun executePROCEDURE_H() {
         assertEquals(
-            expected = listOf(
-                "11",
+            expected = listOf("11",
                 "22",
                 "33",
                 "0",
                 "33",
                 "22",
-                "121"
-            ),
+                "121"),
             actual = outputOf("PROCEDURE_H")
         )
     }
@@ -1792,8 +1668,7 @@ Test 6
     @Test
     fun executePROCEDURE_I() {
         assertEquals(
-            expected = listOf(
-                "1",
+            expected = listOf("1",
                 "4"
             ),
             actual = outputOf("PROCEDURE_I")
@@ -1803,8 +1678,7 @@ Test 6
     @Test
     fun executePROCEDURE_J() {
         assertEquals(
-            expected = listOf(
-                "1",
+            expected = listOf("1",
                 "4",
                 "8",
                 "9",
@@ -1820,8 +1694,7 @@ Test 6
     @Test
     fun executePROCEDURE_K() {
         assertEquals(
-            expected = listOf(
-                "69.12",
+            expected = listOf("69.12",
                 ".59",
                 "12345          54321",
                 "73.00",
@@ -1839,8 +1712,7 @@ Test 6
     @Test
     fun executePROCEDURE_L() {
         assertEquals(
-            expected = listOf(
-                ".99",
+            expected = listOf(".99",
                 "1.11",
                 "9.99"
             ),
@@ -1851,8 +1723,7 @@ Test 6
     @Test
     fun executePROCEDURE_M() {
         assertEquals(
-            expected = listOf(
-                "2.24",
+            expected = listOf("2.24",
                 "3.36"
             ),
             actual = outputOf("PROCEDURE_M")
@@ -1864,8 +1735,7 @@ Test 6
     // TODO ignored until 'DS as parameter' will be supported (maybe never?)
     fun executePROCEDURE_N() {
         assertEquals(
-            expected = listOf(
-                "10.2",
+            expected = listOf("10.2",
                 "ABCDE"
             ),
             actual = outputOf("PROCEDURE_N")
@@ -1906,8 +1776,7 @@ Test 6
     @Test
     fun executePROCEDURE_P() {
         assertEquals(
-            expected = listOf(
-                "2.04",
+            expected = listOf("2.04",
                 "1.02",
                 "1.03"
             ),
@@ -1932,39 +1801,30 @@ Test 6
         // PASS NO PARAMETERS
         var si = CollectorSystemInterface()
         si.programs[rpgProgramName] = rpgProgram(rpgProgramName)
-        execute(
-            cu, emptyMap(),
-            si, listOf(logHandler)
-        )
+        execute(cu, emptyMap(),
+            si, listOf(logHandler))
         assertEquals(listOf("0"), si.displayed)
 
         // PASS ONE PARAMETER
         si = CollectorSystemInterface()
         si.programs[rpgProgramName] = rpgProgram(rpgProgramName)
-        execute(
-            cu, mapOf("P1" to StringValue("5")),
-            si, listOf(logHandler)
-        )
+        execute(cu, mapOf("P1" to StringValue("5")),
+            si, listOf(logHandler))
         assertEquals(listOf("1"), si.displayed)
 
         // PASS TWO PARAMETERS
         si = CollectorSystemInterface()
         si.programs[rpgProgramName] = rpgProgram(rpgProgramName)
-        execute(
-            cu, mapOf(
-                "P1" to StringValue("5"),
-                "P2" to StringValue("10")
-            ),
-            si, listOf(logHandler)
-        )
+        execute(cu, mapOf("P1" to StringValue("5"),
+            "P2" to StringValue("10")),
+            si, listOf(logHandler))
         assertEquals(listOf("2"), si.displayed)
     }
 
     @Test
     fun executePROCEDURE_R() {
         assertEquals(
-            expected = listOf(
-                "1.01",
+            expected = listOf("1.01",
                 "2.04",
                 "3.09",
                 "1.04",
@@ -2003,8 +1863,7 @@ Test 6
     fun executeAPIPGM1() {
         assertEquals(
             expected = "100".split(Regex(", ")),
-            actual = outputOf("APIPGM1")
-        )
+            actual = outputOf("APIPGM1"))
     }
 
     @Test
@@ -2025,8 +1884,7 @@ Test 6
     @Test
     fun executeDOPED_PROC() {
         assertEquals(
-            expected = listOf(
-                "46",
+            expected = listOf("46",
                 "12",
                 "-22",
                 "56",
@@ -2049,8 +1907,7 @@ Test 6
     @Test
     fun executeDOPED_PROC3() {
         assertEquals(
-            expected = listOf(
-                "12",
+            expected = listOf("12",
                 "46",
                 "56",
                 "99"
@@ -2074,8 +1931,7 @@ Test 6
     @Test
     fun executeJAJAX1C() {
         assertEquals(
-            expected = listOf(
-                "Ahi quanto a dir qual era è cosa dura,esta selva selvaggia",
+            expected = listOf("Ahi quanto a dir qual era è cosa dura,esta selva selvaggia",
                 "Lupa"
             ),
             actual = outputOf("JAJAX1C")
@@ -2085,8 +1941,7 @@ Test 6
     @Test
     fun executeJAJAX1C_2() {
         assertEquals(
-            expected = listOf(
-                "ERB",
+            expected = listOf("ERB",
                 "Erbusco"
             ),
             actual = outputOf("JAJAX1C_2")
@@ -2107,24 +1962,18 @@ Test 6
             memorySliceStorage = IMemorySliceStorage.createMemoryStorage(mutableMapOf())
         )
         assertEquals(
-            listOf(
-                "Echo P1: INZ",
+            listOf("Echo P1: INZ",
                 "Echo P2:",
                 "Echo P1: INZ",
-                "Echo P2:"
-            ),
-            outputOf("PGM_A", configuration = configuration)
-        )
+                "Echo P2:"),
+            outputOf("PGM_A", configuration = configuration))
 
         assertEquals(
-            listOf(
-                "Echo P1: INZ",
+            listOf("Echo P1: INZ",
                 "Echo P2:",
                 "Echo P1: INZ",
-                "Echo P2:"
-            ),
-            outputOf("PGM_A", configuration = configuration)
-        )
+                "Echo P2:"),
+            outputOf("PGM_A", configuration = configuration))
     }
 
     // CALL_DIVIDE calls DIVIDE and it expects a regular execution
@@ -2264,8 +2113,7 @@ Test 6
         executePgm(
             programName = "PARMS1",
             params = CommandLineParms(listOf("FUNC", "METH")),
-            systemInterface = systemInterface
-        )
+            systemInterface = systemInterface)
         assertEquals(expected, console)
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -162,21 +162,25 @@ open class InterpreterTest : AbstractTest() {
         cu.resolveAndValidate()
         val si = CollectorSystemInterface()
         val logHandler = ListLogHandler()
-        si.programs["CALCFIB"] = object : JvmProgramRaw("CALCFIB", listOf(ProgramParam("ppdat", StringType(8, false)))) {
-            override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
-                val n = params["ppdat"]!!.asString().value.asInt()
-                var t1 = 0
-                var t2 = 1
+        si.programs["CALCFIB"] =
+            object : JvmProgramRaw("CALCFIB", listOf(ProgramParam("ppdat", StringType(8, false)))) {
+                override fun execute(
+                    systemInterface: SystemInterface,
+                    params: LinkedHashMap<String, Value>
+                ): List<Value> {
+                    val n = params["ppdat"]!!.asString().value.asInt()
+                    var t1 = 0
+                    var t2 = 1
 
-                for (i in 1..n) {
-                    val sum = t1 + t2
-                    t1 = t2
-                    t2 = sum
+                    for (i in 1..n) {
+                        val sum = t1 + t2
+                        t1 = t2
+                        t2 = sum
+                    }
+                    systemInterface.display("FIBONACCI OF: $n IS: $t1")
+                    return listOf(params["ppdat"]!!)
                 }
-                systemInterface.display("FIBONACCI OF: $n IS: $t1")
-                return listOf(params["ppdat"]!!)
             }
-        }
         execute(cu, mapOf("ppdat" to StringValue("10")), si, listOf(logHandler))
         assertEquals(listOf("FIBONACCI OF: 10 IS: 55"), si.displayed)
         assertEquals(logHandler.getExecutedSubroutines().size, 0)
@@ -233,15 +237,17 @@ open class InterpreterTest : AbstractTest() {
 
     @Test
     fun executeLEN() {
-        assertEquals(listOf(
-            "Hello World! 23",
-            "%LEN(B_01) is 1",
-            "%LEN(B_02) is 20",
-            "%LEN(B_03) is 0",
-            "%LEN(B_03) is 1",
-            "%LEN(B_03) is 5",
-            "%LEN(B_04) is 0"
-        ), outputOf("LEN"))
+        assertEquals(
+            listOf(
+                "Hello World! 23",
+                "%LEN(B_01) is 1",
+                "%LEN(B_02) is 20",
+                "%LEN(B_03) is 0",
+                "%LEN(B_03) is 1",
+                "%LEN(B_03) is 5",
+                "%LEN(B_04) is 0"
+            ), outputOf("LEN")
+        )
     }
 
     @Test
@@ -256,20 +262,29 @@ open class InterpreterTest : AbstractTest() {
 
     @Test
     fun executeSETONSETOF() {
-        assertEquals(listOf("Before",
+        assertEquals(
+            listOf(
+                "Before",
                 "56=off57=off",
                 "After set",
                 "56=on",
                 "After off",
-                "56=off57=off"), outputOf("SETONOF01"))
+                "56=off57=off"
+            ), outputOf("SETONOF01")
+        )
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeSETOFLF() {
-        assertEquals(listOf("Before",
-                            "LR Of",
-                            "After set",
-                            "LR Off"), outputOf("SETOFLR"))
+        assertEquals(
+            listOf(
+                "Before",
+                "LR Of",
+                "After set",
+                "LR Off"
+            ), outputOf("SETOFLR")
+        )
     }
 
     @Test
@@ -358,7 +373,8 @@ open class InterpreterTest : AbstractTest() {
         assertEquals(listOf("40208"), outputOf("DIFFTEST2"))
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeDAYOFWEEK() {
         val currentDayOfWeek = SimpleDateFormat("u").format(Date())
         assertEquals(listOf(currentDayOfWeek), outputOf("DAYOFWEEK"))
@@ -427,32 +443,40 @@ open class InterpreterTest : AbstractTest() {
 
     @Test
     fun executeMOVEAMUT13() {
-        assertEquals(listOf("ABCDEFGHIL         1",
-                            "BBBBBBBBBBBBBBBBBBBB",
-                            "AAAAAAAAAAAAAAAAAAAA",
-                            "  ABCDEFGHILMNOPQRST",
-                            "  ABCDEFGHILMNOPQRST",
-                            "XXXXXXXXXXXXXXXXXXXX",
-                            "XXXXXXXXXXXXXXXXXXXX",
-                            "XXXXXXXXXXXXXXXXXXXX",
-                            "XXXXXXXXXXXXXXXXXXXX",
-                            "XXXXXXXXXXXXXXXXXXXX"),
-            outputOf("MOVEAMUT13"))
+        assertEquals(
+            listOf(
+                "ABCDEFGHIL         1",
+                "BBBBBBBBBBBBBBBBBBBB",
+                "AAAAAAAAAAAAAAAAAAAA",
+                "  ABCDEFGHILMNOPQRST",
+                "  ABCDEFGHILMNOPQRST",
+                "XXXXXXXXXXXXXXXXXXXX",
+                "XXXXXXXXXXXXXXXXXXXX",
+                "XXXXXXXXXXXXXXXXXXXX",
+                "XXXXXXXXXXXXXXXXXXXX",
+                "XXXXXXXXXXXXXXXXXXXX"
+            ),
+            outputOf("MOVEAMUT13")
+        )
     }
 
     @Test
     fun executeMOVEAP0904_p_with_chars() {
-        assertEquals(listOf("ABCDEFGHIL",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            ""),
-            outputOf("MOVEAP0904"))
+        assertEquals(
+            listOf(
+                "ABCDEFGHIL",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                ""
+            ),
+            outputOf("MOVEAP0904")
+        )
     }
 
     @Test
@@ -525,7 +549,8 @@ open class InterpreterTest : AbstractTest() {
         assertEquals(listOf("XXXXX", "YYYYY"), outputOf("MOVELDECLA"))
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeRESULTTARG_resultAsExpressionRefenecingArray() {
         assertEquals(listOf("15.3"), outputOf("RESULTTARG"))
     }
@@ -586,9 +611,11 @@ open class InterpreterTest : AbstractTest() {
         assertEquals(listOf("0", "1", "4", "5", "6", "8", "9"), outputOf("SORTANUM"))
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeLOOKUP_OPCODE() {
-        assertEquals("""
+        assertEquals(
+            """
 Test 1
 68 OFF
 69 ON-
@@ -614,7 +641,8 @@ Test 6
 69 ON- 
  7               
         """.trimIndent().lines().map(String::trim),
-            outputOf("LOOKUP_OP1"))
+            outputOf("LOOKUP_OP1")
+        )
     }
 
     @Test
@@ -627,9 +655,11 @@ Test 6
         assertEquals(listOf("68 ON-", "69 OFF"), outputOf("LOOKUP_OP3"))
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeLOOKUP_OPCODE_GoodArray() {
-        assertEquals("""
+        assertEquals(
+            """
 Test 1
 68 ON-
 69 OFF
@@ -655,10 +685,12 @@ Test 6
 69 OFF
  1    
         """.trimIndent().lines().map(String::trim),
-            outputOf("LOOKUP_OP9"))
+            outputOf("LOOKUP_OP9")
+        )
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeSCANARRAY() {
         assertEquals(listOf("4"), outputOf("SCANARRAY"))
     }
@@ -704,28 +736,33 @@ Test 6
 
     @Test
     fun executeCALLER_CALLED_pgm_with_RT() {
-        assertEquals(listOf(
-            "Executing CALLER",
-            "x initialized at: 18",
-            "x is now: 6",
-            "Calling CALLED",
-            "Executing CALLED",
-            "x initialized at: 9",
-            "x is now: 3",
-            "Calling CALLED",
-            "Executing CALLED",
-            "x initialized at: 3",
-            "x is now: 1"
+        assertEquals(
+            listOf(
+                "Executing CALLER",
+                "x initialized at: 18",
+                "x is now: 6",
+                "Calling CALLED",
+                "Executing CALLED",
+                "x initialized at: 9",
+                "x is now: 3",
+                "Calling CALLED",
+                "Executing CALLED",
+                "x initialized at: 3",
+                "x is now: 1"
             ),
-            outputOf("CALLER"))
+            outputOf("CALLER")
+        )
     }
 
     @Test
     fun executeCAL01_callingJavaPgm() {
         val si = CollectorSystemInterface()
         var javaPgmCalled = false
-        si.programs["CAL02"] = object : JvmProgramRaw("CAL02", listOf(
-                ProgramParam("NBR", NumberType(8, 0)))) {
+        si.programs["CAL02"] = object : JvmProgramRaw(
+            "CAL02", listOf(
+                ProgramParam("NBR", NumberType(8, 0))
+            )
+        ) {
             override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
                 javaPgmCalled = true
                 val nbr = params["NBR"]
@@ -748,12 +785,15 @@ Test 6
 
     @Test
     fun executeMOVEFIXFIX() {
-        assertEquals(outputOf("MOVEFIXFIX"), listOf("ABCDE", "56789", "", "MNOPX"))
+        assertEquals(
+            listOf("ZYXWA", "ABCDE", "FGHIJ", "     ".trim()),
+            outputOf("MOVEFIXFIX")
+        )
     }
 
     @Test
     fun executeMOVENBRNBR() {
-        assertEquals(outputOf("MOVENBRNBR"), listOf("12345", "45678", "123", "99991"))
+        assertEquals(listOf("99991", "12345", "67890", "1234"), outputOf("MOVENBRNBR"))
     }
 
     @Test
@@ -782,12 +822,14 @@ Test 6
         assertEquals(listOf("Body"), outputOf("DO_TST02"))
     }
 
-    @Test @Category(PerformanceTest::class)
+    @Test
+    @Category(PerformanceTest::class)
     fun executeDOW_PERF() {
         assertEquals(outputOf("DOW_PERF"), listOf("COUNTER IS NOW 100000001"))
     }
 
-    @Test @Category(PerformanceTest::class)
+    @Test
+    @Category(PerformanceTest::class)
     fun executeDOW_LEAVE_PERF() {
         assertEquals(outputOf("DOW_LEAVE_PERF"), listOf("COUNTER IS NOW 100000001"))
     }
@@ -876,8 +918,18 @@ Test 6
 
     @Test
     fun executeREPLACEBIF() {
-        assertEquals(listOf("Pippo world!", "Hello Pippo!", "Hello Pippoorld!", "Hello Pippold!", "Hello Pippoworld!", "%20 ef", "abc%20ef"),
-            outputOf("REPLACEBIF"))
+        assertEquals(
+            listOf(
+                "Pippo world!",
+                "Hello Pippo!",
+                "Hello Pippoorld!",
+                "Hello Pippold!",
+                "Hello Pippoworld!",
+                "%20 ef",
+                "abc%20ef"
+            ),
+            outputOf("REPLACEBIF")
+        )
     }
 
     @Test
@@ -892,43 +944,64 @@ Test 6
 
     @Test
     fun executeBIFEDITC_2() {
-        assertEquals(listOf("x   123,456   123,456  1,234.56X",
-                            "x  1,234.56          X",
-                            "x  1,234.50X"),
-            outputOf("BIFEDITC_2"))
+        assertEquals(
+            listOf(
+                "x   123,456   123,456  1,234.56X",
+                "x  1,234.56          X",
+                "x  1,234.50X"
+            ),
+            outputOf("BIFEDITC_2")
+        )
     }
 
     @Test
     fun executeBIFEDITC_3() {
-        assertEquals(listOf("x  123456  123456  1234.56X",
-                            "x  1234.56      .00X",
-                            "x  1234.50X"),
-            outputOf("BIFEDITC_3"))
+        assertEquals(
+            listOf(
+                "x  123456  123456  1234.56X",
+                "x  1234.56      .00X",
+                "x  1234.50X"
+            ),
+            outputOf("BIFEDITC_3")
+        )
     }
+
     @Test
     fun executeBIFEDITC_4() {
-        assertEquals(listOf("x  123456  123456  1234.56X",
-                            "x  1234.56         X",
-                            "x  1234.50X"),
-            outputOf("BIFEDITC_4"))
+        assertEquals(
+            listOf(
+                "x  123456  123456  1234.56X",
+                "x  1234.56         X",
+                "x  1234.50X"
+            ),
+            outputOf("BIFEDITC_4")
+        )
     }
 
     @Test
     fun executeBIFEDITC_J() {
-        assertEquals(listOf("x   123,456   123,456-  1,234.56X",
-                            "x  1,234.56-       .00X",
-                            "x  1,234.50X"),
-            outputOf("BIFEDITC_J"))
+        assertEquals(
+            listOf(
+                "x   123,456   123,456-  1,234.56X",
+                "x  1,234.56-       .00X",
+                "x  1,234.50X"
+            ),
+            outputOf("BIFEDITC_J")
+        )
     }
 
     @Test
     @Ignore // we are working on DECEDIT
     fun executeBIFEDITC_Y() {
-        assertEquals(listOf("x  12/34/56  12/34/56  12/34/56X",
-                            "x  12/34/56   0/00/00X",
-                            "x  12/34/50 12/34/5678  0/00/12X",
-                            "x   1/23/45X"),
-            outputOf("BIFEDITC_Y"))
+        assertEquals(
+            listOf(
+                "x  12/34/56  12/34/56  12/34/56X",
+                "x  12/34/56   0/00/00X",
+                "x  12/34/50 12/34/5678  0/00/12X",
+                "x   1/23/45X"
+            ),
+            outputOf("BIFEDITC_Y")
+        )
     }
 
     @Test
@@ -953,8 +1026,9 @@ Test 6
 
     @Test
     fun executeCTDATA() {
-        assertEquals(expected =
-                    ("001\n" +
+        assertEquals(
+            expected =
+            ("001\n" +
                     "d01\n" +
                     "A01\n" +
                     "c01\n" +
@@ -971,72 +1045,81 @@ Test 6
                     "a01\n" +
                     "x01\n" +
                     "X01").lines(),
-                    actual = outputOf("CTDATA").map(String::trim))
+            actual = outputOf("CTDATA").map(String::trim)
+        )
     }
 
     @Test
     fun executeARRAY02_arrayWithComments() {
-        assertEquals(expected =
+        assertEquals(
+            expected =
             ("abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "xxx").lines(),
-            actual = outputOf("ARRAY02").map(String::trim))
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "xxx").lines(),
+            actual = outputOf("ARRAY02").map(String::trim)
+        )
     }
 
     @Test
     fun executeARRAY03_arrayWithCommentsPERRCD_1() {
-        assertEquals(expected =
+        assertEquals(
+            expected =
             ("abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "xxx").lines(),
-            actual = outputOf("ARRAY02").map(String::trim))
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "xxx").lines(),
+            actual = outputOf("ARRAY02").map(String::trim)
+        )
     }
 
     @Test
     fun executeARRAY04_arrayWithCommentsAndDataReference() {
-        assertEquals(expected =
+        assertEquals(
+            expected =
             ("abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "123\n" +
-            "abc\n" +
-            "xxx").lines(),
-            actual = outputOf("ARRAY04").map(String::trim))
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "123\n" +
+                    "abc\n" +
+                    "xxx").lines(),
+            actual = outputOf("ARRAY04").map(String::trim)
+        )
     }
 
     @Test
     fun executeARRAY05NAM_namedCompileTimeArrays() {
-        assertEquals(expected =
+        assertEquals(
+            expected =
             ("100\n" +
-            "100\n" +
-            "100\n" +
-            "100\n" +
-            "100").lines(),
-            actual = outputOf("ARRAY05NAM").map(String::trim))
+                    "100\n" +
+                    "100\n" +
+                    "100\n" +
+                    "100").lines(),
+            actual = outputOf("ARRAY05NAM").map(String::trim)
+        )
     }
 
     @Test
@@ -1116,7 +1199,8 @@ Test 6
     }
 
     // TODO implement DataStructureType coercion
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeDSCHARS() {
         assertEquals(listOf("Result is: X 1Y 2"), outputOf("DSCHARS"))
     }
@@ -1148,14 +1232,18 @@ Test 6
 
     @Test
     fun executeDS_CALLED_with_String_parameter() {
-        assertEquals(listOf("James", "Bond", "007"),
-            outputOf("DS_CALLED", initialValues = mapOf("P1" to StringValue("JamesBond   7"))))
+        assertEquals(
+            listOf("James", "Bond", "007"),
+            outputOf("DS_CALLED", initialValues = mapOf("P1" to StringValue("JamesBond   7")))
+        )
     }
 
     @Test
     fun executeDS_CALLED_with_DS_parameter() {
-        assertEquals(listOf("James", "Bond", "007"),
-            outputOf("DS_CALLED", initialValues = mapOf("P1" to DataStructValue("JamesBond   7"))))
+        assertEquals(
+            listOf("James", "Bond", "007"),
+            outputOf("DS_CALLED", initialValues = mapOf("P1" to DataStructValue("JamesBond   7")))
+        )
     }
 
     @Test
@@ -1187,7 +1275,11 @@ Test 6
 
     @Test
     fun executeASSIGNSUBS() {
-        assertEquals(listOf("-xyz--", "-xyz", "-xyz -"), outputOf("ASSIGNSUBS"), message = "We can't handle %SUBST(X)=Y")
+        assertEquals(
+            listOf("-xyz--", "-xyz", "-xyz -"),
+            outputOf("ASSIGNSUBS"),
+            message = "We can't handle %SUBST(X)=Y"
+        )
     }
 
     @Test
@@ -1196,14 +1288,16 @@ Test 6
     }
 
     // TODO understand why this test does not pass
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeJCODFISD() {
-        val parms = mapOf("CFDS" to StringValue("LNZNLN09B63H501J"),
+        val parms = mapOf(
+            "CFDS" to StringValue("LNZNLN09B63H501J"),
             "FISICA" to BooleanValue(false),
             "OMONIM" to BooleanValue(false),
             "SINTAX" to BooleanValue(false),
             "CHKDIG" to BooleanValue(false)
-            )
+        )
         assertEquals(outputOf("JCODFISD", parms), emptyList())
     }
 
@@ -1279,7 +1373,10 @@ Test 6
 
     @Test
     fun executeFCONSTRES() {
-        assertEquals(listOf("FLAG=ON", "FLAG=OFF", "IN34=OFF", "IN34=ON", "STR=BLANK", "STR=NOBLANK", "IN35=OFF"), outputOf(programName = "FCONSTRES"))
+        assertEquals(
+            listOf("FLAG=ON", "FLAG=OFF", "IN34=OFF", "IN34=ON", "STR=BLANK", "STR=NOBLANK", "IN35=OFF"),
+            outputOf(programName = "FCONSTRES")
+        )
     }
 
     @Test
@@ -1307,7 +1404,8 @@ Test 6
         assertEquals(listOf("10", "No Error", "Got Error"), outputOf("ERRCALLER"))
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeRTCALLER_lrIndicatorOnCall() {
         assertEquals(listOf("End LR", "End RT"), outputOf("RTCALLER"))
     }
@@ -1324,17 +1422,25 @@ Test 6
 
     @Test
     fun executeFIZZBUZZ() {
-        assertEquals(listOf("7"),
-            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("7"), "RESULT" to StringValue(""))))
+        assertEquals(
+            listOf("7"),
+            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("7"), "RESULT" to StringValue("")))
+        )
 
-        assertEquals(listOf("FIZZ"),
-            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("3"), "RESULT" to StringValue(""))))
+        assertEquals(
+            listOf("FIZZ"),
+            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("3"), "RESULT" to StringValue("")))
+        )
 
-        assertEquals(listOf("BUZZ"),
-            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("5"), "RESULT" to StringValue(""))))
+        assertEquals(
+            listOf("BUZZ"),
+            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("5"), "RESULT" to StringValue("")))
+        )
 
-        assertEquals(listOf("FIZZBUZZ"),
-            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("30"), "RESULT" to StringValue(""))))
+        assertEquals(
+            listOf("FIZZBUZZ"),
+            outputOf("mute/FIZZBUZZ", mapOf("NBRPAR" to StringValue("30"), "RESULT" to StringValue("")))
+        )
     }
 
     @Test
@@ -1411,7 +1517,8 @@ Test 6
         assertEquals(listOf("Hello world!", "Hello worl", "Hello world"), outputOf("TRIMR"))
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeELEM() {
         assertEquals(listOf("10", "20", "30"), outputOf("ELEM"))
     }
@@ -1421,12 +1528,14 @@ Test 6
         assertEquals(listOf("20.1", "19.9", "2.0", "200.0"), outputOf("SUMDIVMULT"))
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeACTGRP_CAL() {
         assertEquals(listOf("1", "2", "3", "1", "1", "1"), outputOf("ACTGRP_CAL"))
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeCLEARDS() {
         assertEquals(listOf("0000"), outputOf("CLEARDS"))
     }
@@ -1461,7 +1570,8 @@ Test 6
                 "                      ",
                 "                      "
             ),
-            outputOf("CLEARARRAY"))
+            outputOf("CLEARARRAY")
+        )
     }
 
     @Test
@@ -1485,7 +1595,8 @@ Test 6
                 " ",
                 " "
             ),
-            outputOf("CLEARARRAY1"))
+            outputOf("CLEARARRAY1")
+        )
     }
 
     @Test
@@ -1550,15 +1661,26 @@ Test 6
                                 dsDataDefinition = dataDefinition
                                 dataDefinition.fields.forEach {
                                     when (it.name) {
-                                        "\$UIBPG" -> { dsValue.set(it, StringValue("EXP", false)) }
-                                        "\$UIBFU" -> { dsValue.set(it, StringValue("X1X2110", false)) }
-                                        "\$UIBME" -> { dsValue.set(it, StringValue("FIB", false)) }
-                                        "\$UIBD1" -> { dsValue.set(it, StringValue("NUM(10)", false)) }
+                                        "\$UIBPG" -> {
+                                            dsValue.set(it, StringValue("EXP", false))
+                                        }
+
+                                        "\$UIBFU" -> {
+                                            dsValue.set(it, StringValue("X1X2110", false))
+                                        }
+
+                                        "\$UIBME" -> {
+                                            dsValue.set(it, StringValue("FIB", false))
+                                        }
+
+                                        "\$UIBD1" -> {
+                                            dsValue.set(it, StringValue("NUM(10)", false))
+                                        }
                                     }
                                 }
                             }
                             /* no-op */
-                            else -> { }
+                            else -> {}
                         }
                     }
                 },
@@ -1578,10 +1700,12 @@ Test 6
     fun executeFREE_HELLO() {
         assertEquals(
             expected = "Hello world, Hello world in Chinese: 你好世界, number1 * number2 = 15".split(Regex(", ")),
-            actual = outputOf("FREE_HELLO"))
+            actual = outputOf("FREE_HELLO")
+        )
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     fun executeLOSER_PR() {
         executePgm("LOSER_PR")
     }
@@ -1607,7 +1731,8 @@ Test 6
     @Test
     fun executePROCEDURE_C() {
         assertEquals(
-            expected = listOf("p received must be 11, is:11",
+            expected = listOf(
+                "p received must be 11, is:11",
                 "q received must be 22, is:22",
                 "r received must be 0, is:0",
                 "r=p+q must be 33, is:33",
@@ -1646,13 +1771,15 @@ Test 6
     @Test
     fun executePROCEDURE_H() {
         assertEquals(
-            expected = listOf("11",
+            expected = listOf(
+                "11",
                 "22",
                 "33",
                 "0",
                 "33",
                 "22",
-                "121"),
+                "121"
+            ),
             actual = outputOf("PROCEDURE_H")
         )
     }
@@ -1660,7 +1787,8 @@ Test 6
     @Test
     fun executePROCEDURE_I() {
         assertEquals(
-            expected = listOf("1",
+            expected = listOf(
+                "1",
                 "4"
             ),
             actual = outputOf("PROCEDURE_I")
@@ -1670,7 +1798,8 @@ Test 6
     @Test
     fun executePROCEDURE_J() {
         assertEquals(
-            expected = listOf("1",
+            expected = listOf(
+                "1",
                 "4",
                 "8",
                 "9",
@@ -1686,7 +1815,8 @@ Test 6
     @Test
     fun executePROCEDURE_K() {
         assertEquals(
-            expected = listOf("69.12",
+            expected = listOf(
+                "69.12",
                 ".59",
                 "12345          54321",
                 "73.00",
@@ -1704,7 +1834,8 @@ Test 6
     @Test
     fun executePROCEDURE_L() {
         assertEquals(
-            expected = listOf(".99",
+            expected = listOf(
+                ".99",
                 "1.11",
                 "9.99"
             ),
@@ -1715,7 +1846,8 @@ Test 6
     @Test
     fun executePROCEDURE_M() {
         assertEquals(
-            expected = listOf("2.24",
+            expected = listOf(
+                "2.24",
                 "3.36"
             ),
             actual = outputOf("PROCEDURE_M")
@@ -1727,7 +1859,8 @@ Test 6
     // TODO ignored until 'DS as parameter' will be supported (maybe never?)
     fun executePROCEDURE_N() {
         assertEquals(
-            expected = listOf("10.2",
+            expected = listOf(
+                "10.2",
                 "ABCDE"
             ),
             actual = outputOf("PROCEDURE_N")
@@ -1768,7 +1901,8 @@ Test 6
     @Test
     fun executePROCEDURE_P() {
         assertEquals(
-            expected = listOf("2.04",
+            expected = listOf(
+                "2.04",
                 "1.02",
                 "1.03"
             ),
@@ -1793,30 +1927,39 @@ Test 6
         // PASS NO PARAMETERS
         var si = CollectorSystemInterface()
         si.programs[rpgProgramName] = rpgProgram(rpgProgramName)
-        execute(cu, emptyMap(),
-            si, listOf(logHandler))
+        execute(
+            cu, emptyMap(),
+            si, listOf(logHandler)
+        )
         assertEquals(listOf("0"), si.displayed)
 
         // PASS ONE PARAMETER
         si = CollectorSystemInterface()
         si.programs[rpgProgramName] = rpgProgram(rpgProgramName)
-        execute(cu, mapOf("P1" to StringValue("5")),
-            si, listOf(logHandler))
+        execute(
+            cu, mapOf("P1" to StringValue("5")),
+            si, listOf(logHandler)
+        )
         assertEquals(listOf("1"), si.displayed)
 
         // PASS TWO PARAMETERS
         si = CollectorSystemInterface()
         si.programs[rpgProgramName] = rpgProgram(rpgProgramName)
-        execute(cu, mapOf("P1" to StringValue("5"),
-            "P2" to StringValue("10")),
-            si, listOf(logHandler))
+        execute(
+            cu, mapOf(
+                "P1" to StringValue("5"),
+                "P2" to StringValue("10")
+            ),
+            si, listOf(logHandler)
+        )
         assertEquals(listOf("2"), si.displayed)
     }
 
     @Test
     fun executePROCEDURE_R() {
         assertEquals(
-            expected = listOf("1.01",
+            expected = listOf(
+                "1.01",
                 "2.04",
                 "3.09",
                 "1.04",
@@ -1855,7 +1998,8 @@ Test 6
     fun executeAPIPGM1() {
         assertEquals(
             expected = "100".split(Regex(", ")),
-            actual = outputOf("APIPGM1"))
+            actual = outputOf("APIPGM1")
+        )
     }
 
     @Test
@@ -1876,7 +2020,8 @@ Test 6
     @Test
     fun executeDOPED_PROC() {
         assertEquals(
-            expected = listOf("46",
+            expected = listOf(
+                "46",
                 "12",
                 "-22",
                 "56",
@@ -1899,7 +2044,8 @@ Test 6
     @Test
     fun executeDOPED_PROC3() {
         assertEquals(
-            expected = listOf("12",
+            expected = listOf(
+                "12",
                 "46",
                 "56",
                 "99"
@@ -1923,7 +2069,8 @@ Test 6
     @Test
     fun executeJAJAX1C() {
         assertEquals(
-            expected = listOf("Ahi quanto a dir qual era è cosa dura,esta selva selvaggia",
+            expected = listOf(
+                "Ahi quanto a dir qual era è cosa dura,esta selva selvaggia",
                 "Lupa"
             ),
             actual = outputOf("JAJAX1C")
@@ -1933,7 +2080,8 @@ Test 6
     @Test
     fun executeJAJAX1C_2() {
         assertEquals(
-            expected = listOf("ERB",
+            expected = listOf(
+                "ERB",
                 "Erbusco"
             ),
             actual = outputOf("JAJAX1C_2")
@@ -1954,18 +2102,24 @@ Test 6
             memorySliceStorage = IMemorySliceStorage.createMemoryStorage(mutableMapOf())
         )
         assertEquals(
-            listOf("Echo P1: INZ",
+            listOf(
+                "Echo P1: INZ",
                 "Echo P2:",
                 "Echo P1: INZ",
-                "Echo P2:"),
-            outputOf("PGM_A", configuration = configuration))
+                "Echo P2:"
+            ),
+            outputOf("PGM_A", configuration = configuration)
+        )
 
         assertEquals(
-            listOf("Echo P1: INZ",
+            listOf(
+                "Echo P1: INZ",
                 "Echo P2:",
                 "Echo P1: INZ",
-                "Echo P2:"),
-            outputOf("PGM_A", configuration = configuration))
+                "Echo P2:"
+            ),
+            outputOf("PGM_A", configuration = configuration)
+        )
     }
 
     // CALL_DIVIDE calls DIVIDE and it expects a regular execution
@@ -2105,7 +2259,8 @@ Test 6
         executePgm(
             programName = "PARMS1",
             params = CommandLineParms(listOf("FUNC", "METH")),
-            systemInterface = systemInterface)
+            systemInterface = systemInterface
+        )
         assertEquals(expected, console)
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -797,6 +797,11 @@ Test 6
     }
 
     @Test
+    fun executeMOVESTRNBR() {
+        assertEquals(listOf("ABCD1", "12345", "67890", "01234"), outputOf("MOVESTRNBR"))
+    }
+
+    @Test
     fun executeDOWTEST() {
         assertEquals(outputOf("DOWTEST"), listOf("COUNTER IS NOW 21"))
     }

--- a/rpgJavaInterpreter-core/src/test/resources/MOVEFIXFIX.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/MOVEFIXFIX.rpgle
@@ -1,21 +1,27 @@
-     Dvar5             S              5A   inz('ABCDE')
-     Dvar10            S             10A   INZ('0123456789')
-     Dvar15            S             15A   INZ('FGH')
-     Dvar1             S              1A   INZ('X')
-     Dfix5a            S              5A   INZ('MNOPQ')
-     Dfix5b            S              5A   INZ('MNOPQ')
-     Dfix5c            S              5A   INZ('MNOPQ')
-     Dfix5d            S              5A   INZ('MNOPQ')
-     C                   move      var5          fix5a
-     C     fix5a         dsply
-      ***********************************************
-     C                   move      var10         fix5b
-     C     fix5b         dsply
-      ***********************************************
-     C                   move      var15         fix5C
-     C     fix5C         dsply
-      ***********************************************
-     C                   move      var1          fix5d
-     C     fix5d         dsply
-      ***********************************************
+     DSTR1             S              1    INZ('A')
+     DSTR5             S              5    INZ('ABCDE')
+     DSTR10            S             10    INZ('ACBDEFGHIJ')
+     DSTR15            S             15    INZ('XXXX')
+      *
+     DRES1             S              5    INZ('ZYXWV')
+     DRES2             S              5    INZ('ZYXWV')
+     DRES3             S              5    INZ('ZYXWV')
+     DRES4             S              5    INZ('ZYXWV')
+      *
+      * MOVE('A', 'ZYXWV') => 'ZYXWA'
+     C                   MOVE      STR1          RES1
+     C     RES1          DSPLY
+      *
+      * MOVE('ABCDE', 'ZYXWV') => 'ABCDE')
+     C                   MOVE      STR5          RES2
+     C     RES2          DSPLY
+      *
+      * MOVE('ABCDEFGHIJ', 'ZYXWV') => 'FGHIJ')
+     C                   MOVE      STR10         RES3
+     C     RES3          DSPLY
+      *
+      * MOVE('XXXX           ', 'ZYXWV') => '     ')
+     C                   MOVE      STR15         RES4
+     C     RES4          DSPLY
+      *
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/MOVENBRNBR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/MOVENBRNBR.rpgle
@@ -1,21 +1,22 @@
-     Dvar5             S              5  0 inz(12345)
-     Dvar8             S              8  0 INZ(12345678)
-     Dvar15            S             15  0 INZ(123)
-     Dvar1             S              1  0 INZ(1)
-     Dfix5a            S              5  0 INZ(99999)
-     Dfix5b            S              5  0 INZ(99999)
-     Dfix5c            S              5  0 INZ(99999)
-     Dfix5d            S              5  0 INZ(99999)
-     C                   move      var5          fix5a
-     C     fix5a         dsply
-      ***********************************************
-     C                   move      var8          fix5b
-     C     fix5b         dsply
-      ***********************************************
-     C                   move      var15         fix5C
-     C     fix5C         dsply
-      ***********************************************
-     C                   move      var1          fix5d
-     C     fix5d         dsply
-      ***********************************************
-     C                   SETON                                          LR
+     DINT1             S              1  0 INZ(1)
+     DINT5             S              5  0 INZ(12345)
+     DINT10            S             10  0 INZ(1234567890)
+     DINT15            S             15  0 INZ(1234)
+      *
+     DRES1             S              5  0 INZ(99999)
+     DRES2             S              5  0 INZ(99999)
+     DRES3             S              5  0 INZ(99999)
+     DRES4             S              5  0 INZ(99999)
+      *
+      * MOVE(1, 99999) => 99991
+     C                   MOVE      INT1          RES1
+     C     RES1          DSPLY
+      * MOVE(12345, 99999) => 12345
+     C                   MOVE      INT5          RES2
+     C     RES2          DSPLY
+      * MOVE(1234567890, 99999) => 67890
+     C                   MOVE      INT10         RES3
+     C     RES3          DSPLY
+      * MOVE(           1234, 99999) =>  1234
+     C                   MOVE      INT15         RES4
+     C     RES4          DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/MOVESTRNBR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/MOVESTRNBR.rpgle
@@ -1,0 +1,24 @@
+     DINT1             S              1  0 INZ(1)
+     DINT5             S              5  0 INZ(12345)
+     DINT10            S             10  0 INZ(1234567890)
+     DINT15            S             15  0 INZ(1234)
+      *
+     DRES1             S              5    INZ('ABCD')
+     DRES2             S              5    INZ('ABCD')
+     DRES3             S              5    INZ('ABCD')
+     DRES4             S              5    INZ('ABCD')
+      *
+      * MOVE(1, 'ABCD') => 'ABCD1'
+     C                   MOVE      INT1          RES1
+     C     RES1          DSPLY
+      * MOVE(12345, 'ABCD') => '12345'
+     C                   MOVE      INT5          RES2
+     C     RES2          DSPLY
+      * MOVE(1234567890, 'ABCD') => '67890'
+     C                   MOVE      INT10         RES3
+     C     RES3          DSPLY
+      * MOVE(000000000001234, 'ABCD') => '01234'
+     C                   MOVE      INT15         RES4
+     C     RES4          DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Fix MOVE statement to allow operation between Strings and Integers. 

NB. Rpgle sources were run on AS400.

Related to # (issue)

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
