### PR TITLE
Bugfix/NW23001440/fix move with arrays

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
@@ -81,7 +81,7 @@ fun move(
             arrayValue.elements.forEachIndexed { index, el ->
                 arrayValue.setElement(
                     index + 1, stringToValue(
-                        movel(
+                        move(
                             valueToMove,
                             valueToString(el, valueToApplyMoveElementType),
                             valueToApplyMoveElementType,

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -752,14 +752,14 @@ Test 6
     @Test
     fun executeMOVE() {
         assertEquals(
-            listOf("ZYXWA", "ABCDE", "FGHIJ", "     ".trim(), "ZY123", "ZY456", "99123", "99456", "ZYXYY", "DE"),
+            listOf("ZYXWA", "ABCDE", "FGHIJ", "     ".trim(), "ZY123", "ZY456", "99123", "99456", "ZYXYY", "DE", "DE", "DE"),
             outputOf("MOVE")
         )
     }
 
     @Test
     fun executeMOVEP() {
-        assertEquals(listOf("  ABC", "  123", "  456", "456", "  ABC", "BC"), outputOf("MOVEP"))
+        assertEquals(listOf("  ABC", "  123", "  456", "456", "  ABC", "BC", "  ABC", "  ABC"), outputOf("MOVEP"))
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/resources/MOVE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/MOVE.rpgle
@@ -18,6 +18,7 @@
      DRES8             S              5P 0 INZ(99999)
      DRES9             S              5    INZ('ZYXWV')
      DRES10            S             10    INZ('WV') VARYING
+     DRES11            S              2    DIM(2)
       *
       * String-String MOVE('A', 'ZYXWV') => 'ZYXWA'
      C                   MOVE      STR1          RES1
@@ -58,5 +59,10 @@
       * String-String(Varying) MOVE('ABCDE', 'YY') => 'DE')
      C                   MOVE      STR5          RES10
      C     RES10         DSPLY
+      *
+      * String-Array(String) MOVE('ABCDE', ARRAY('  ', '  ') => ARRAY('DE', 'DE')
+     C                   MOVE      STR5              RES11
+     C     RES11(1)      DSPLY
+     C     RES11(2)      DSPLY
       *
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/MOVEP.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/MOVEP.rpgle
@@ -10,6 +10,7 @@
      DRES4             S              5P 0 INZ(99999)
      DRES5             S              5    INZ('ZYXWV')
      DRES6             S              5    INZ('YY') VARYING
+     DRES7             S              5    DIM(2)
       *
       * String-String - MOVE(P)('ABC', 'ZYXWV') => '  ABC'
      C                   MOVE(P)   STR3          RES1
@@ -34,5 +35,10 @@
       * String-String(Varying) MOVE(P)('ABC', 'YY') => 'BC')
      C                   MOVE(P)    STR3          RES6
      C     RES6          DSPLY
+      *
+      * String-Array(String) MOVE('ABC', ARRAY('    ', '    ') => ARRAY('  ABC', '  ABC')
+     C                   MOVE      STR3              RES7
+     C     RES7(1)       DSPLY
+     C     RES7(2)       DSPLY
       *
      C                   SETON                                          LR


### PR DESCRIPTION
## Description

fix `MOVE` AND `MOVE(P)` with array + test

Related to # (issue)
MULANGT40 - SEZ_A20 - P03: Delta error on `MOVE(P)` with arrays (NW23001440 - LS23095336)

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
