### PR TITLE
Real literal assigment scale error

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -205,6 +205,8 @@ fun coerce(value: Value, type: Type): Value {
                     if (type.decimalDigits < value.value.scale()) {
                         val roundingMode = if (value.isPositive()) RoundingMode.FLOOR else RoundingMode.CEILING
                         return DecimalValue(value.value.setScale(type.decimalDigits, roundingMode))
+                    } else {
+                        return DecimalValue(value.value.setScale(type.decimalDigits))
                     }
                     return value
                 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -883,7 +883,7 @@ Test 6
             "%INT",
             "1234",
             "%DEC",
-            "1.5"
+            "1.50"
         )
         assertEquals(expected, outputOf("UNLIMIT_BIF"))
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -37,4 +37,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T02_A30".outputOf())
     }
+
+    @Test
+    fun executeT04_A40() {
+        val expected = listOf("A40_P1(122469.88)A40_P2(987.22)A40_P3(123456.10)A40_P4(121028170.03)")
+        assertEquals(expected, "smeup/T04_A40".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A40.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A40.rpgle
@@ -1,0 +1,18 @@
+     D £DBG_Str        S             100
+     D A40_P1          S             26P 2
+     D A40_P2          S             26P 2
+     D A40_P3          S             26P 2
+     D A40_P4          S             26P 2
+
+     C*                   EVAL      £DBG_Pas='P04'
+     C                   EVAL      A40_P2 = 987.22
+     C                   EVAL      A40_P3 = 123456.1
+     C                   EVAL      A40_P1 = A40_P3 - A40_P2 + 1
+     C                   EVAL      A40_P4 = A40_P1 * A40_P2 + A40_P3 - 1
+     C                   EVAL      £DBG_Str = 'A40_P1('+%CHAR(A40_P1)+')'
+     C                                     +'A40_P2('+%CHAR(A40_P2)+')'
+     C                                     +'A40_P3('+%CHAR(A40_P3)+')'
+     C                                     +'A40_P4('+%CHAR(A40_P4)+')'
+     C     £DBG_Str      DSPLY
+
+     C* expected: A40_P1(122469.88)A40_P2(987.22)A40_P3(123456.10)A40_P4(121028170.03)


### PR DESCRIPTION
## Description
In assignment operations the `DecimalValue` could not take in account of the target reference type.
As side effect this issue took to a wrong execution of `%CHAR` bif.
For example in this case:
```
     D £DBG_Str        S             100
     D A40_P3          S             26P 2
     C                   EVAL      A40_P3 = 123456.1
     C                   EVAL      £DBG_Str = %CHAR(A40_P1)
```
the content of `£DBG_Str` was `'123456.1'` instead of `'123456.10'`

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory