### PR TITLE
Bugfix/nw23001440/array

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -80,7 +80,7 @@ private fun coerceString(value: StringValue, type: Type): Value {
                 else -> if (value.value.isEmpty()) {
                     StringValue(" ".repeat(type.length), false)
                 } else {
-                    StringValue(value.value, false)
+                    StringValue(value.value.padEnd(type.size, ' '), false)
                 }
             }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -88,7 +88,8 @@ open class InterpreterTest : AbstractTest() {
         val logHandler = ListLogHandler()
         val interpreter = execute(cu, mapOf("ppdat" to StringValue("10")), si, listOf(logHandler))
         val assignments = logHandler.getAssignments()
-        assertEquals(assignments[0].value, StringValue("10"))
+        // The ppdat variable is not varying length 8
+        assertEquals(StringValue("10".padEnd(8, ' ')), assignments[0].value)
         assertIsIntValue(interpreter["NBR"], 10)
         assertEquals(listOf("10"), si.displayed)
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -16,4 +16,9 @@ open class SmeupInterpreterTest : AbstractTest() {
         // TODO When we will have more clear idea about the expected result, we will add the assert
         println("executeT15_A90: " + "smeup/T15_A90".outputOf())
     }
+
+    @Test
+    fun executeT02_A30() {
+        println("executeT02_A30: " + "smeup/T02_A30".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -2,6 +2,7 @@ package com.smeup.rpgparser.evaluation
 
 import com.smeup.rpgparser.AbstractTest
 import org.junit.Test
+import kotlin.test.assertEquals
 
 open class SmeupInterpreterTest : AbstractTest() {
 
@@ -19,6 +20,21 @@ open class SmeupInterpreterTest : AbstractTest() {
 
     @Test
     fun executeT02_A30() {
-        println("executeT02_A30: " + "smeup/T02_A30".outputOf())
+        val len = 100
+        val expected = listOf(
+            buildString {
+                append("AAAAA".padEnd(len, ' '))
+                append("BBBBB".padEnd(len, ' '))
+                append("CCCCC".padEnd(len, ' '))
+                append("DDDDD".padEnd(len, ' '))
+                append("EEEEE".padEnd(len, ' '))
+                append("FFFFF".padEnd(len, ' '))
+                append("GGGGG".padEnd(len, ' '))
+                append("HHHHH".padEnd(len, ' '))
+                // Here I don't padEnd because the display messages are trimmed
+                append("IIIII")
+            }
+        )
+        assertEquals(expected, "smeup/T02_A30".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A30.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A30.rpgle
@@ -1,0 +1,21 @@
+     D A30_AR2         S            100    DIM(09) CTDATA PERRCD(1)             _TXT
+     D £DBG_Str        S           2560                                         Stringa
+     D £DBG_Pas        S             10                                         Passo     
+     C                   EVAL      £DBG_Pas='P02'
+     C                   EVAL      £DBG_Str=A30_AR2(01)+A30_AR2(02)+A30_AR2(03)
+     C                                     +A30_AR2(04)+A30_AR2(05)+A30_AR2(06)
+     C                                     +A30_AR2(07)+A30_AR2(08)+A30_AR2(09)
+
+     C     £DBG_Str      DSPLY
+     
+
+** A30_AR2
+AAAAA
+BBBBB
+CCCCC
+DDDDD
+EEEEE
+FFFFF
+GGGGG
+HHHHH
+IIIII


### PR DESCRIPTION
## Description

If the element size of a static array was greater than 80 it was truncated to 80

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
