### PR TITLE
Bugfix/nw23001440/eval array array

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -132,35 +132,32 @@ class ExpressionEvaluation(
                 DecimalValue(left.bigDecimal.plus(right.bigDecimal))
             }
             left is ArrayValue && right is ArrayValue -> {
-                val result = left.copy()
-                when {
-                    left.elementType is StringType && right.elementType is StringType -> {
-                        result.elements().forEachIndexed { i: Int, v: Value ->
-                            val valueToAdd: StringValue = if (left.asString().varying) {
-                                StringValue(v.asString().value + right.getElement(i + 1).asString().value, true)
+                val listValue = when {
+                    left.elementType is StringType && right.elementType is StringType ->
+                        left.elements().mapIndexed { i: Int, v: Value ->
+                            val valueToAdd: String = if (v.asString().varying) {
+                                (v.asString().value + right.getElement(i + 1).asString().value)
                             } else {
-                                StringValue(v.asString().value + " ".repeat(left.elementType.elementSize() - v.asString().value.length) + right.getElement(i + 1).asString().value)
+                                (v.asString().value + " ".repeat(left.elementType.elementSize() - v.asString().value.length) + right.getElement(i + 1).asString().value)
                             }
-                            result.setElement(i + 1, valueToAdd)
+                            StringValue(valueToAdd, left.elementType.hasVariableSize())
                         }
-                    }
-                    left.elementType is NumberType && right.elementType is NumberType -> {
-                        result.elements().forEachIndexed { i: Int, v: Value ->
+                    left.elementType is NumberType && right.elementType is NumberType ->
+                        left.elements().mapIndexed { i: Int, v: Value ->
                             val rightElement = right.getElement(i + 1)
                             when {
                                 v is IntValue && rightElement is IntValue -> {
-                                    result.setElement(i + 1, v + rightElement)
+                                    (v + rightElement)
                                 }
                                 v is NumberValue && rightElement is NumberValue -> {
-                                    result.setElement(i + 1, DecimalValue(v.bigDecimal.plus(rightElement.bigDecimal)))
+                                    DecimalValue(v.bigDecimal.plus(rightElement.bigDecimal))
                                 }
                                 else -> throw UnsupportedOperationException("Unable to sum ${left.elementType} and ${right.elementType} as Array elements at ${expression.position}")
                             }
                         }
-                    }
                     else -> throw UnsupportedOperationException("Unable to sum ${left.elementType} and ${right.elementType} as Array elements at ${expression.position}")
-                }
-                result
+                } as MutableList<Value>
+                ConcreteArrayValue(listValue, left.elementType)
             }
             else -> {
                 throw UnsupportedOperationException("I do not know how to sum $left and $right at ${expression.position}")

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -572,6 +572,15 @@ open class InterpreterTest : AbstractTest() {
     }
 
     @Test
+    /**
+     * Test the '+' operator with arrays
+     */
+    fun executeEVALARRAY3() {
+        val expected = listOf("1(A ) 2(B ) 3( C) 4(  )", "1(1) 2(4) 3(3) 4(0)")
+        assertEquals(expected, "EVALARRAY3".outputOf())
+    }
+
+    @Test
     fun executeARRAY12() {
         assertCanBeParsed(exampleName = "ARRAY12", printTree = true)
         assertEquals(listOf("AA", "BB"), outputOf("ARRAY12"))

--- a/rpgJavaInterpreter-core/src/test/resources/EVALARRAY3.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/EVALARRAY3.rpgle
@@ -1,0 +1,35 @@
+     D A_STR1          S              1    DIM(3)
+     D A_STR2          S              2    DIM(4)
+     D A_INT1          S              1  0 DIM(3)
+     D A_INT2          S              1  0 DIM(4)
+      *
+     D RES_S           S              2    DIM(4)
+     D RES_I           S              1  0 DIM(4)
+      *
+     D £DBG_Str        S             52
+      *
+     C                   EVAL      A_STR1(1)='A'
+     C                   EVAL      A_STR1(2)='B'
+     C                   EVAL      A_STR2(3)='C'
+     C                   EVAL      A_STR2(4)='D'
+     C                   EVAL      RES_S=A_STR1+A_STR2
+     C                   EVAL      £DBG_Str='1('+RES_S(1)+')'
+     C                                    +' 2('+RES_S(2)+')'
+     C                                    +' 3('+RES_S(3)+')'
+     C                                    +' 4('+RES_S(4)+')'
+      * Expect '1(A ) 2(B ) 3( C) 4(  )'
+     C     £DBG_Str      DSPLY
+      *
+     C                   EVAL      A_INT1(1)=1
+     C                   EVAL      A_INT1(2)=2
+     C                   EVAL      A_INT2(2)=2
+     C                   EVAL      A_INT2(3)=3
+     C                   EVAL      RES_I=A_INT1+A_INT2
+     C                   EVAL      £DBG_Str='1('+%CHAR(RES_I(1))+')'
+     C                                    +' 2('+%CHAR(RES_I(2))+')'
+     C                                    +' 3('+%CHAR(RES_I(3))+')'
+     C                                    +' 4('+%CHAR(RES_I(4))+')'
+      * Expect '1(1) 2(4) 3(3) 4(0)'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description

Fixed the assignment between Array and Array by `+` operator in `EVAL` statement.

Related to # (issue)
MULANGT90 - SEZ_A80 - P04

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
