### PR TITLE
fix: %REPLACE with varying

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -546,22 +546,36 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: ReplaceExpr): Value {
-        val replString = evalAsString(expression.replacement)
+        val replacement = evalAsString(expression.replacement)
         val sourceString = evalAsString(expression.source)
-        val replStringLength: Int = replString.length
-        // case of %REPLACE(stringToReplaceWith:stringSource)
-        if (expression.start == null) {
-            return StringValue(sourceString.replaceRange(0..replStringLength - 1, replString))
-        }
-        // case of %REPLACE(stringToReplaceWith:stringSource:startIndex)
-        if (expression.length == null) {
-            val startNr = evalAsInt(expression.start)
-            return StringValue(sourceString.replaceRange((startNr - 1)..(startNr + replStringLength - 2), replString))
+        val replacementLength: Int = replacement.length
+        val result: String = if (expression.start == null) {
+            // case of %REPLACE(stringToReplaceWith:stringSource)
+            // replace text at beginning of variable
+            sourceString.replaceRange(0 until replacementLength, replacement)
         } else {
-            // case of %REPLACE(stringToReplaceWith:stringSource:startIndex:nrOfCharsToReplace)
-            val startNr = evalAsInt(expression.start) - 1
-            val nrOfCharsToReplace = evalAsInt(expression.length)
-            return StringValue(sourceString.replaceRange(startNr, (startNr + nrOfCharsToReplace), replString))
+            val start = evalAsInt(expression.start) - 1
+            if (expression.length == null) {
+                // case of %REPLACE(stringToReplaceWith:stringSource:startIndex)
+                // replace text at specified position
+                val truncatedSource = sourceString.substring(0, start)
+                if (truncatedSource.length + replacement.length < sourceString.length) {
+                    (truncatedSource + replacement + sourceString.substring(truncatedSource.length + replacementLength))
+                } else {
+                    truncatedSource + replacement
+                }
+            } else {
+                // case of %REPLACE(stringToReplaceWith:stringSource:startIndex:nrOfCharsToReplace)
+                // replace to insert or delete text
+                val characterToReplace = evalAsInt(expression.length)
+                sourceString.replaceRange(start, (start + characterToReplace), replacement)
+            }
+        }
+        // truncated if length is greater than type.elementSize
+        return if (result.length > expression.source.type().elementSize()) {
+            StringValue(result.substring(0, expression.source.type().elementSize()), expression.source.type().hasVariableSize())
+        } else {
+            StringValue(result, expression.source.type().hasVariableSize())
         }
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -69,6 +69,12 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
+    fun executeT16_A20() {
+        val expected = listOf("(Ontario, Canada)", "(Ontario, California     )", "(Ontario, Ontario, California     )", "(Somewhere else: Ontario, Ontario, California     )")
+        assertEquals(expected, "smeup/T16_A20".outputOf())
+    }
+
+    @Test
     fun executeT16_A70() {
         val expected = listOf("A70_AR1(10) A70_AR2(20) A70_DS1(30) A70_AR3(10)")
         assertEquals(expected, "smeup/T16_A70".outputOf())

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T16_A20.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T16_A20.rpgle
@@ -1,0 +1,30 @@
+     D £DBG_Str        S             52
+     D A20_A50         S             50    VARYING
+     D A20_A2          S             10A   INZ('Ontario') VARYING
+     D A20_A3          S             10A   INZ('Canada') VARYING
+     D A20_A4          S             15A   INZ('California')
+      *
+     C                   EVAL      A20_A50=A20_A2+', ON'
+      * Expected '(Ontario, Canada)'
+     C                   EVAL      £DBG_Str='('+%REPLACE(A20_A3:A20_A50:10)+')'
+     C     £DBG_Str      DSPLY
+      *
+     C                   EVAL      A20_A50=A20_A2+', '+A20_A3
+     C                   EVAL      A20_A50=%REPLACE(A20_A4:A20_A50:
+     C                                      %SCAN(',':A20_A50)+2)
+     C                   EVAL      £DBG_Str='('+A20_A50+')'
+      * Expected '(Ontario, California     )'
+     C     £DBG_Str      DSPLY
+      *
+     C                   EVAL      A20_A50=%REPLACE(', ' + A20_A2: A20_A50:
+     C                                      %SCAN(',': A20_A50): 0)
+     C                   EVAL      £DBG_Str='('+A20_A50+')'
+      * Expected '(Ontario, Ontario, California     )'
+     C     £DBG_Str      DSPLY
+      *
+     C                   EVAL      £DBG_Str='('+%REPLACE('Somewhere else: ':
+     C                                       A20_A50: 1: 0)+')'
+      * Expected '(Somewhere else: Ontario, Ontario, California     )'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Fix `%REPLACE` bif with varying strings.

**PS**: I used `+` operator for string concatenation because I think that in this case is more efficient than `StringBuilder`. There isn't iterations. If not, I will change it.

Related to # (issue)
MULANGT90 - T16_A20 - P02
MULANGT90 - T16_A20 - P05

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
