### PR TITLE
Feature/nw23000730/add on call error callback

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -117,6 +117,8 @@ data class Options(
  * @param onEnterFunction It is invoked on function enter after symboltable initialization.
  * @param onExitFunction It is invoked on function exit, only if the function does not throw any error
  * @param onError It is invoked in case of errors. The default implementation writes error event in stderr
+ * @param onCallPgmError It is invoked in case of runtime errors accurred inside the program called only if the error indicator
+ * at column 73-74 is specified. The default implementation does nothing
  * @param logInfo If specified, it is invoked to log information messages, for all channel enabled
  * @param channelLoggingEnabled If specified, it allows to enable programmatically the channel logging.
  * For instance, you can enable all channels by using [consoleVerboseConfiguration] but you can decide, through
@@ -158,6 +160,7 @@ data class JarikoCallback(
             }
         } ?: System.err.println(errorEvent)
     },
+    var onCallPgmError: (errorEvent: ErrorEvent) -> Unit = { },
     var logInfo: ((channel: String, message: String) -> Unit)? = null,
     var channelLoggingEnabled: ((channel: String) -> Boolean)? = null
 )
@@ -180,7 +183,7 @@ data class CallProgramHandler(
 data class ErrorEvent(val error: Throwable, val errorEventSource: ErrorEventSource, val absoluteLine: Int?, val sourceReference: SourceReference?) {
 
     /**
-Re     * The source code line from which the error event has been fired.
+     * The source code line from which the error event has been fired.
      * Could be null
      * */
     val fragment = absoluteLine?.let { line ->

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
@@ -18,9 +18,9 @@ package com.smeup.rpgparser.interpreter
 
 import com.smeup.dbnative.file.Record
 import com.smeup.rpgparser.execution.ErrorEvent
-import com.smeup.rpgparser.execution.ErrorEventSource
+import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.parsing.ast.*
-import com.strumenta.kolasu.model.Position
+import java.util.*
 
 /**
  * Expose interpreter core method that could be useful in statements logic implementation
@@ -69,12 +69,10 @@ interface InterpreterCore {
     fun increment(dataDefinition: AbstractDataDefinition, amount: Long): Value
 }
 
-/**
- * Fire a runtime error event. These kinds of errors are fired during the execution of the program.
- * @param position the position of the error
- * @param callback the callback to invoke
- */
-fun Throwable.fireRuntimeErrorEvent(position: Position?, callback: (errorEvent: ErrorEvent) -> Unit) {
-    val errorEvent = ErrorEvent(this, ErrorEventSource.Interpreter, position?.start?.line, position?.relative()?.second)
-    callback.invoke(errorEvent)
+internal fun ErrorEvent.pushRuntimeErrorEvent() {
+    getErrorEventStack().push(this)
 }
+
+internal fun popRuntimeErrorEvent() = getErrorEventStack().pop()
+
+private fun getErrorEventStack() = MainExecutionContext.getAttributes().computeIfAbsent("errorEventStack") { Stack<ErrorEvent>() } as Stack<ErrorEvent>

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
@@ -17,7 +17,10 @@
 package com.smeup.rpgparser.interpreter
 
 import com.smeup.dbnative.file.Record
+import com.smeup.rpgparser.execution.ErrorEvent
+import com.smeup.rpgparser.execution.ErrorEventSource
 import com.smeup.rpgparser.parsing.ast.*
+import com.strumenta.kolasu.model.Position
 
 /**
  * Expose interpreter core method that could be useful in statements logic implementation
@@ -64,4 +67,14 @@ interface InterpreterCore {
     fun optimizedIntExpression(expression: Expression): () -> Long
     fun enterCondition(index: Value, end: Value, downward: Boolean): Boolean
     fun increment(dataDefinition: AbstractDataDefinition, amount: Long): Value
+}
+
+/**
+ * Fire a runtime error event. These kinds of errors are fired during the execution of the program.
+ * @param position the position of the error
+ * @param callback the callback to invoke
+ */
+fun Throwable.fireRuntimeErrorEvent(position: Position?, callback: (errorEvent: ErrorEvent) -> Unit) {
+    val errorEvent = ErrorEvent(this, ErrorEventSource.Interpreter, position?.start?.line, position?.relative()?.second)
+    callback.invoke(errorEvent)
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -18,6 +18,8 @@ package com.smeup.rpgparser.interpreter
 
 import com.smeup.dbnative.file.DBFile
 import com.smeup.dbnative.file.Record
+import com.smeup.rpgparser.execution.ErrorEvent
+import com.smeup.rpgparser.execution.ErrorEventSource
 import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.parsing.ast.*
 import com.smeup.rpgparser.parsing.ast.AssignmentOperator.*
@@ -416,7 +418,9 @@ open class InternalInterpreter(
     }
 
     private fun Throwable.fireErrorEvent(position: Position?): Throwable {
-        this.fireRuntimeErrorEvent(position, MainExecutionContext.getConfiguration().jarikoCallback.onError)
+        val errorEvent = ErrorEvent(this, ErrorEventSource.Interpreter, position?.start?.line, position?.relative()?.second)
+        errorEvent.pushRuntimeErrorEvent()
+        MainExecutionContext.getConfiguration().jarikoCallback.onError.invoke(errorEvent)
         return this
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -18,8 +18,6 @@ package com.smeup.rpgparser.interpreter
 
 import com.smeup.dbnative.file.DBFile
 import com.smeup.dbnative.file.Record
-import com.smeup.rpgparser.execution.ErrorEvent
-import com.smeup.rpgparser.execution.ErrorEventSource
 import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.parsing.ast.*
 import com.smeup.rpgparser.parsing.ast.AssignmentOperator.*
@@ -418,8 +416,7 @@ open class InternalInterpreter(
     }
 
     private fun Throwable.fireErrorEvent(position: Position?): Throwable {
-        val errorEvent = ErrorEvent(this, ErrorEventSource.Interpreter, position?.start?.line, position?.relative()?.second)
-        MainExecutionContext.getConfiguration().jarikoCallback.onError.invoke(errorEvent)
+        this.fireRuntimeErrorEvent(position, MainExecutionContext.getConfiguration().jarikoCallback.onError)
         return this
     }
 
@@ -624,7 +621,7 @@ open class InternalInterpreter(
     }
 
     override fun toSearchValues(searchArgExpression: Expression, fileMetadata: FileMetadata): List<String> {
-        val kListName = searchArgExpression.render().toUpperCase()
+        val kListName = searchArgExpression.render().uppercase(Locale.getDefault())
         return klists[kListName]!!.mapIndexed { index, name ->
             get(name).asString(fileMetadata.accessFieldsType[index])
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -42,6 +42,10 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
         interpreterCore
     }
 
+    val intepreterCore: InterpreterCore by lazy {
+        interpreter
+    }
+
     lateinit var activationGroup: ActivationGroup
     private var initialized = false
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -660,6 +660,9 @@ data class CallStmt(
                     throw e
                 }
                 interpreter.getIndicators()[errorIndicator] = BooleanValue.TRUE
+                e.fireRuntimeErrorEvent(
+                    position = callStatement.position,
+                    callback = MainExecutionContext.getConfiguration().jarikoCallback.onCallPgmError)
                 null
             }
         paramValuesAtTheEnd?.forEachIndexed { index, value ->

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -660,9 +660,7 @@ data class CallStmt(
                     throw e
                 }
                 interpreter.getIndicators()[errorIndicator] = BooleanValue.TRUE
-                e.fireRuntimeErrorEvent(
-                    position = callStatement.position,
-                    callback = MainExecutionContext.getConfiguration().jarikoCallback.onCallPgmError)
+                MainExecutionContext.getConfiguration().jarikoCallback.onCallPgmError.invoke(popRuntimeErrorEvent())
                 null
             }
         paramValuesAtTheEnd?.forEachIndexed { index, value ->

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -27,6 +27,7 @@ import org.junit.Assert
 import java.io.StringReader
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 /**
  * Test suite to test Jariko callback features
@@ -453,6 +454,18 @@ class JarikoCallbackTest : AbstractTest() {
         }
         executePgm(programName = program, configuration = configuration)
         assertEquals(expectedIncludedCopies, includedCopies)
+    }
+
+    @Test
+    fun onCallPgmError() {
+        var catchedError: ErrorEvent? = null
+        val configuration = Configuration().apply {
+            jarikoCallback.onCallPgmError = { errorEvent ->
+                catchedError = errorEvent
+            }
+        }
+        executePgm(programName = "ERRCALLER", configuration = configuration)
+        assertNotNull(catchedError)
     }
 
     private fun executePgmCallBackTest(pgm: String, sourceReferenceType: SourceReferenceType, sourceId: String, lines: List<Int>) {


### PR DESCRIPTION
## Description

If in `CALL` operation code you specify the error indicator (in the example the indicator is the 69):
```
     C                   CALL      'CALLED'                             69
```

you can handle the occurred error in the called program by implementing the new callback [JarikoCallback.onCallPgmError](https://github.com/smeup/jariko/blob/a1348a5f8d479ba9a2c94d7450195fbecc7eda97/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt#L163C16-L163C16)

As helpful information view this test [onCallPgmError](https://github.com/smeup/jariko/blob/a1348a5f8d479ba9a2c94d7450195fbecc7eda97/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt#L460)

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
