### PR TITLE
Bugfix/nw23001440/timestamp

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -27,7 +27,7 @@ import java.math.BigDecimal
 import java.math.MathContext
 import java.math.RoundingMode
 import java.time.temporal.ChronoUnit
-import java.util.*
+import java.time.ZoneId
 import kotlin.math.abs
 import kotlin.math.sqrt
 
@@ -358,11 +358,11 @@ class ExpressionEvaluation(
 
     override fun eval(expression: TimeStampExpr): Value {
         if (expression.value == null) {
-            return TimeStampValue(Date())
+            return TimeStampValue.now()
         } else {
             val evaluated = expression.value.evalWith(this)
             if (evaluated is StringValue) {
-                return TimeStampValue(evaluated.value.asIsoDate())
+                return TimeStampValue.of(evaluated.value)
             }
             TODO("TimeStamp parsing: " + evaluated)
         }
@@ -381,27 +381,27 @@ class ExpressionEvaluation(
         return when (expression.durationCode) {
             is DurationInMSecs -> IntValue(
                 ChronoUnit.MICROS.between(
-                    v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
+                    v2.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant(), v1.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant()
                 )
             )
             is DurationInDays -> IntValue(
                 ChronoUnit.DAYS.between(
-                    v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
+                    v2.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant(), v1.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant()
                 )
             )
             is DurationInSecs -> IntValue(
                 ChronoUnit.SECONDS.between(
-                    v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
+                    v2.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant(), v1.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant()
                 )
             )
             is DurationInMinutes -> IntValue(
                 ChronoUnit.MINUTES.between(
-                    v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
+                    v2.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant(), v1.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant()
                 )
             )
             is DurationInHours -> IntValue(
                 ChronoUnit.HOURS.between(
-                    v2.asTimeStamp().value.toInstant(), v1.asTimeStamp().value.toInstant()
+                    v2.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant(), v1.asTimeStamp().value.atZone(ZoneId.systemDefault()).toInstant()
                 )
             )
             is DurationInMonths -> IntValue(

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -176,6 +176,7 @@ private fun coerceString(value: StringValue, type: Type): Value {
         is UnlimitedStringType -> {
             return UnlimitedStringValue(value.value)
         }
+        is TimeStampType -> TimeStampValue.of(value.value)
         else -> TODO("Converting String to $type")
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
@@ -17,7 +17,7 @@
 package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.parsing.ast.*
-import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.*
 
 fun Value.stringRepresentation(format: String? = null): String {
@@ -39,9 +39,9 @@ fun Value.stringRepresentation(format: String? = null): String {
 private fun TimeStampValue.timestampFormatting(format: String?): String =
     // TODO this is a simple stub for what the full implementation will be
     if ("*ISO0" == format) {
-        SimpleDateFormat("yyyyMMddHHmmssSSS000").format(value)
+        DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS000").format(value)
     } else {
-        SimpleDateFormat("yyyy-MM-dd-HH.mm.ss.SSSSSS").format(value)
+        DateTimeFormatter.ofPattern(TimeStampValue.DEFAULT_FORMAT).format(value)
     }
 
 fun CompilationUnit.activationGroupType(): ActivationGroupType? {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/serialization/serialization_options.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/serialization/serialization_options.kt
@@ -18,7 +18,7 @@ package com.smeup.rpgparser.interpreter.serialization
 
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.serialization.BigDecimalSerializer
-import com.smeup.rpgparser.serialization.DateAsLongSerializer
+import com.smeup.rpgparser.serialization.LocalDateTimeSerializer
 import kotlinx.serialization.*
 import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.json.Json
@@ -29,7 +29,7 @@ import kotlinx.serialization.modules.subclass
 
 private val module = SerializersModule {
     contextual(BigDecimalSerializer)
-    contextual(DateAsLongSerializer)
+    contextual(LocalDateTimeSerializer)
     polymorphic(Value::class) {
         subclass(IntValue::class)
         subclass(DecimalValue::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -23,9 +23,9 @@ import kotlinx.serialization.Serializable
 import java.math.BigDecimal
 import java.nio.charset.Charset
 import java.text.SimpleDateFormat
-import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.*
 
 const val PAD_CHAR = ' '
@@ -136,7 +136,7 @@ data class StringValue(var value: String, val varying: Boolean = false) : Abstra
         return BooleanValue.FALSE
     }
 
-    override fun asTimeStamp(): TimeStampValue = TimeStampValue(value.asIsoDate())
+    override fun asTimeStamp(): TimeStampValue = TimeStampValue.of(value)
 
     fun setSubstring(startOffset: Int, endOffset: Int, substringValue: StringValue) {
         require(startOffset >= 0)
@@ -438,10 +438,10 @@ data class CharacterValue(val value: Array<Char>) : Value {
 }
 
 @Serializable
-data class TimeStampValue(@Contextual val value: Date) : Value {
+data class TimeStampValue(@Contextual val value: LocalDateTime) : Value {
 
     val localDate: LocalDate by lazy {
-        Instant.ofEpochMilli(value.time).atZone(ZoneId.systemDefault()).toLocalDate()
+        value.toLocalDate()
     }
 
     override fun assignableTo(expectedType: Type): Boolean {
@@ -451,22 +451,27 @@ data class TimeStampValue(@Contextual val value: Date) : Value {
     override fun asTimeStamp() = this
 
     companion object {
+        val DEFAULT_FORMAT = "yyyy-MM-dd-HH.mm.ss.SSSSSS"
         val LOVAL: TimeStampValue by lazy {
-            val calendar = GregorianCalendar().apply {
-                clear()
-                set(Calendar.YEAR, 1)
-                set(Calendar.MONTH, Calendar.JANUARY)
-                set(Calendar.DAY_OF_MONTH, 1)
-                set(Calendar.ERA, GregorianCalendar.BC)
+            TimeStampValue(LocalDateTime.parse("0001-01-01-00.00.00.000000", DateTimeFormatter.ofPattern(DEFAULT_FORMAT)))
+        }
+        fun of(value: String): TimeStampValue {
+            // parse only Date
+            return if (value.trim().length < 11) {
+                TimeStampValue(LocalDate.parse(value.trim(), DateTimeFormatter.ofPattern(DEFAULT_FORMAT.substring(0, value.trim().length))).atStartOfDay())
+            } else {
+                TimeStampValue(LocalDateTime.parse(value.trim(), DateTimeFormatter.ofPattern(DEFAULT_FORMAT.substring(0, value.trim().length))))
             }
-            TimeStampValue(calendar.time)
+        }
+        fun now(): TimeStampValue {
+            return TimeStampValue(LocalDateTime.now())
         }
     }
 
     override fun copy(): TimeStampValue = this
 
     override fun asString(): StringValue {
-        return StringValue(value.toString())
+        return StringValue(DateTimeFormatter.ofPattern(DEFAULT_FORMAT).format(value))
     }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -21,6 +21,7 @@ import com.smeup.rpgparser.interpreter.DataDefinition
 import com.smeup.rpgparser.interpreter.FieldDefinition
 import com.smeup.rpgparser.parsing.parsetreetoast.LogicalCondition
 import com.smeup.rpgparser.serialization.BigDecimalSerializer
+import com.smeup.rpgparser.serialization.LocalDateTimeSerializer
 import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.decodeFromString
@@ -31,6 +32,7 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 import java.math.BigDecimal
+import java.time.LocalDateTime
 
 private val modules = SerializersModule {
     polymorphic(AbstractDataDefinition::class) {
@@ -176,6 +178,7 @@ private val modules = SerializersModule {
         subclass(MuteTypeAnnotation::class)
     }
     contextual(BigDecimal::class, BigDecimalSerializer)
+    contextual(LocalDateTime::class, LocalDateTimeSerializer)
 }
 
 val json = Json {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1156,7 +1156,7 @@ data class TimeStmt(
     override fun execute(interpreter: InterpreterCore) {
         when (value) {
             is DataRefExpr -> {
-                interpreter.assign(value, TimeStampValue(Date()))
+                interpreter.assign(value, TimeStampValue.now())
             }
             else -> throw UnsupportedOperationException("I do not know how to set TIME to ${this.value}")
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/serialization/custom_serializers.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/serialization/custom_serializers.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import java.math.BigDecimal
-import java.util.*
+import java.time.LocalDateTime
 
 object BigDecimalSerializer : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
@@ -15,8 +15,8 @@ object BigDecimalSerializer : KSerializer<BigDecimal> {
     override fun deserialize(decoder: Decoder): BigDecimal = BigDecimal(decoder.decodeString())
 }
 
-object DateAsLongSerializer : KSerializer<Date> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Date", PrimitiveKind.LONG)
-    override fun serialize(encoder: Encoder, value: Date) = encoder.encodeLong(value.time)
-    override fun deserialize(decoder: Decoder): Date = Date(decoder.decodeLong())
+object LocalDateTimeSerializer : KSerializer<LocalDateTime> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: LocalDateTime) = encoder.encodeString(value.toString())
+    override fun deserialize(decoder: Decoder): LocalDateTime = LocalDateTime.parse(decoder.decodeString())
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -2,6 +2,8 @@ package com.smeup.rpgparser.evaluation
 
 import com.smeup.rpgparser.AbstractTest
 import org.junit.Test
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -62,6 +64,18 @@ open class SmeupInterpreterTest : AbstractTest() {
     fun executeT04_A40() {
         val expected = listOf("A40_P1(122469.88)A40_P2(987.22)A40_P3(123456.10)A40_P4(121028170.03)")
         assertEquals(expected, "smeup/T04_A40".outputOf())
+    }
+
+    @Test
+    fun executeT04_A80() {
+        val actual = "smeup/T04_A80".outputOf()
+        val t = LocalDateTime.now()
+        val expected = listOf(
+            DateTimeFormatter.ofPattern("HHmmss").format(t),
+            DateTimeFormatter.ofPattern("HHmmssddMMyy").format(t),
+            DateTimeFormatter.ofPattern("HHmmssddMMyyyy").format(t)
+        )
+        assertEquals(expected, actual)
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -3,6 +3,7 @@ package com.smeup.rpgparser.evaluation
 import com.smeup.rpgparser.AbstractTest
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 open class SmeupInterpreterTest : AbstractTest() {
 
@@ -16,6 +17,13 @@ open class SmeupInterpreterTest : AbstractTest() {
     fun executeT15_A90() {
         // TODO When we will have more clear idea about the expected result, we will add the assert
         println("executeT15_A90: " + "smeup/T15_A90".outputOf())
+    }
+
+    @Test
+    fun executeT02_A20() {
+        val values = "smeup/T02_A20".outputOf()
+        assertTrue(values[0].matches(Regex("A20_Z1\\(\\d{4}-\\d{2}-\\d{2}-\\d{2}\\.\\d{2}\\.\\d{2}\\.\\d{6}\\)")))
+        assertEquals("A20_Z2(2003-06-27-09.25.59.123456)", values[1])
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/serialization/SerializationTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/serialization/SerializationTest.kt
@@ -24,6 +24,7 @@ import com.smeup.rpgparser.test.longs
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import java.math.BigDecimal
+import java.time.ZoneId
 import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -55,7 +56,7 @@ class SerializationTest {
     @Test
     fun `TimeStampValue can be serialized to Json`() {
         val aDate = GregorianCalendar(2020, Calendar.JANUARY, 15).time
-        checkValueSerialization(TimeStampValue(aDate), true)
+        checkValueSerialization(TimeStampValue(aDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()), true)
     }
 
     @Test
@@ -100,7 +101,7 @@ class SerializationTest {
         val intValue = IntValue(aLongNumber)
         val stringValue = StringValue(aLongNumber.toString())
         val booleanValue = BooleanValue.TRUE
-        val timeStampValue = TimeStampValue(Date())
+        val timeStampValue = TimeStampValue.now()
         val characterValue = CharacterValue("Hello world".toCharArray().toTypedArray())
         val arrayValue =
             ConcreteArrayValue(

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A20.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A20.rpgle
@@ -1,0 +1,14 @@
+     D A20_Z1          S               Z
+     D A10_Z2          S               Z   INZ(Z'2003-06-27-09.25.59.123456')
+     D £DBG_Str        S             52
+      *
+     C                   EVAL      A20_Z1=%TIMESTAMP()
+     C                   EVAL      £DBG_Str='A20_Z1('+%CHAR(A20_Z1)+')'
+      * Expected 'A20_Z1(xxxxxxxxxxxxxxxxxxxxxxxxxx)' actual value of timestamp
+     C     £DBG_Str      DSPLY
+      *
+     C                   EVAL      £DBG_Str='A20_Z2('+%CHAR(A10_Z2)+')'
+      * Expected 'A20_Z2(2003-06-27-09.25.59.123456)'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A80.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A80.rpgle
@@ -1,0 +1,21 @@
+     D A80_N1          S              6  0
+     D A80_N2          S             12  0
+     D A80_N3          S             14  0
+     D £DBG_Str        S             52
+      *
+     C                   TIME                    A80_N1
+     C                   EVAL      £DBG_Str=%CHAR(A80_N1)
+      * Expected number in HHmmSS format
+     C     £DBG_Str      DSPLY
+      *
+     C                   TIME                    A80_N2
+     C                   EVAL      £DBG_Str=%CHAR(A80_N2)
+      * Expected numer in HHmmSSDDMMYY
+     C     £DBG_Str      DSPLY
+      *
+     C                   TIME                    A80_N3
+     C                   EVAL      £DBG_Str=%CHAR(A80_N3)
+      * Expected numer in HHmmSSDDMMYYYY
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Handle `%CHAR` for TimeStampValue, and `TIME` op code for IntValue (6, 12, 14). 
- Refactor `TimeStampValue`: change primitive type from `Date` to `LocalDateTime` (b0a99f91154ceb225df6962a11d12d4d9220e928). I perform the refactoring because the java/kotlin primitive type `Date` does't support micro seconds. In rpgle TimeStampValue has micro seconds (`HH:mm:ss.SSSSSS`). `LocalDateTime` is the new Java/Kotlin class (`java.time`) to handle TimeStamp. Adjust methods in project (luckily they were only a couple).
- Fix serialization: Delete old date serializer and replace with new LocalDateTIme serializer.
- Handle `NumberType` (`IntValue`) in `TIME` op code. 

Related to # (issue)
MULANGT90 - T02_A20 - P10
MULANGT90 - T04_A80 - P03

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
