### PR TITLE
Fix/nw23001440/fix cat statement

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1515,9 +1515,9 @@ data class CatStmt(
         } else {
             result
         } else if (blanks != null) {
-            (factor1 + blanks + factor2)
+            (factor1.trim() + blanks + factor2)
         } else {
-            (factor1 + factor2)
+            (factor1.trim() + factor2)
         }
 
         interpreter.assign(target, StringValue(result))

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1490,7 +1490,7 @@ data class CatStmt(
 
     override fun execute(interpreter: InterpreterCore) {
         val factor1: String? = if (left != null) {
-            interpreter.eval(left).asString().value;
+            interpreter.eval(left).asString().value
         } else {
             null
         }
@@ -1509,7 +1509,6 @@ data class CatStmt(
         }
         var result: String = interpreter.eval(target).asString().value
 
-        // handle factor 1 null
         result = if (factor1 == null) if (blanks != null) {
             (result.trim() + blanks + factor2)
         } else {
@@ -1521,45 +1520,7 @@ data class CatStmt(
         }
 
         interpreter.assign(target, StringValue(result))
-
-
-        /*val blanks = StringValue.blank(blanksInBetween)
-        val factor2 = interpreter.eval(right)
-        var result = interpreter.eval(target)
-        val resultLen = result.asString().length()
-        val concatenatedFactors: Value
-
-        if (null != left) {
-            val factor1 = interpreter.eval(left)
-            val f1Trimmed = (factor1 as StringValue).value.trim()
-            val factor1Trimmed = StringValue(f1Trimmed)
-            concatenatedFactors = if (blanksInBetween > 0) {
-                factor1Trimmed.concatenate(blanks).concatenate(factor2)
-            } else {
-                factor1.concatenate(factor2)
-            }
-        } else {
-            concatenatedFactors = if (!result.asString().isBlank()) {
-                result
-            } else if (blanksInBetween > 0) {
-                if (blanksInBetween >= resultLen) {
-                    result
-                } else {
-                    blanks.concatenate(factor2)
-                }
-            } else {
-                result
-            }
-        }
-        val concatenatedFactorsLen = concatenatedFactors.asString().length()
-        result = if (concatenatedFactorsLen >= resultLen) {
-            concatenatedFactors.asString().getSubstring(0, resultLen)
-        } else {
-            concatenatedFactors.concatenate(result.asString().getSubstring(concatenatedFactorsLen, resultLen))
-        }
-
-        interpreter.assign(target, result)
-        interpreter.log { CatStatementExecutionLog(interpreter.getInterpretationContext().currentProgramName, this, interpreter.eval(target)) }*/
+        interpreter.log { CatStatementExecutionLog(interpreter.getInterpretationContext().currentProgramName, this, interpreter.eval(target)) }
     }
 
     override fun dataDefinition(): List<InStatementDataDefinition> = dataDefinition?.let { listOf(it) } ?: emptyList()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1604,6 +1604,7 @@ internal fun ResultIndicatorContext.asIndex(): Int? {
 }
 
 internal fun CsCATContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): CatStmt {
+    val operationExtender = this.operationExtender?.text
     val position = toPosition(conf.considerPosition)
     val left = leftExpr(conf)
     val right = this.cspec_fixed_standard_parts().factor2Expression(conf) ?: throw UnsupportedOperationException("COMP operation requires factor 2: ${this.text} - ${position.atLine()}")
@@ -1624,7 +1625,8 @@ internal fun CsCATContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
         target = target,
         blanksInBetween = blanksInBetweenExpression,
         position = position,
-        dataDefinition = dataDefinition
+        dataDefinition = dataDefinition,
+        operationExtender = operationExtender
     )
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1607,12 +1607,14 @@ internal fun CsCATContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
     val position = toPosition(conf.considerPosition)
     val left = leftExpr(conf)
     val right = this.cspec_fixed_standard_parts().factor2Expression(conf) ?: throw UnsupportedOperationException("COMP operation requires factor 2: ${this.text} - ${position.atLine()}")
-    var blanksInBetween = 0
 
-    if (null != this.cspec_fixed_standard_parts().factor2.content2 &&
-            this.cspec_fixed_standard_parts().factor2.content2.children.size > 0) {
-        blanksInBetween = this.cspec_fixed_standard_parts().factor2.content2.children[0].toString().toInt()
-    }
+    val blanksInBetweenExpression: Expression? =
+        if (this.cspec_fixed_standard_parts().factor2.factorContent().size > 1) {
+            this.cspec_fixed_standard_parts().factor2.factorContent(1).toAst(conf)
+        } else {
+            null
+        }
+
     val target = this.cspec_fixed_standard_parts().resultExpression(conf) as AssignableExpression
     val result = this.cspec_fixed_standard_parts().result.text
     val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
@@ -1620,7 +1622,7 @@ internal fun CsCATContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
         left = left,
         right = right,
         target = target,
-        blanksInBetween = blanksInBetween,
+        blanksInBetween = blanksInBetweenExpression,
         position = position,
         dataDefinition = dataDefinition
     )

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2131,4 +2131,10 @@ Test 6
         val expected = listOf("(ABCDEF)", "(CDEFGH)", "(CDEF  )", "(AB CDE)", "(AB    )", "(99 XYZ)")
         assertEquals(expected, "CAT".outputOf())
     }
+
+    @Test
+    fun executeCATP() {
+        val expected = listOf("(ABCDEF)", "(CDEFGH)", "(CDEF  )", "(AB CDE)", "(AB    )", "(99 XYZ)")
+        assertEquals(expected, "CATP".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2125,4 +2125,10 @@ Test 6
     fun executeCONST02() {
         assertEquals(listOf("100"), outputOf("CONST02"))
     }
+
+    @Test
+    fun executeCAT() {
+        val expected = listOf("(ABCDEF)", "(CDEFGH)", "(CDEF  )", "(AB CDE)", "(AB    )", "(99 XYZ)")
+        assertEquals(expected, "CAT".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/MuteExecutionTest.kt
@@ -362,7 +362,7 @@ open class MuteExecutionTest : AbstractTest() {
         assertMuteExecutionSucceded("mute/MUTE12_15")
     }
 
-    @Test @Ignore
+    @Test
     fun executeMUTE13_17() {
         assertMuteExecutionSucceded("mute/MUTE13_17")
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -63,6 +63,12 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
+    fun executeT10_A70() {
+        val expected = listOf("CAT_1(MR. SMITH) CAT_2(RPG/400) CAT_3(RPG/4)", "CAT_1(ABC  XYZ ) CAT_2(Mr. Smith)", "CAT_1(RPG/400   )", "CAT_1(RPGIV     )")
+        assertEquals(expected, "smeup/T10_A70".outputOf())
+    }
+
+    @Test
     fun executeT16_A70() {
         val expected = listOf("A70_AR1(10) A70_AR2(20) A70_DS1(30) A70_AR3(10)")
         assertEquals(expected, "smeup/T16_A70".outputOf())

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/performance/Kute10_50.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/performance/Kute10_50.kt
@@ -78,7 +78,7 @@ class Kute10_50 : Kute() {
         globalSymbolTable[resultRef] = StringValue("XXXXXXXXXXXXXXXXXXXX")
 
         // Statement creation (similar to 'toAst' does)
-        val statement = catStmt(factor1DataRefExpr, factor2DataRefExpr, resultDataRefExpr, 0, null)
+        val statement = catStmt(factor1DataRefExpr, factor2DataRefExpr, resultDataRefExpr, IntLiteral(0), null)
 
         // Perform a pure kotlin loop
         var actualElapsedTimeInMillisec: Long = measureTimeMillis {
@@ -133,7 +133,7 @@ class Kute10_50 : Kute() {
     }
 
     private fun exec_CAT(statement: CatStmt) {
-        val blanksInBetween = statement.blanksInBetween
+        val blanksInBetween = eval(statement.blanksInBetween!!).asInt().value.toInt()
         val blanks = StringValue.blank(blanksInBetween)
         val factor2 = eval(statement.right)
         var result = eval(statement.target)
@@ -171,7 +171,7 @@ class Kute10_50 : Kute() {
         assign(statement.target, result)
     }
 
-    private fun catStmt(left: Expression?, right: Expression, target: AssignableExpression, blanksInBetween: Int, position: Position? = null): CatStmt {
+    private fun catStmt(left: Expression?, right: Expression, target: AssignableExpression, blanksInBetween: Expression?, position: Position? = null): CatStmt {
         return CatStmt(
                 left = left,
                 right = right,

--- a/rpgJavaInterpreter-core/src/test/resources/CAT.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/CAT.rpgle
@@ -1,0 +1,44 @@
+     D STR2            S              2    INZ('AB')
+     D STR3            S              3    INZ('XYZ')
+     D STR4            S              4    INZ('CDEF')
+     D STR6            S              6    INZ('GHIJKL')
+      *
+     D RES1            S              6
+     D RES2            S              6
+     D RES3            S              6    INZ('AB    ')
+     D RES4            S              6
+     D RES5            S              6    INZ('AB    ')
+     D RES6            S              6    INZ('99    ')
+     D DBG             S             52
+      *
+      * CAT('AB','CDEF') '      ' -> 'ABCDEF'
+     C     STR2          CAT       STR4          RES1
+     C                   EVAL      DBG='('+RES1+')'
+     C     DBG           DSPLY
+      *
+      * CAT('CDEF','GHIJKL') '      '  -> 'CDEFGH'
+     C     STR4          CAT       STR6          RES2
+     C                   EVAL      DBG='('+RES2+')'
+     C     DBG           DSPLY
+      *
+      * CAT('CD','EF') 'AB    ' -> 'CDEF  '
+     C     'CD'          CAT       'EF'          RES3
+     C                   EVAL      DBG='('+RES3+')'
+     C     DBG           DSPLY
+      *
+      * CAT('AB','CDEF':1) '      ' -> 'AB CDE'
+     C     STR2          CAT       STR4:1        RES4
+     C                   EVAL      DBG='('+RES4+')'
+     C     DBG           DSPLY
+      *
+      * CAT(-,'CDEF') 'AB    ' -> 'AB    '
+     C                   CAT       STR4          RES5
+     C                   EVAL      DBG='('+RES5+')'
+     C     DBG           DSPLY
+      *
+      * CAT(-,'XYZ':1) '99    ' -> '99 XYZ'
+     C                   CAT       STR3:1        RES6
+     C                   EVAL      DBG='('+RES6+')'
+     C     DBG           DSPLY
+      *
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/CATP.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/CATP.rpgle
@@ -1,0 +1,44 @@
+     D STR2            S              2    INZ('AB')
+     D STR3            S              3    INZ('XYZ')
+     D STR4            S              4    INZ('CDEF')
+     D STR6            S              6    INZ('GHIJKL')
+      *
+     D RES1            S              6
+     D RES2            S              6
+     D RES3            S              6    INZ('AB    ')
+     D RES4            S              6
+     D RES5            S              6    INZ('AB    ')
+     D RES6            S              6    INZ('99    ')
+     D DBG             S             52
+      *
+      * CAT('AB','CDEF') '      ' -> 'ABCDEF'
+     C     STR2          CAT(P)    STR4          RES1
+     C                   EVAL      DBG='('+RES1+')'
+     C     DBG           DSPLY
+      *
+      * CAT('CDEF','GHIJKL') '      '  -> 'CDEFGH'
+     C     STR4          CAT(P)    STR6          RES2
+     C                   EVAL      DBG='('+RES2+')'
+     C     DBG           DSPLY
+      *
+      * CAT('CD','EF') 'AB    ' -> 'CDEF  '
+     C     'CD'          CAT(P)    'EF'          RES3
+     C                   EVAL      DBG='('+RES3+')'
+     C     DBG           DSPLY
+      *
+      * CAT('AB','CDEF':1) '      ' -> 'AB CDE'
+     C     STR2          CAT(P)    STR4:1        RES4
+     C                   EVAL      DBG='('+RES4+')'
+     C     DBG           DSPLY
+      *
+      * CAT(-,'CDEF') 'AB    ' -> 'AB    '
+     C                   CAT(P)    STR4          RES5
+     C                   EVAL      DBG='('+RES5+')'
+     C     DBG           DSPLY
+      *
+      * CAT(-,'XYZ':1) '99    ' -> '99 XYZ'
+     C                   CAT(P)    STR3:1        RES6
+     C                   EVAL      DBG='('+RES6+')'
+     C     DBG           DSPLY
+      *
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A70.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A70.rpgle
@@ -1,0 +1,62 @@
+     D A70_A03         S              3
+     D A70_A04         S              4
+     D A70_A05         S              5
+     D A70_A06         S              6
+     D A70_A07         S              7
+     D A70_A09         S              9
+     D A70_A10         S             10
+     D A70_N1          S              1  0 INZ(0)
+     D £DBG_Str        S             52
+      * CAT
+     C                   MOVE      'MR.'         A70_A03
+     C                   MOVE      ' SMITH'      A70_A06
+     C     A70_A03       CAT       A70_A06       A70_A09
+     C                   EVAL      £DBG_Str='CAT_1('+A70_A09+')'
+      *
+     C                   MOVE      '/400'        A70_A04
+     C     'RPG'         CAT       A70_A04       A70_A07
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                     +' CAT_2('+A70_A07+')'
+      *
+     C                   CLEAR                   A70_A04
+     C                   CLEAR                   A70_A05
+      *
+     C                   MOVE      '/400'        A70_A04
+     C     'RPG'         CAT       A70_A04       A70_A05
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                     +' CAT_3('+A70_A05+')'
+      * Expect 'CAT_1(MR. SMITH) CAT_2(RPG/400) CAT_3(RPG/4)'
+     C     £DBG_Str      DSPLY
+      *
+     D* CAT blank number
+     C                   CLEAR                   A70_A09
+     C                   MOVEL(P)  'ABC'         A70_A09
+     C                   MOVE      'XYZ'         A70_A03
+     C                   CAT       A70_A03:2     A70_A09
+     C                   EVAL      £DBG_Str='CAT_1('+A70_A09+')'
+      *
+     C                   MOVE      'Mr.   '      A70_A06
+     C                   MOVE      'Smith  '     A70_A07
+     C     A70_A06       CAT       A70_A07:1     A70_A09
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                     +' CAT_2('+A70_A09+')'
+      * Expect 'CAT_1(ABC  XYZ )CAT_2(Mr. Smith)'
+     C     £DBG_Str      DSPLY
+      *
+      * CAT(P)
+     C                   MOVE      *ALL'*'       A70_A10
+     C                   MOVE      '/400'        A70_A04
+     C     'RPG'         CAT(P)    A70_A04       A70_A10
+     C                   EVAL      £DBG_Str='CAT_1('+A70_A10+')'
+      * Expect 'CAT_1(RPG/400   )'
+     C     £DBG_Str      DSPLY
+      *
+     D* CAT(P) with blank number
+     C                   MOVE      'RPG '        A70_A04
+     C                   MOVE      'IV    '      A70_A06
+     C     A70_A04       CAT(P)    A70_A06:A70_N1A70_A10
+     C                   EVAL      £DBG_Str='CAT_1('+A70_A10+')'
+      * Expect 'CAT_1(RPGIV     )'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A70.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A70.rpgle
@@ -29,7 +29,7 @@
      C     £DBG_Str      DSPLY
       *
      D* CAT blank number
-     C                   CLEAR                   A70_A09
+     C*                   CLEAR                   A70_A09
      C                   MOVEL(P)  'ABC'         A70_A09
      C                   MOVE      'XYZ'         A70_A03
      C                   CAT       A70_A03:2     A70_A09
@@ -40,7 +40,7 @@
      C     A70_A06       CAT       A70_A07:1     A70_A09
      C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
      C                                     +' CAT_2('+A70_A09+')'
-      * Expect 'CAT_1(ABC  XYZ )CAT_2(Mr. Smith)'
+      * Expect 'CAT_1(ABC  XYZ ) CAT_2(Mr. Smith)'
      C     £DBG_Str      DSPLY
       *
       * CAT(P)


### PR DESCRIPTION
## Description

Fix `CAT` and `CAT(P)` statement. 

Errors:
- Content 2 of Factor 2 can be a Number or a Number Variable.
- If Factor 1 isn't defined, Factor 2 contains both string variable and number expression (string var`:`number expr) and result field has initial value, `CAT` statement concatenate factor 2, number of blanks to result field.

```rpgle
 * CAT(-,'XYZ':1) '99    ' -> '99 XYZ'
 C                   CAT       STR3:1        RES6
```
- If Factor 1 isn't defined, Factor 2 contains only the string variable and result field has initial value, `CAT` statement not concatenate factor 2 to result field.

```rpgle
 * CAT(-,'CDEF') 'AB    ' -> 'AB    '
C                   CAT       STR4          RES5
```

Related to # (issue)
MULANGT10 - SEZ_A70 - P02
MULANGT10 - SEZ_A70 - P03
MULANGT10 - SEZ_A70 - P04 (MULANGT90)
MULANGT10 - SEZ_A70 - P06
MULANGT10 - SEZ_A70 - P07
MULANGT10 - SEZ_A70 - P09
MULANGT10 - SEZ_A70 - P10



## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
