### PR TITLE
Bugfix/char bif trailng spaces

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
@@ -22,7 +22,7 @@ import java.util.*
 
 fun Value.stringRepresentation(format: String? = null): String {
     return when (this) {
-        is StringValue -> value.trimEnd()
+        is StringValue -> if (this.varying) value.trimEnd() else value
         is BooleanValue -> asString().value // TODO check if it's the best solution
         is NumberValue -> render()
         is ArrayValue -> "[${elements().map { it.render() }.joinToString(", ")}]"

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
@@ -218,7 +218,7 @@ abstract class AbstractTest {
      * @receiver Name or relative path followed by name. Example performance/MUTE10_01 to execute a PGM
      * in test/resources/performance/MUTE10_01.rpgle. If this parameter contains at least a line feed it is considered
      * an inline program
-     * @return The output of the program as a list of displayed messages
+     * @return The output of the program as a list of **trimmed** displayed messages
      * */
     protected fun String.outputOf(): List<String> {
         val messages = mutableListOf<String>()
@@ -226,7 +226,7 @@ abstract class AbstractTest {
             onDisplay = { message, _ -> messages.add(message) }
         }
         executePgm(programName = this, systemInterface = systemInterface)
-        return messages
+        return messages.map { it.trim() }
     }
 
     private fun createSimpleReloadConfig(): SimpleReloadConfig? {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
@@ -133,19 +133,33 @@ abstract class AbstractTest {
         )
     }
 
+    /**
+     * Executes a DB program and returns the output.
+     *
+     * @param programName The name of the program to be executed.
+     * @param metadata The metadata of the files used in the program.
+     * @param initialSQL The initial SQL statements to be executed before the program.
+     * @param inputParms The input parameters for the program.
+     * @param configuration The configuration for the execution of the program.
+     * @param trimOutput A boolean value indicating whether the output should be trimmed or not. Default value is true.
+     *
+     * @return A list of strings representing the output of the program. If trimOutput is true, the strings are trimmed.
+     */
     fun outputOfDBPgm(
         programName: String,
         metadata: List<FileMetadata> = emptyList(),
         initialSQL: List<String> = emptyList(),
         inputParms: Map<String, Value> = mapOf(),
-        configuration: Configuration = Configuration(options = Options(muteSupport = true))
+        configuration: Configuration = Configuration(options = Options(muteSupport = true)),
+        trimOutput: Boolean = true
     ): List<String> {
         return com.smeup.rpgparser.db.utilities.outputOfDBPgm(
             programName = programName,
             metadata = metadata,
             initialSQL = initialSQL,
             inputParms = inputParms,
-            configuration = configuration.adaptForTestCase(this)
+            configuration = configuration.adaptForTestCase(this),
+            trimOutput = trimOutput
         )
     }
 
@@ -213,20 +227,19 @@ abstract class AbstractTest {
     }
 
     /**
-     * Execute a program and return the output as a list of strings.
-     * This method guarantees that the program is executed just like Jariko.
-     * @receiver Name or relative path followed by name. Example performance/MUTE10_01 to execute a PGM
-     * in test/resources/performance/MUTE10_01.rpgle. If this parameter contains at least a line feed it is considered
-     * an inline program
-     * @return The output of the program as a list of **trimmed** displayed messages
-     * */
-    protected fun String.outputOf(): List<String> {
+     * Executes a program and returns the output as a list of displayed messages.
+     *
+     * @param trimOutput A boolean value indicating whether the output should be trimmed or not. Default value is true.
+     *
+     * @return A list of strings representing the output of the program. If trimOutput is true, the strings are trimmed.
+     */
+    protected fun String.outputOf(trimOutput: Boolean = true): List<String> {
         val messages = mutableListOf<String>()
         val systemInterface = JavaSystemInterface().apply {
             onDisplay = { message, _ -> messages.add(message) }
         }
         executePgm(programName = this, systemInterface = systemInterface)
-        return messages.map { it.trim() }
+        return if (trimOutput) messages.map { it.trim() } else messages
     }
 
     private fun createSimpleReloadConfig(): SimpleReloadConfig? {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
@@ -91,9 +91,19 @@ abstract class AbstractTest {
         )
     }
 
+
     /**
-     * Execute a program and return the output as a list of displayed messages
-     * */
+     * Executes a program and returns the output as a list of displayed messages.
+     *
+     * @param programName The name of the program to be executed.
+     * @param initialValues The initial values for the program.
+     * @param printTree A boolean value indicating whether the parse tree should be printed or not. Default value is false.
+     * @param si The system interface to be used for the execution. Default is an instance of ExtendedCollectorSystemInterface.
+     * @param configuration The configuration for the execution of the program.
+     * @param trimEnd A boolean value indicating whether the output should be trimmed or not. Default value is true.
+     *
+     * @return A list of strings representing the output of the program. If trimEnd is true, the strings are trimmed.
+     */
     @Deprecated(
         message = "This function does not provide all the features of Jariko",
         replaceWith = ReplaceWith(expression = "String.outputOf()", imports = ["com.smeup.rpgparser.AbstractTest.outputOf"]),
@@ -104,7 +114,8 @@ abstract class AbstractTest {
         initialValues: Map<String, Value> = mapOf(),
         printTree: Boolean = false,
         si: CollectorSystemInterface = ExtendedCollectorSystemInterface(),
-        configuration: Configuration = Configuration()
+        configuration: Configuration = Configuration(),
+        trimEnd: Boolean = true
     ): List<String> {
         return outputOf(
             programName = programName,
@@ -112,7 +123,8 @@ abstract class AbstractTest {
             printTree = printTree,
             si = si,
             compiledProgramsDir = getTestCompileDir(),
-            configuration = configuration
+            configuration = configuration,
+            trimEnd = trimEnd
         )
     }
 
@@ -141,9 +153,9 @@ abstract class AbstractTest {
      * @param initialSQL The initial SQL statements to be executed before the program.
      * @param inputParms The input parameters for the program.
      * @param configuration The configuration for the execution of the program.
-     * @param trimOutput A boolean value indicating whether the output should be trimmed or not. Default value is true.
+     * @param trimEnd A boolean value indicating whether the output should be trimmed or not. Default value is true.
      *
-     * @return A list of strings representing the output of the program. If trimOutput is true, the strings are trimmed.
+     * @return A list of strings representing the output of the program. If trimEnd is true, the strings are trimmed.
      */
     fun outputOfDBPgm(
         programName: String,
@@ -151,7 +163,7 @@ abstract class AbstractTest {
         initialSQL: List<String> = emptyList(),
         inputParms: Map<String, Value> = mapOf(),
         configuration: Configuration = Configuration(options = Options(muteSupport = true)),
-        trimOutput: Boolean = true
+        trimEnd: Boolean = true
     ): List<String> {
         return com.smeup.rpgparser.db.utilities.outputOfDBPgm(
             programName = programName,
@@ -159,7 +171,7 @@ abstract class AbstractTest {
             initialSQL = initialSQL,
             inputParms = inputParms,
             configuration = configuration.adaptForTestCase(this),
-            trimOutput = trimOutput
+            trimEnd = trimEnd
         )
     }
 
@@ -229,17 +241,17 @@ abstract class AbstractTest {
     /**
      * Executes a program and returns the output as a list of displayed messages.
      *
-     * @param trimOutput A boolean value indicating whether the output should be trimmed or not. Default value is true.
+     * @param trimEnd A boolean value indicating whether the output should be trimmed or not. Default value is true.
      *
-     * @return A list of strings representing the output of the program. If trimOutput is true, the strings are trimmed.
+     * @return A list of strings representing the output of the program. If trimEnd is true, the strings are trimmed.
      */
-    protected fun String.outputOf(trimOutput: Boolean = true): List<String> {
+    protected fun String.outputOf(trimEnd: Boolean = true): List<String> {
         val messages = mutableListOf<String>()
         val systemInterface = JavaSystemInterface().apply {
             onDisplay = { message, _ -> messages.add(message) }
         }
         executePgm(programName = this, systemInterface = systemInterface)
-        return if (trimOutput) messages.map { it.trim() } else messages
+        return if (trimEnd) messages.map { it.trimEnd() } else messages
     }
 
     private fun createSimpleReloadConfig(): SimpleReloadConfig? {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/dbTestUtils.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/dbTestUtils.kt
@@ -86,6 +86,17 @@ fun execute(sqlStatements: List<String>) {
     }
 }
 
+/**
+ * Executes a DB program and returns the output.
+ *
+ * @param programName The name of the program to be executed.
+ * @param metadata The metadata of the files used in the program.
+ * @param initialSQL The initial SQL statements to be executed before the program.
+ * @param inputParms The input parameters for the program.
+ * @param configuration The configuration for the execution of the program.
+ *
+ * @return A list of strings representing the output of the program. The strings are trimmed.
+ */
 fun outputOfDBPgm(
     programName: String,
     metadata: List<FileMetadata>,
@@ -119,5 +130,5 @@ fun outputOfDBPgm(
         }
     )
     commandLineProgram.singleCall(parms, configuration)
-    return si.displayed
+    return si.displayed.map { it.trim() }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/dbTestUtils.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/dbTestUtils.kt
@@ -26,6 +26,7 @@ import com.smeup.rpgparser.interpreter.FileMetadata
 import com.smeup.rpgparser.interpreter.Value
 import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
 import org.hsqldb.Server
+import java.io.DataOutput
 import java.io.File
 import java.sql.Connection
 import java.sql.DriverManager
@@ -94,15 +95,17 @@ fun execute(sqlStatements: List<String>) {
  * @param initialSQL The initial SQL statements to be executed before the program.
  * @param inputParms The input parameters for the program.
  * @param configuration The configuration for the execution of the program.
+ * @param trimOutput A boolean value indicating whether the output should be trimmed or not. Default value is true.
  *
- * @return A list of strings representing the output of the program. The strings are trimmed.
+ * @return A list of strings representing the output of the program. If trimOutput is true, the strings are trimmed.
  */
 fun outputOfDBPgm(
     programName: String,
     metadata: List<FileMetadata>,
     initialSQL: List<String>,
     inputParms: Map<String, Value> = mapOf(),
-    configuration: Configuration
+    configuration: Configuration,
+    trimOutput: Boolean = true
 ): List<String> {
 
     val si = CollectorSystemInterface()
@@ -130,5 +133,5 @@ fun outputOfDBPgm(
         }
     )
     commandLineProgram.singleCall(parms, configuration)
-    return si.displayed.map { it.trim() }
+    return if (trimOutput) si.displayed.map { it.trim() } else si.displayed
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/dbTestUtils.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/dbTestUtils.kt
@@ -26,7 +26,6 @@ import com.smeup.rpgparser.interpreter.FileMetadata
 import com.smeup.rpgparser.interpreter.Value
 import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
 import org.hsqldb.Server
-import java.io.DataOutput
 import java.io.File
 import java.sql.Connection
 import java.sql.DriverManager

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/dbTestUtils.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/dbTestUtils.kt
@@ -94,9 +94,9 @@ fun execute(sqlStatements: List<String>) {
  * @param initialSQL The initial SQL statements to be executed before the program.
  * @param inputParms The input parameters for the program.
  * @param configuration The configuration for the execution of the program.
- * @param trimOutput A boolean value indicating whether the output should be trimmed or not. Default value is true.
+ * @param trimEnd A boolean value indicating whether the output should be trimmed or not. Default value is true.
  *
- * @return A list of strings representing the output of the program. If trimOutput is true, the strings are trimmed.
+ * @return A list of strings representing the output of the program. If trimEnd is true, the strings are trimmed.
  */
 fun outputOfDBPgm(
     programName: String,
@@ -104,7 +104,7 @@ fun outputOfDBPgm(
     initialSQL: List<String>,
     inputParms: Map<String, Value> = mapOf(),
     configuration: Configuration,
-    trimOutput: Boolean = true
+    trimEnd: Boolean = true
 ): List<String> {
 
     val si = CollectorSystemInterface()
@@ -132,5 +132,5 @@ fun outputOfDBPgm(
         }
     )
     commandLineProgram.singleCall(parms, configuration)
-    return if (trimOutput) si.displayed.map { it.trim() } else si.displayed
+    return if (trimEnd) si.displayed.map { it.trimEnd() } else si.displayed
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -100,7 +100,7 @@ open class InterpreterTest : AbstractTest() {
         val si = CollectorSystemInterface()
         val logHandler = ListLogHandler()
         execute(cu, mapOf("ppdat" to StringValue(input)), si, listOf(logHandler))
-        assertEquals(listOf("FIBONACCI OF: ${input.padEnd(8)} IS: $output"), si.displayed)
+        assertEquals(listOf("FIBONACCI OF: ${input.padEnd(8)} IS: $output"), si.displayed.map { it.trim() })
         assertEquals(logHandler.getExecutedSubroutineNames()[0], "FIB")
     }
 
@@ -153,7 +153,7 @@ open class InterpreterTest : AbstractTest() {
         val logHandler = ListLogHandler()
         si.programs["CALCFIB"] = rpgProgram("CALCFIB")
         execute(cu, mapOf("ppdat" to StringValue("10")), si, listOf(logHandler))
-        assertEquals(listOf("FIBONACCI OF: 10       IS: 55"), si.displayed)
+        assertEquals(listOf("FIBONACCI OF: 10       IS: 55"), si.displayed.map { it.trim() })
         assertEquals(1, logHandler.getExecutedSubroutines().size)
     }
 
@@ -192,7 +192,7 @@ open class InterpreterTest : AbstractTest() {
         rpgProgram.execute(si, linkedMapOf("ppdat" to StringValue("10")))
         assertEquals(1, rpgProgram.params().size)
         assertEquals(ProgramParam("ppdat", StringType(8, false)), rpgProgram.params()[0])
-        assertEquals(listOf("FIBONACCI OF: 10       IS: 55"), si.displayed)
+        assertEquals(listOf("FIBONACCI OF: 10       IS: 55"), si.displayed.map { it.trim() })
     }
 
     @Test
@@ -741,7 +741,7 @@ Test 6
         }
         execute("CAL01", emptyMap(), si)
         assertTrue(javaPgmCalled, "Java pgm CAL02 was not called")
-        assertEquals(si.displayed, listOf("1"))
+        assertEquals(si.displayed.map { it.trim() }, listOf("1"))
     }
 
     @Test
@@ -793,12 +793,12 @@ Test 6
 
     @Test
     fun executeDOVAR01_ModifyingEndVarAffectsDO() {
-        assertEquals(outputOf("DOVAR01"), listOf("N =101", "I =96"))
+        assertEquals("DOVAR01".outputOf(), listOf("N = 101", "I = 96"))
     }
 
     @Test
     fun executeDOVAR02_ModifyingStartVarDoesntAffectDO() {
-        assertEquals(outputOf("DOVAR02"), listOf("N =11", "I =6"))
+        assertEquals("DOVAR02".outputOf(), listOf("N = 11", "I = 6"))
     }
 
     @Test
@@ -2101,7 +2101,7 @@ Test 6
         val systemInterface = JavaSystemInterface().apply {
             this.onDisplay = { message, _ ->
                 println(message)
-                console.add(message)
+                console.add(message.trim())
             }
         }
         executePgm(

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/CopyTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/CopyTest.kt
@@ -465,7 +465,7 @@ class CopyTest {
             nameOrSource = pgm,
             programFinders = listOf(DirRpgProgramFinder(Paths.get("src", "test", "resources").toFile())),
             systemInterface = JavaSystemInterface().apply {
-                onDisplay = { mess, _ -> message = mess }
+                onDisplay = { mess, _ -> message = mess.trim() }
             }
         ).singleCall(listOf(), configuration = Configuration().apply {
             jarikoCallback = JarikoCallback().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/testing_utils.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/testing_utils.kt
@@ -510,17 +510,31 @@ fun assertStartsWith(lines: List<String>, value: String) {
     assertTrue(lines.get(0).startsWith(value), Assert.format("Output not matching", value, lines))
 }
 
+/**
+ * Executes a program and returns the output as a list of displayed messages.
+ *
+ * @param programName The name of the program to be executed.
+ * @param initialValues The initial values for the program.
+ * @param printTree A boolean value indicating whether the parse tree should be printed or not. Default value is false.
+ * @param si The system interface to be used for the execution. Default is an instance of ExtendedCollectorSystemInterface.
+ * @param compiledProgramsDir The directory where the compiled programs are located.
+ * @param configuration The configuration for the execution of the program.
+ * @param trimEnd A boolean value indicating whether the output should be trimmed or not. Default value is true.
+ *
+ * @return A list of strings representing the output of the program. If trimEnd is true, the strings are trimmed.
+ */
 fun outputOf(
     programName: String,
     initialValues: Map<String, Value> = mapOf(),
     printTree: Boolean = false,
     si: CollectorSystemInterface = ExtendedCollectorSystemInterface(),
     compiledProgramsDir: File?,
-    configuration: Configuration = Configuration()
+    configuration: Configuration = Configuration(),
+    trimEnd: Boolean = true
 ): List<String> {
     execute(programName, initialValues, logHandlers = SimpleLogHandler.fromFlag(TRACE), printTree = printTree, si = si,
         compiledProgramsDir = compiledProgramsDir, configuration = configuration)
-    return si.displayed.map(String::trimEnd)
+    return if (trimEnd) si.displayed.map(String::trimEnd) else si.displayed
 }
 
 const val TRACE = false


### PR DESCRIPTION
## Description

`%CHAR` fix
When the argument is a `StringValue`  instance, it trims anyway the result , also if `StringValue.varying` is `false`.

This change had an impact of all tests that makes comparisons between expected and actual value by using the `DSPLY` opcode.
In order to reduce as much as possible the impact of this change, I have changed the default behavior of some utility function.

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
