### PR TITLE
fix: move/movel throws exceptions for negative values

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
@@ -159,25 +159,20 @@ private fun valueToString(value: Value, type: Type): String {
         is CharacterType -> return s
 
         is NumberType -> {
-            when (value) {
-                is IntValue -> {
-                    if (value.value < 0) {
-                        throw UnsupportedOperationException("MOVEL/MOVE for integer negative numbers not supported")
-                    }
+            if (value is NumberValue) {
+                if (value.isNegative()) {
+                    throw UnsupportedOperationException("MOVEL/MOVE for negative numbers not supported")
+                }
+                if (value is IntValue) {
                     val zeros = "0".repeat(type.numberOfDigits - s.length)
                     zeros + s
-                }
-
-                is DecimalValue -> {
-                    if (value.value < BigDecimal.ZERO) {
-                        throw UnsupportedOperationException("MOVEL/MOVE for decimal negative numbers not supported")
-                    }
+                } else {
                     s = s.replace(".", "")
                     val zeros = "0".repeat(type.numberOfDigits - s.length)
                     zeros + s
                 }
-
-                else -> throw UnsupportedOperationException("MOVE/MOVEL of NumberType $value not supported")
+            } else {
+                throw UnsupportedOperationException("MOVE/MOVEL not supported for the type: $type")
             }
         }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
@@ -159,17 +159,29 @@ private fun valueToString(value: Value, type: Type): String {
         is CharacterType -> return s
 
         is NumberType -> {
-            if (value is IntValue) {
-                val zeros = "0".repeat(type.numberOfDigits - s.length)
-                zeros + s
-            } else {
-                s = s.replace(".", "")
-                val zeros = "0".repeat(type.numberOfDigits - s.length)
-                zeros + s
+            when (value) {
+                is IntValue -> {
+                    if (value.value < 0) {
+                        throw UnsupportedOperationException("MOVEL/MOVE for integer negative numbers not supported")
+                    }
+                    val zeros = "0".repeat(type.numberOfDigits - s.length)
+                    zeros + s
+                }
+
+                is DecimalValue -> {
+                    if (value.value < BigDecimal.ZERO) {
+                        throw UnsupportedOperationException("MOVEL/MOVE for decimal negative numbers not supported")
+                    }
+                    s = s.replace(".", "")
+                    val zeros = "0".repeat(type.numberOfDigits - s.length)
+                    zeros + s
+                }
+
+                else -> throw UnsupportedOperationException("MOVE/MOVEL of NumberType $value not supported")
             }
         }
 
-        else -> throw UnsupportedOperationException("Unable to stringify the type: $type")
+        else -> throw UnsupportedOperationException("MOVE/MOVEL not supported for the type: $type")
     }
 }
 
@@ -202,6 +214,6 @@ private fun stringToValue(value: String, type: Type): Value {
             }
         }
 
-        else -> throw UnsupportedOperationException("Unable to convert string to value the type: $type")
+        else -> throw UnsupportedOperationException("MOVE/MOVEL not supported for the type: $type")
     }
 }


### PR DESCRIPTION
## Description

`MOVE` `MOVEL` throws exceptions for negative values.

Related to # (issue)

## Checklist:
- [ ] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
