### PR TITLE
Feature/nw23001440/handle param initial value in callstmt

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -610,6 +610,7 @@ data class CallStmt(
 
         val params = this.params.mapIndexed { index, it ->
             if (it.dataDefinition != null) {
+                // handle declaration of new variable
                 if (it.dataDefinition.initializationValue != null) {
                     if (!interpreter.exists(it.param.name)) {
                         interpreter.assign(it.dataDefinition, interpreter.eval(it.dataDefinition.initializationValue))
@@ -623,6 +624,14 @@ data class CallStmt(
                     if (!interpreter.exists(it.param.name)) {
                         interpreter.assign(it.dataDefinition, interpreter.eval(BlanksRefExpr()))
                     }
+                }
+            } else {
+                // handle initialization value without declaration of new variables
+                // change the value of parameter with initialization value
+                if (it.initializationValue != null) {
+                    interpreter.assign(
+                        interpreter.dataDefinitionByName(it.param.name)!!,
+                        interpreter.eval(it.initializationValue))
                 }
             }
             require(program.params().size > index) {
@@ -877,7 +886,8 @@ data class PlistParam(
     val param: ReferenceByName<AbstractDataDefinition>,
     // TODO @Derived????
     @Derived val dataDefinition: InStatementDataDefinition? = null,
-    override val position: Position? = null
+    override val position: Position? = null,
+    val initializationValue: Expression? = null
 ) : Node(position), StatementThatCanDefineData {
     override fun dataDefinition(): List<InStatementDataDefinition> {
         if (dataDefinition != null) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1003,13 +1003,15 @@ internal fun CsPLISTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 
 internal fun CsPARMContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): PlistParam {
     val paramName = this.cspec_fixed_standard_parts().result.text
+    val initializationValue = this.cspec_fixed_standard_parts().factor2Expression(conf)
     val position = toPosition(conf.considerPosition)
     return PlistParam(
         ReferenceByName(paramName), this.cspec_fixed_standard_parts().toDataDefinition(
             paramName,
             position,
             conf
-        ), position
+        ), position,
+        initializationValue
     )
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1003,7 +1003,12 @@ internal fun CsPLISTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 
 internal fun CsPARMContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): PlistParam {
     val paramName = this.cspec_fixed_standard_parts().result.text
-    val initializationValue = this.cspec_fixed_standard_parts().factor2Expression(conf)
+    // initialization value valid only if there isn't a variable declaration
+    val initializationValue = if (this.cspec_fixed_standard_parts().len.asInt() == null) {
+        this.cspec_fixed_standard_parts().factor2Expression(conf)
+    } else {
+        null
+    }
     val position = toPosition(conf.considerPosition)
     return PlistParam(
         ReferenceByName(paramName), this.cspec_fixed_standard_parts().toDataDefinition(

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -724,6 +724,11 @@ Test 6
     }
 
     @Test
+    fun executeCALLER2_callProgramPassingStringValueDirectlyOnParm() {
+        assertEquals(listOf("ABCDEFGHIJ"), outputOf("CALLER2"))
+    }
+
+    @Test
     fun executeCAL01_callingJavaPgm() {
         val si = CollectorSystemInterface()
         var javaPgmCalled = false

--- a/rpgJavaInterpreter-core/src/test/resources/CALLED2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/CALLED2.rpgle
@@ -1,0 +1,8 @@
+﻿     D STR10           S             10
+      *
+     C     *ENTRY        PLIST
+     C                   PARM                    STR10
+      *
+     C                   EVAL      STR10=%TRIM(STR10)+'FGHIJ'
+      *
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/CALLER2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/CALLER2.rpgle
@@ -1,0 +1,8 @@
+﻿     D STR10           S             10
+      *
+     C                   CALL      'CALLED2'
+     C                   PARM      'ABCDE'       STR10
+      * Expected 'ABCDEFGHIJ'
+     C     STR10         DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Handle initial value of parameters in `CALL` statement.

```rpgle
     C                   CALL      [PGM_NAME]
     C                   PARM      [INITIAL VALUE]  STR10
```

that's different to variable declaration on `CALL` statement

```rpgle
     C                   CALL      [PGM_NAME]
     C                   PARM      [INITIAL VALUE]  STR10     10
```

In the first case variable `STR10` has already declared. The variable is cleaned and reassigned with `[INITIAL VALUE]'. In the second case `STR10` is declared directly in the `CALL` statement-

Related to # (issue)
Program `MULANGT12` - `A01` - `P04`: `CALL` doesn't handle initialization value of parameters.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
