### PR TITLE
Bugfix/nw23001440/handle return stmt

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -840,6 +840,8 @@ data class SetStmt(val valueSet: ValueSet, val indicators: List<AssignableExpres
 @Serializable
 data class ReturnStmt(val expression: Expression?, override val position: Position? = null) : Statement(position) {
     override fun execute(interpreter: InterpreterCore) {
+        // set the RT indicator always on
+        interpreter.getIndicators()[IndicatorType.RT.name.toIndicatorKey()] = BooleanValue.TRUE
         val returnValue = expression?.let { interpreter.eval(expression) }
         throw ReturnException(returnValue)
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -43,4 +43,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf("A40_P1(122469.88)A40_P2(987.22)A40_P3(123456.10)A40_P4(121028170.03)")
         assertEquals(expected, "smeup/T04_A40".outputOf())
     }
+
+    @Test
+    fun executeT04_A20() {
+        val expected = listOf("CALL_1(MULANGT04 , 1, MULANGTB10: MULANGT04 chiamata 1                  ) CALL_2(MULANGT04 , 3, MULANGTB10: MULANGT04 chiamata 1                  )")
+        assertEquals(expected, "smeup/T04_A20".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -45,17 +45,18 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
+    fun executeT04_A20() {
+        val expected = listOf("CALL_1(MULANGT04 , 1, MULANGTB10: MULANGT04 chiamata 1                  ) CALL_2(MULANGT04 , 3, MULANGTB10: MULANGT04 chiamata 1                  )")
+        assertEquals(expected, "smeup/T04_A20".outputOf())
+    }
+
+    @Test
     fun executeT04_A40() {
         val expected = listOf("A40_P1(122469.88)A40_P2(987.22)A40_P3(123456.10)A40_P4(121028170.03)")
         assertEquals(expected, "smeup/T04_A40".outputOf())
     }
 
     @Test
-    fun executeT04_A20() {
-        val expected = listOf("CALL_1(MULANGT04 , 1, MULANGTB10: MULANGT04 chiamata 1                  ) CALL_2(MULANGT04 , 3, MULANGTB10: MULANGT04 chiamata 1                  )")
-        assertEquals(expected, "smeup/T04_A20".outputOf())
-    }
-    
     fun executeT10_A20() {
         val expected = listOf("172.670-22146.863-.987000000")
         assertEquals(expected, "smeup/T10_A20".outputOf())

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MULANGTB10.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MULANGTB10.rpgle
@@ -1,0 +1,20 @@
+     D B10_P1          S             10
+     D B10_P2          S              2  0
+     D B10_P3          S             50
+      *
+     D B10_A50         S             50
+      *---------------------------------------------------------------------
+     C     *ENTRY        PLIST
+     C                   PARM                    B10_P1
+     C                   PARM                    B10_P2
+     C                   PARM                    B10_P3
+      *
+     C                   IF        B10_P2=1
+     C                   EVAL      B10_A50 ='MULANGTB10: '+%TRIMR(B10_P1)
+     C                                     +' chiamata '+%CHAR(B10_P2)
+     C                   ENDIF
+      *
+     C                   EVAL      B10_P3 = B10_A50
+      *
+     C*                   RETURN
+     C                   SETON                                        RT

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MULANGTB10.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MULANGTB10.rpgle
@@ -16,5 +16,4 @@
       *
      C                   EVAL      B10_P3 = B10_A50
       *
-     C*                   RETURN
-     C                   SETON                                        RT
+     C                   RETURN

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A20.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A20.rpgle
@@ -1,0 +1,30 @@
+     D £DBG_Str        S           2560
+     D A20_A10         S             10
+     D A20_P1          S             10    INZ('MULANGT04')
+     D A20_P2          S              2  0
+     D A20_P3          S             50
+      *
+     C                   CLEAR                   A20_P3
+     C                   CALL      'MULANGTB10'
+     C                   PARM                    A20_P1
+     C                   PARM      1             A20_P2
+     C                   PARM                    A20_P3
+     C                   EVAL      £DBG_Str='CALL_1('+A20_P1+', '
+     C                                     +%CHAR(A20_P2)
+     C                                     +', '+A20_P3+') '
+      *
+     C                   CLEAR                   A20_P3
+     C                   EVAL      A20_A10='MULANGTB10'
+     C                   CALL      A20_A10
+     C                   PARM                    A20_P1
+     C                   PARM      3             A20_P2
+     C                   PARM                    A20_P3
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                     +' CALL_2('+A20_P1+', '
+     C                                     +%CHAR(A20_P2)
+     C                                     +', '+A20_P3+') '
+      *
+      * Expect 'CALL_1(MULANGT04 , 1, MULANGTB10: MULANGT04 chiamata 1                  ) CALL_2(MULANGT04 , 3, MULANGTB10: MULANGT04 chiamata 1                  )'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Set the RT indicator always on in `ReturnStmt` + test case.

If the program finish with `ReturnStmt` the `RT` indicator always set. If the program finish with `ReturnStmt` and before it the `LR` statement was set `LR` indicator wins (see kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt 943).

Related to # (issue)
MULANGT04 - SEZ_A20 - P02

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
