### PR TITLE
fix: gregorian calendar settings, string representation and clear

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -54,6 +54,9 @@ private fun coerceBlanks(type: Type): Value {
         is RecordFormatType -> {
             type.blank()
         }
+        is TimeStampType -> {
+            TimeStampValue.LOVAL
+        }
         else -> TODO("Converting BlanksValue to $type")
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
@@ -41,7 +41,7 @@ private fun TimeStampValue.timestampFormatting(format: String?): String =
     if ("*ISO0" == format) {
         SimpleDateFormat("yyyyMMddHHmmssSSS000").format(value)
     } else {
-        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(value)
+        SimpleDateFormat("yyyy-MM-dd-HH.mm.ss.SSSSSS").format(value)
     }
 
 fun CompilationUnit.activationGroupType(): ActivationGroupType? {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -451,7 +451,16 @@ data class TimeStampValue(@Contextual val value: Date) : Value {
     override fun asTimeStamp() = this
 
     companion object {
-        val LOVAL = TimeStampValue(GregorianCalendar(0, Calendar.JANUARY, 0).time)
+        val LOVAL: TimeStampValue by lazy {
+            val calendar = GregorianCalendar().apply {
+                clear()
+                set(Calendar.YEAR, 1)
+                set(Calendar.MONTH, Calendar.JANUARY)
+                set(Calendar.DAY_OF_MONTH, 1)
+                set(Calendar.ERA, GregorianCalendar.BC)
+            }
+            TimeStampValue(calendar.time)
+        }
     }
 
     override fun copy(): TimeStampValue = this

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -31,10 +31,7 @@ import org.junit.experimental.categories.Category
 import java.math.BigDecimal
 import java.text.SimpleDateFormat
 import java.util.*
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
-import kotlin.test.fail
+import kotlin.test.*
 
 open class InterpreterTest : AbstractTest() {
 
@@ -2142,5 +2139,13 @@ Test 6
     fun executeMVR() {
         val expected = listOf("3", "3.0", "0", ".8", "2", "2.5", "0", ".2")
         assertEquals(expected, "MVR".outputOf())
+    }
+
+    @Test
+    fun executeTIMEST_CLR() {
+        val values = "TIMEST_CLR".outputOf()
+        assertEquals("0001-01-01-00.00.00.000000", values[0])
+        assertNotEquals("0001-01-01-00.00.00.000000", values[1])
+        assertEquals("0001-01-01-00.00.00.000000", values[2])
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/TIMEST_CLR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/TIMEST_CLR.rpgle
@@ -1,0 +1,14 @@
+     D TIMEST          S               Z
+      *
+      * Expected '0001-01-01-00.00.00.000000'
+     C     TIMEST        DSPLY
+      *
+     C                   TIME                    TIMEST
+      * Expected Actual Timestamp
+     C     TIMEST        DSPLY
+      *
+     C                   CLEAR                   TIMEST
+      * Expected '0001-01-01-00.00.00.000000'
+     C     TIMEST        DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Fix Gregorian calendar settings, string representation and `CLEAR` statement for TimeStampValue

Related to # (issue)
Is a free error, not in MULANGTx yet.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
