### PR TITLE
Feature/nw23001440/bif subarr

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -2642,6 +2642,7 @@ target:
     | container=idOrKeyword FREE_DOT field=idOrKeyword #qualifiedTarget
     | base=target OPEN_PAREN index=expression CLOSE_PAREN #indexedTarget
     | bif_subst #substTarget
+    | bif_subarr #subarrTarget
     | container=idOrKeyword DOT fieldName=idOrKeyword #qualifiedTarget
     | indic=SPLAT_INDICATOR #indicatorTarget
     | SPLAT_IN #globalIndicatorTarget

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
@@ -51,6 +51,7 @@ interface Evaluator {
     fun eval(expression: NotExpr): BooleanValue
     fun eval(expression: ScanExpr): Value
     fun eval(expression: SubstExpr): Value
+    fun eval(expression: SubarrExpr): Value
     fun eval(expression: LenExpr): Value
     fun eval(expression: OffRefExpr): BooleanValue
     fun eval(expression: IndicatorExpr): BooleanValue

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -272,7 +272,15 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: SubarrExpr): Value {
-        TODO("Not yet implemented")
+        val start = expression.start.evalWith(this).asInt().value.toInt() - 1
+        val numberOfElement: Int? = if (expression.numberOfElements != null) expression.numberOfElements.evalWith(this).asInt().value.toInt() else null
+        val originalArray: ArrayValue = expression.array.evalWith(this).asArray()
+        val to: Int = if (numberOfElement == null) {
+            originalArray.arrayLength()
+        } else {
+            (start) + numberOfElement
+        }
+        return originalArray.take(start, to)
     }
 
     override fun eval(expression: LenExpr): Value {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -271,6 +271,10 @@ class ExpressionEvaluation(
         }
     }
 
+    override fun eval(expression: SubarrExpr): Value {
+        TODO("Not yet implemented")
+    }
+
     override fun eval(expression: LenExpr): Value {
         return when (val value = expression.value.evalWith(this)) {
             is StringValue -> {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -28,7 +28,7 @@ private fun coerceBlanks(type: Type): Value {
         }
         is ArrayType -> {
             createArrayValue(type.element, type.nElements) {
-                type.element.blank()
+                coerceBlanks(type.element)
             }
         }
         is NumberType -> {
@@ -192,7 +192,29 @@ fun coerce(value: Value, type: Type): Value {
                     value.asString()
                 }
                 is ArrayType -> {
-                    value
+                    if (value.elements().size > type.nElements) {
+                        // coerce elements and truncate array
+                        val values: MutableList<Value> = mutableListOf()
+                        for (i in 1..type.numberOfElements()) {
+                            values.add(coerce(value.getElement(i), type.element))
+                        }
+                        ConcreteArrayValue(values, type.element)
+                    } else {
+                        if (value.elements().size == type.nElements) {
+                            // coerce elements and set new type creating new instance
+                            val values: MutableList<Value> = value.elements().map {
+                                coerce(it, type.element)
+                            }.toMutableList()
+                            ConcreteArrayValue(values, type.element)
+                        } else {
+                            // create an array blank and set element
+                            val array = coerceBlanks(type) as ConcreteArrayValue
+                            value.elements().forEachIndexed { i, v ->
+                                array.setElement(i + 1, coerce(v, type.element))
+                            }
+                            array
+                        }
+                    }
                 }
                 else -> TODO("Converting ArrayValue to $type")
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -756,14 +756,7 @@ fun decodeFromDS(value: String, digits: Int, scale: Int): BigDecimal {
     }
     number = sign + number
     return try {
-        val builder = StringBuilder()
-        val valueWithoutSeparator = value.replace(".", "").replace(",", "")
-        val decimalSlice = valueWithoutSeparator.substring(valueWithoutSeparator.length - scale)
-        builder
-            .append(valueWithoutSeparator.substring(0, valueWithoutSeparator.length - decimalSlice.length))
-            .append(".")
-            .append(decimalSlice)
-        builder.toString().toBigDecimal()
+        value.toBigDecimal()
     } catch (e: Exception) {
         number.toBigDecimal()
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -756,7 +756,14 @@ fun decodeFromDS(value: String, digits: Int, scale: Int): BigDecimal {
     }
     number = sign + number
     return try {
-        value.toBigDecimal()
+        val builder = StringBuilder()
+        val valueWithoutSeparator = value.replace(".", "").replace(",", "")
+        val decimalSlice = valueWithoutSeparator.substring(valueWithoutSeparator.length - scale)
+        builder
+            .append(valueWithoutSeparator.substring(0, valueWithoutSeparator.length - decimalSlice.length))
+            .append(".")
+            .append(decimalSlice)
+        builder.toString().toBigDecimal()
     } catch (e: Exception) {
         number.toBigDecimal()
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -790,6 +790,25 @@ open class InternalInterpreter(
 
                 return assign(target.string as AssignableExpression, newValue)
             }
+            is SubarrExpr -> {
+                require(value is ArrayValue)
+                // replace portion of array with another array
+                val start: Int = eval(target.start).asInt().value.toInt()
+                val numberOfElement: Int? = if (target.numberOfElements != null) eval(target.numberOfElements).asInt().value.toInt() else null
+                val array: ArrayValue = eval(target.array).asArray().copy()
+                val to: Int = if (numberOfElement == null) {
+                    array.arrayLength()
+                } else {
+                    (start) + numberOfElement
+                } - 1
+                // replace elements
+                var j = 1
+                for (i in start..to) {
+                    array.setElement(i, coerce(value.getElement(j), target.type().asArray().element))
+                    j++
+                }
+                return assign(target.array as AssignableExpression, array)
+            }
             is QualifiedAccessExpr -> {
                 when (val container = eval(target.container)) {
                     is DataStructValue -> {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -305,11 +305,7 @@ open class InternalInterpreter(
                 .map {
                     // force rpgle to zoned if is number type
                     val elementType = if (arrayType.element is NumberType) {
-                        NumberType(
-                            entireDigits = arrayType.element.entireDigits,
-                            decimalDigits = arrayType.element.decimalDigits,
-                            rpgType = RpgType.ZONED
-                        )
+                        arrayType.element.copy(rpgType = RpgType.ZONED.rpgType)
                     } else {
                         arrayType.element
                     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
@@ -302,6 +302,9 @@ fun Expression.type(): Type {
         is SubstExpr -> {
             return this.string.type()
         }
+        is SubarrExpr -> {
+            return this.array.type()
+        }
         is QualifiedAccessExpr -> {
             return this.field.referred!!.type
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -579,6 +579,10 @@ data class ConcreteArrayValue(val elements: MutableList<Value>, override val ele
         }
     }
 
+    override fun take(from: Int, to: Int): Value {
+        return ConcreteArrayValue(elements.subList(from, to), this.elementType)
+    }
+
     fun takeAll(): Value {
         var result = elements[0]
         for (i in 1 until elements.size) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -126,6 +126,25 @@ data class SubstExpr(
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
 
+// %SUBARR
+@Serializable
+data class SubarrExpr(
+    var array: Expression,
+    var start: Expression,
+    val numberOfElements: Expression? = null,
+    override val position: Position? = null
+) :
+    AssignableExpression(position) {
+    override fun render(): String {
+        val len = if (numberOfElements != null) ": ${numberOfElements.render()}" else ""
+        return "%SUBARR(${this.array.render()} : ${start.render()} $len)"
+    }
+    override fun size(): Int {
+        TODO("size")
+    }
+    override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
+}
+
 // %LEN
 @Serializable
 data class LenExpr(var value: Expression, override val position: Position? = null) :

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -143,6 +143,7 @@ private val modules = SerializersModule {
         subclass(SqrtExpr::class)
         subclass(StringLiteral::class)
         subclass(SubstExpr::class)
+        subclass(SubarrExpr::class)
         subclass(TimeStampExpr::class)
         subclass(TranslateExpr::class)
         subclass(TrimExpr::class)
@@ -159,6 +160,7 @@ private val modules = SerializersModule {
         subclass(IndicatorExpr::class)
         subclass(QualifiedAccessExpr::class)
         subclass(SubstExpr::class)
+        subclass(SubarrExpr::class)
     }
     polymorphic(Directive::class) {
         subclass(ActivationGroupDirective::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -214,7 +214,7 @@ data class EvalStmt(
     override fun execute(interpreter: InterpreterCore) {
             // Should I assign it one by one?
             val result = if (target.type().isArray() &&
-                    target.type().asArray().element.canBeAssigned(expression.type())) {
+                    target.type().asArray().element.canBeAssigned(expression.type()) && expression.type() !is ArrayType) {
                 interpreter.assignEachElement(target, expression, operator)
             } else {
                 interpreter.assign(target, expression, operator)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/bif.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/bif.kt
@@ -35,6 +35,7 @@ internal fun RpgParser.BifContext.toAst(conf: ToAstConfiguration = ToAstConfigur
         this.bif_trimr() != null -> this.bif_trimr().toAst(conf)
         this.bif_triml() != null -> this.bif_triml().toAst(conf)
         this.bif_subst() != null -> this.bif_subst().toAst(conf)
+        this.bif_subarr() != null -> this.bif_subarr().toAst(conf)
         this.bif_len() != null -> this.bif_len().toAst(conf)
         this.bif_dec() != null -> this.bif_dec().toAst(conf)
         this.bif_char() != null -> this.bif_char().toAst(conf)
@@ -170,6 +171,14 @@ internal fun RpgParser.Bif_substContext.toAst(conf: ToAstConfiguration = ToAstCo
             this.start.toAst(conf),
             this.length?.toAst(conf),
             toPosition(conf.considerPosition))
+}
+
+internal fun RpgParser.Bif_subarrContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): SubarrExpr {
+    return SubarrExpr(
+        array = this.array.toAst(conf),
+        start = this.start.toAst(conf),
+        numberOfElements = this.numberelements?.toAst(conf),
+        position = toPosition(conf.considerPosition))
 }
 
 internal fun RpgParser.Bif_trimContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): TrimExpr {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1537,6 +1537,7 @@ internal fun TargetContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
             position = toPosition(conf.considerPosition)
         )
         is SubstTargetContext -> this.bif_subst().toAst(conf)
+        is SubarrTargetContext -> this.bif_subarr().toAst(conf)
         is QualifiedTargetContext -> QualifiedAccessExpr(
             DataRefExpr(ReferenceByName(this.container.text), this.container!!.toPosition(conf.considerPosition)),
             ReferenceByName(this.getFieldName()),

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2137,4 +2137,10 @@ Test 6
         val expected = listOf("(ABCDEF)", "(CDEFGH)", "(CDEF  )", "(AB CDE)", "(AB    )", "(99 XYZ)")
         assertEquals(expected, "CATP".outputOf())
     }
+
+    @Test
+    fun executeSUBARR() {
+        val expected = listOf("AR3(1)(13) AR3(2)(3) AR3(3)(0)", "AR2(1)(0) AR2(2)(0) AR2(3)(5) AR2(4)(16) AR2(5)(13)")
+        assertEquals(expected, "SUBARR".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2146,8 +2146,7 @@ Test 6
 
     @Test
     fun executeSUBARR() {
-        // "AR2(1)(0) AR2(2)(0) AR2(3)(5) AR2(4)(16) AR2(5)(13)"*/
-        val expected = listOf("AR3(1)(13) AR3(2)(3) AR3(3)(0)")
+        val expected = listOf("AR3(1)(13) AR3(2)(3) AR3(3)(0)", "AR2(1)(0) AR2(2)(0) AR2(3)(5) AR2(4)(16) AR2(5)(13)")
         assertEquals(expected, "SUBARR".outputOf())
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -569,6 +569,12 @@ open class InterpreterTest : AbstractTest() {
     }
 
     @Test
+    fun executeEVALARRAY2() {
+        val expected = listOf("1(A) 2(B) 6( )", "1(A) 2(B) 5(E)", "1(A ) 2(B )", "1(A) 2(B)")
+        assertEquals(expected, "EVALARRAY2".outputOf())
+    }
+
+    @Test
     fun executeARRAY12() {
         assertCanBeParsed(exampleName = "ARRAY12", printTree = true)
         assertEquals(listOf("AA", "BB"), outputOf("ARRAY12"))
@@ -2140,10 +2146,12 @@ Test 6
 
     @Test
     fun executeSUBARR() {
-        val expected = listOf("AR3(1)(13) AR3(2)(3) AR3(3)(0)", "AR2(1)(0) AR2(2)(0) AR2(3)(5) AR2(4)(16) AR2(5)(13)")
+        // "AR2(1)(0) AR2(2)(0) AR2(3)(5) AR2(4)(16) AR2(5)(13)"*/
+        val expected = listOf("AR3(1)(13) AR3(2)(3) AR3(3)(0)")
         assertEquals(expected, "SUBARR".outputOf())
     }
-    
+
+    @Test
     fun executeMVR() {
         val expected = listOf("3", "3.0", "0", ".8", "2", "2.5", "0", ".2")
         assertEquals(expected, "MVR".outputOf())

--- a/rpgJavaInterpreter-core/src/test/resources/EVALARRAY2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/EVALARRAY2.rpgle
@@ -1,0 +1,59 @@
+     D AR1_5           S              1    DIM(5)
+     D AR1_20          S              1    DIM(20)
+     D AR2_5           S              2    DIM(5)
+     D £DBG_Str        S             52
+      *
+      * Assing Array/Array with same field length. Left array dim > Right array dim
+      * The array on the right is correctly copied
+     C                   EVAL      AR1_5(1)='A'
+     C                   EVAL      AR1_5(2)='B'
+     C                   EVAL      AR1_20=AR1_5
+     C                   EVAL      £DBG_Str='1('+AR1_20(1)+')'
+     C                                    +' 2('+AR1_20(2)+')'
+     C                                    +' 6('+AR1_20(6)+')'
+      * Expected '1(A) 2(B) 6( )'
+     C     £DBG_Str      DSPLY
+      *
+     C                   CLEAR                   AR1_5
+     C                   CLEAR                   AR1_20
+      *
+      * Assing Array/Array with same field length. Left array dim < Right array dim
+      * Only fields with index less than DIM are copied
+     C                   EVAL      AR1_20(1)='A'
+     C                   EVAL      AR1_20(2)='B'
+     C                   EVAL      AR1_20(5)='E'
+     C                   EVAL      AR1_20(6)='F'
+     C                   EVAL      AR1_5=AR1_20
+     C                   EVAL      £DBG_Str='1('+AR1_5(1)+')'
+     C                                    +' 2('+AR1_5(2)+')'
+     C                                    +' 5('+AR1_5(5)+')'
+      * Expected '1(A) 2(B) 5(E)'
+     C     £DBG_Str      DSPLY
+      *
+     C                   CLEAR                   AR1_5
+     C                   CLEAR                   AR2_5
+      *
+      * Assing Array/Array with different field length. Left field length > Right field length
+      * The array on the right is correctly copied
+     C                   EVAL      AR1_5(1)='A'
+     C                   EVAL      AR1_5(2)='B'
+     C                   EVAL      AR2_5=AR1_5
+     C                   EVAL      £DBG_Str='1('+AR2_5(1)+')'
+     C                                    +' 2('+AR2_5(2)+')'
+      * Expected '1(A ) 2(B )'
+     C     £DBG_Str      DSPLY
+      *
+     C                   CLEAR                   AR1_5
+     C                   CLEAR                   AR2_5
+      *
+      * Assing Array/Array with different field length. Left field length < Right field length
+      * Felds are copied but trunched based on field length
+     C                   EVAL      AR2_5(1)='AZ'
+     C                   EVAL      AR2_5(2)='BY'
+     C                   EVAL      AR1_5=AR2_5
+     C                   EVAL      £DBG_Str='1('+AR1_5(1)+')'
+     C                                    +' 2('+AR1_5(2)+')'
+      * Expected '1(A) 2(B)'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/SUBARR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/SUBARR.rpgle
@@ -22,13 +22,13 @@
      C                   EVAL      A80_AR1(4)=13
      C                   EVAL      A80_AR1(5)=3
      C                   CLEAR                   A80_AR2
-     C*                   EVAL      %SUBARR(A80_AR2:3:3)=%SUBARR(A80_AR1:2:3)
-     C*                   EVAL      £DBG_Str='AR2(1)('+%CHAR(A80_AR2(1))+')'
-     C*                                    +' AR2(2)('+%CHAR(A80_AR2(2))+')'
-     C*                                    +' AR2(3)('+%CHAR(A80_AR2(3))+')'
-     C*                                    +' AR2(4)('+%CHAR(A80_AR2(4))+')'
-     C*                                    +' AR2(5)('+%CHAR(A80_AR2(5))+')'
+     C                   EVAL      %SUBARR(A80_AR2:3:3)=%SUBARR(A80_AR1:2:3)
+     C                   EVAL      £DBG_Str='AR2(1)('+%CHAR(A80_AR2(1))+')'
+     C                                    +' AR2(2)('+%CHAR(A80_AR2(2))+')'
+     C                                    +' AR2(3)('+%CHAR(A80_AR2(3))+')'
+     C                                    +' AR2(4)('+%CHAR(A80_AR2(4))+')'
+     C                                    +' AR2(5)('+%CHAR(A80_AR2(5))+')'
       * Expected 'AR2(1)(0) AR2(2)(0) AR2(3)(5) AR2(4)(16) AR2(5)(13)'
-     C*     £DBG_Str      DSPLY
+     C     £DBG_Str      DSPLY
       *
      C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/SUBARR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/SUBARR.rpgle
@@ -16,12 +16,12 @@
       * Expected 'AR3(1)(13) AR3(2)(3) AR3(3)(0)'
      C     £DBG_Str      DSPLY
       *
-     C*                   EVAL      A80_AR1(1)=9
-     C*                   EVAL      A80_AR1(2)=5
-     C*                   EVAL      A80_AR1(3)=16
-     C*                   EVAL      A80_AR1(4)=13
-     C*                   EVAL      A80_AR1(5)=3
-     C*                   CLEAR                   A80_AR2
+     C                   EVAL      A80_AR1(1)=9
+     C                   EVAL      A80_AR1(2)=5
+     C                   EVAL      A80_AR1(3)=16
+     C                   EVAL      A80_AR1(4)=13
+     C                   EVAL      A80_AR1(5)=3
+     C                   CLEAR                   A80_AR2
      C*                   EVAL      %SUBARR(A80_AR2:3:3)=%SUBARR(A80_AR1:2:3)
      C*                   EVAL      £DBG_Str='AR2(1)('+%CHAR(A80_AR2(1))+')'
      C*                                    +' AR2(2)('+%CHAR(A80_AR2(2))+')'

--- a/rpgJavaInterpreter-core/src/test/resources/SUBARR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/SUBARR.rpgle
@@ -1,0 +1,34 @@
+     D A80_AR1         S             10I 0 DIM(5)
+     D A80_AR2         S             10I 0 DIM(15)
+     D A80_AR3         S             10I 0 DIM(20)
+     D £DBG_Str        S             52
+      *
+     C                   EVAL      A80_AR1(1)=9
+     C                   EVAL      A80_AR1(2)=5
+     C                   EVAL      A80_AR1(3)=16
+     C                   EVAL      A80_AR1(4)=13
+     C                   EVAL      A80_AR1(5)=3
+     C                   CLEAR                   A80_AR3
+     C                   EVAL      A80_AR3=%SUBARR(A80_AR1:4:2)
+     C                   EVAL      £DBG_Str='AR3(1)('+%CHAR(A80_AR3(1))+')'
+     C                                    +' AR3(2)('+%CHAR(A80_AR3(2))+')'
+     C                                    +' AR3(3)('+%CHAR(A80_AR3(3))+')'
+      * Expected 'AR3(1)(13) AR3(2)(3) AR3(3)(0)'
+     C     £DBG_Str      DSPLY
+      *
+     C*                   EVAL      A80_AR1(1)=9
+     C*                   EVAL      A80_AR1(2)=5
+     C*                   EVAL      A80_AR1(3)=16
+     C*                   EVAL      A80_AR1(4)=13
+     C*                   EVAL      A80_AR1(5)=3
+     C*                   CLEAR                   A80_AR2
+     C*                   EVAL      %SUBARR(A80_AR2:3:3)=%SUBARR(A80_AR1:2:3)
+     C*                   EVAL      £DBG_Str='AR2(1)('+%CHAR(A80_AR2(1))+')'
+     C*                                    +' AR2(2)('+%CHAR(A80_AR2(2))+')'
+     C*                                    +' AR2(3)('+%CHAR(A80_AR2(3))+')'
+     C*                                    +' AR2(4)('+%CHAR(A80_AR2(4))+')'
+     C*                                    +' AR2(5)('+%CHAR(A80_AR2(5))+')'
+      * Expected 'AR2(1)(0) AR2(2)(0) AR2(3)(5) AR2(4)(16) AR2(5)(13)'
+     C*     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Implements new bif `%SUBARR`. Handle `%SUBARR` as a factor and as a target of `EVAL` statement.
Handle `SORTA` with `%SUBARR` test case.
Fix `EVAL` for Array to Array.

Related to # (issue)
MULANGT90 - T16_A80 - P01
MULANGT90 - T16_A80 - P02
MULANGT90 - T16_A80 - P03
MULANGT90 - T16_A80 - P04
MULANGT90 - T16_A80 - P05
MULANGT90 - T40_A20 - P07
MULANGT90 - T40_A20 - P08

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
