### PR TITLE
Bugfix/nw23001440/sorta ds overlay

### DIFF
--- a/rpgJavaInterpreter-core/src/main/java/com/smeup/rpgparser/utils/EBCDICComparator.java
+++ b/rpgJavaInterpreter-core/src/main/java/com/smeup/rpgparser/utils/EBCDICComparator.java
@@ -23,12 +23,8 @@ import java.util.Comparator;
 
 public class EBCDICComparator implements Comparator<String> {
 
-    private final String EBCDIC_CODE = "CP037";
     private final Charset STANDARD_CHARSET = StandardCharsets.ISO_8859_1;
     private int order = 1;
-
-    public EBCDICComparator() {
-    }
 
     public EBCDICComparator(boolean descend) {
         if (descend)
@@ -44,6 +40,7 @@ public class EBCDICComparator implements Comparator<String> {
         byte[] b1;
         byte[] b2;
         try {
+            String EBCDIC_CODE = "CP037";
             b1 = s1.getBytes(EBCDIC_CODE);
             b2 = s2.getBytes(EBCDIC_CODE);
         } catch (UnsupportedEncodingException e) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sorta.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sorta.kt
@@ -1,7 +1,6 @@
 package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.utils.EBCDICComparator
-import java.nio.charset.Charset
 
 /**
  * The charset should be sort of system setting
@@ -9,7 +8,7 @@ import java.nio.charset.Charset
  * Cp0280   EBCDIC ITALIAN
  * See: https://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.idad400/ccsids.htm
  */
-fun sortA(value: Value, arrayType: ArrayType, charset: Charset) {
+fun sortA(value: Value, arrayType: ArrayType) {
     val ascend: Boolean = arrayType.ascend == null || arrayType.ascend == true
 
     when (value) {
@@ -51,12 +50,12 @@ fun sortA(value: Value, arrayType: ArrayType, charset: Charset) {
                 .sortedBy { sortedValues.indexOf(it.value) }
                 .associate { it.toPair() }
 
-            var containerValue = ""
+            var containerValue = StringBuilder()
             sortedMap.keys.forEach { key ->
-                containerValue += elements[key - 1]
+                containerValue.append(elements[key - 1])
             }
             // return value
-            value.container.value = containerValue
+            value.container.value = containerValue.toString()
         }
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sorta.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sorta.kt
@@ -1,5 +1,6 @@
 package com.smeup.rpgparser.interpreter
 
+import com.smeup.rpgparser.utils.EBCDICComparator
 import java.nio.charset.Charset
 
 /**
@@ -43,16 +44,17 @@ fun sortA(value: Value, arrayType: ArrayType, charset: Charset) {
             } else {
                 (value.field.overlayingOn as FieldDefinition).descend
             }
-            val sortedMap = if (descend) {
-                indexesMap.toList().sortedByDescending { it.second }.toMap()
-            } else {
-                indexesMap.toList().sortedBy { it.second }.toMap()
-            }
+            // sort using EBCDICComparator
+            val comparator = EBCDICComparator(descend)
+            val sortedValues = indexesMap.values.sortedWith(comparator)
+            val sortedMap = indexesMap.entries
+                .sortedBy { sortedValues.indexOf(it.value) }
+                .associate { it.toPair() }
+
             var containerValue = ""
             sortedMap.keys.forEach { key ->
                 containerValue += elements[key - 1]
             }
-
             // return value
             value.container.value = containerValue
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sorta.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sorta.kt
@@ -1,0 +1,97 @@
+package com.smeup.rpgparser.interpreter
+
+import com.smeup.rpgparser.utils.EBCDICComparator
+import java.nio.charset.Charset
+import java.util.*
+
+/**
+ * The charset should be sort of system setting
+ * Cp037    EBCDIC US
+ * Cp0280   EBCDIC ITALIAN
+ * See: https://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.idad400/ccsids.htm
+ */
+fun sortA(value: Value, arrayType: ArrayType, charset: Charset) {
+    val ascend: Boolean = arrayType.ascend == null || arrayType.ascend == true
+
+    when (value) {
+        is ConcreteArrayValue -> {
+            // TODO pass the correct charset to the default sorting algorithm
+            if (ascend) {
+                value.elements.sort()
+            } else {
+                value.elements.sortByDescending { it }
+            }
+        }
+        is ProjectedArrayValue -> {
+            require(value.field.type is ArrayType)
+            val strings = value.field.type.element is StringType
+            val n = value.arrayLength
+            val multiplier = if (value.field.descend) 1 else -1
+            // the good old Bubble Sort
+            /*for (i in 1..(value.arrayLength - 1)) {
+                for (j in 1..(n - i)) {
+                    val compared =
+                        if (strings) {
+                            value.getElement(j).asString().compare(value.getElement(j + 1).asString(), charset, value.field.descend)
+                        } else {
+                            value.getElement(j).compareTo(value.getElement(j + 1)) * multiplier
+                        }
+                    if (compared > 0) {
+                        // TODO support data structure swap
+                        // For an array data structure, the keyed-ds-array operand is a qualified name
+                        // consisting of the array to be sorted followed by the subfield to be used as
+                        // a key for the sort.
+                        // Swap
+                        val tmp = value.getElement(j + 1)
+                        value.setElement(j + 1, value.getElement(j))
+                        value.setElement(j, tmp)
+                    }
+                }
+            }*/
+
+            val numOfElements = value.arrayLength
+            val totalLengthOfAllElements = value.container.len
+            val elementSize = totalLengthOfAllElements / numOfElements
+
+            // Extract from each array element, its 'key' value (the subfield) to order by, then
+            // store the key into 'keysToBeOrderedBy'
+            val keysToBeOrderedBy = Array(numOfElements) { _ -> "" }
+            var startElement = 0
+            var endElement = elementSize
+            (0 until numOfElements).forEach { i ->
+                value.container.value.substring(startElement, endElement).apply { keysToBeOrderedBy[i] = this }
+                startElement += elementSize
+                endElement += elementSize
+            }
+
+            // Create a TreeMap with order direction (ascend/descend) needed to
+            // store ordered elements.
+            val comparator = EBCDICComparator(value.field.descend)
+            val orderedElements: MutableMap<String, MutableList<String>> = TreeMap(comparator)
+
+            // Array to ordered Treemap
+            keysToBeOrderedBy.indices.forEachIndexed { _, i ->
+                with(
+                    orderedElements,
+                    fun MutableMap<String, MutableList<String>>.() {
+                        var add = computeIfAbsent(
+                            keysToBeOrderedBy[i].substring(
+                                value.field.calculatedStartOffset!!.toInt(),
+                                value.field.calculatedEndOffset!!.toInt()
+                            )
+                        ) { ArrayList() }.add(keysToBeOrderedBy[i])
+                    }
+                )
+            }
+
+            // Set container value with reordered elements
+            var containerValue = ""
+            orderedElements.forEach { (_: String?, v: List<String>) ->
+                v.forEach { s ->
+                    containerValue += s
+                }
+            }
+            value.container.value = containerValue
+        }
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -18,7 +18,6 @@ package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
-import com.smeup.rpgparser.utils.EBCDICComparator
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal
@@ -225,98 +224,6 @@ data class UnlimitedStringValue(var value: String) : AbstractStringValue {
     override fun copy() = UnlimitedStringValue(value)
 
     override fun getWrappedString() = value
-}
-
-/**
- * The charset should be sort of system setting
- * Cp037    EBCDIC US
- * Cp0280   EBCDIC ITALIAN
- * See: https://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.idad400/ccsids.htm
- */
-fun sortA(value: Value, arrayType: ArrayType, charset: Charset) {
-    val ascend: Boolean = arrayType.ascend == null || arrayType.ascend == true
-
-    when (value) {
-        is ConcreteArrayValue -> {
-            // TODO pass the correct charset to the default sorting algorithm
-            if (ascend) {
-                value.elements.sort()
-            } else {
-                value.elements.sortByDescending { it }
-            }
-        }
-        is ProjectedArrayValue -> {
-            require(value.field.type is ArrayType)
-            val strings = value.field.type.element is StringType
-            val n = value.arrayLength
-            val multiplier = if (value.field.descend) 1 else -1
-            // the good old Bubble Sort
-            /*for (i in 1..(value.arrayLength - 1)) {
-                for (j in 1..(n - i)) {
-                    val compared =
-                        if (strings) {
-                            value.getElement(j).asString().compare(value.getElement(j + 1).asString(), charset, value.field.descend)
-                        } else {
-                            value.getElement(j).compareTo(value.getElement(j + 1)) * multiplier
-                        }
-                    if (compared > 0) {
-                        // TODO support data structure swap
-                        // For an array data structure, the keyed-ds-array operand is a qualified name
-                        // consisting of the array to be sorted followed by the subfield to be used as
-                        // a key for the sort.
-                        // Swap
-                        val tmp = value.getElement(j + 1)
-                        value.setElement(j + 1, value.getElement(j))
-                        value.setElement(j, tmp)
-                    }
-                }
-            }*/
-
-            val numOfElements = value.arrayLength
-            val totalLengthOfAllElements = value.container.len
-            val elementSize = totalLengthOfAllElements / numOfElements
-
-            // Extract from each array element, its 'key' value (the subfield) to order by, then
-            // store the key into 'keysToBeOrderedBy'
-            val keysToBeOrderedBy = Array(numOfElements) { _ -> "" }
-            var startElement = 0
-            var endElement = elementSize
-            (0 until numOfElements).forEach { i ->
-                value.container.value.substring(startElement, endElement).apply { keysToBeOrderedBy[i] = this }
-                startElement += elementSize
-                endElement += elementSize
-            }
-
-            // Create a TreeMap with order direction (ascend/descend) needed to
-            // store ordered elements.
-            val comparator = EBCDICComparator(value.field.descend)
-            val orderedElements: MutableMap<String, MutableList<String>> = TreeMap(comparator)
-
-            // Array to ordered Treemap
-            keysToBeOrderedBy.indices.forEachIndexed { _, i ->
-                with(
-                    orderedElements,
-                    fun MutableMap<String, MutableList<String>>.() {
-                        var add = computeIfAbsent(
-                            keysToBeOrderedBy[i].substring(
-                                value.field.calculatedStartOffset!!.toInt(),
-                                value.field.calculatedEndOffset!!.toInt()
-                            )
-                        ) { ArrayList() }.add(keysToBeOrderedBy[i])
-                    }
-                )
-            }
-
-            // Set container value with reordered elements
-            var containerValue = ""
-            orderedElements.forEach { (_: String?, v: List<String>) ->
-                v.forEach { s ->
-                    containerValue += s
-                }
-            }
-            value.container.value = containerValue
-        }
-    }
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1471,8 +1471,7 @@ data class SortAStmt(val target: Expression, override val position: Position? = 
     override fun execute(interpreter: InterpreterCore) {
         sortA(
             value = interpreter.eval(target),
-            arrayType = target.type() as ArrayType,
-            charset = interpreter.getLocalizationContext().charset
+            arrayType = target.type() as ArrayType
         )
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -1,7 +1,6 @@
 package com.smeup.rpgparser.evaluation
 
 import com.smeup.rpgparser.AbstractTest
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -40,7 +39,6 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
-    @Ignore
     fun executeT02_A40() {
         val expected = listOf("DS4_FL1(NNNNNFFFFFMMMMMGGGGGAAAAAZZZZZ)", "DS4_FL2(AAAAAZZZZZMMMMMGGGGGNNNNNFFFFF)")
         assertEquals(expected, "smeup/T02_A40".outputOf())

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -1,6 +1,7 @@
 package com.smeup.rpgparser.evaluation
 
 import com.smeup.rpgparser.AbstractTest
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -36,6 +37,13 @@ open class SmeupInterpreterTest : AbstractTest() {
             }
         )
         assertEquals(expected, "smeup/T02_A30".outputOf())
+    }
+
+    @Test
+    @Ignore
+    fun executeT02_A40() {
+        val expected = listOf("DS4_FL1(NNNNNFFFFFMMMMMGGGGGAAAAAZZZZZ)", "DS4_FL2(AAAAAZZZZZMMMMMGGGGGNNNNNFFFFF)")
+        assertEquals(expected, "smeup/T02_A40".outputOf())
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A40.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A40.rpgle
@@ -1,0 +1,24 @@
+     D £DBG_Str        S             50
+     D                 DS
+     D A40_DS4                      100    DIM(5) DESCEND
+     D  DS4_FL1                       9    OVERLAY(A40_DS4:1)
+     D  DS4_FL2                      10    OVERLAY(A40_DS4:*NEXT)
+      *
+     C                   EVAL      A40_DS4(1) = 'AAAAAZZZZZ'
+     C                   EVAL      A40_DS4(2) = 'NNNNNFFFFF'
+     C                   EVAL      A40_DS4(3) = 'MMMMMGGGGG'
+     C                   SORTA     DS4_FL1
+     C                   EVAL      £DBG_Str='DS4_FL1('+%TRIMR(A40_DS4(1))
+     C                                                +%TRIMR(A40_DS4(2))
+     C                                                +%TRIMR(A40_DS4(3))+')'
+      * Expect 'DS4_FL1(NNNNNFFFFFMMMMMGGGGGAAAAAZZZZZ)'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SORTA     DS4_FL2
+     C                   EVAL      £DBG_Str='DS4_FL2('+%TRIMR(A40_DS4(1))
+     C                                                +%TRIMR(A40_DS4(2))
+     C                                                +%TRIMR(A40_DS4(3))+')'
+      * Expect 'DS4_FL2(AAAAAZZZZZMMMMMGGGGGNNNNNFFFFF)'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Fix `SORTA` statement with `OVERLAY` keyword in Data Structure fields.

- Refactor `sorta` function: move from `values.kt` to separated kotlin file (d19639a6eb3920303ded84073d04ba4976ddec64). I perform the refactor because the `values.kt` contains the Data Type values and `sorta` was and implementation of operative code.
- Fix `sorta` function to properly align entire Data Structure according to factor 2. (952bb06bd148a0c63e46677ab646570f9ec7ae3a, a21abe9a72ebc77de2eab0c1fc4d68ea8b8e677f).
- I edited the `EBCDICComparator.java` according to IntelliJ directives.

Related to # (issue)
Program MULANGT02 - SEZ_A40 - P04

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
