### PR TITLE
fix: when right array is smaller than left array

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -22,6 +22,7 @@ import com.smeup.rpgparser.utils.asBigDecimal
 import com.smeup.rpgparser.utils.asLong
 import com.smeup.rpgparser.utils.divideAtIndex
 import com.smeup.rpgparser.utils.moveEndingString
+import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.specificProcess
 import java.math.BigDecimal
 import java.math.MathContext
@@ -132,49 +133,53 @@ class ExpressionEvaluation(
                 DecimalValue(left.bigDecimal.plus(right.bigDecimal))
             }
             left is ArrayValue && right is ArrayValue -> {
-                val listValue = when {
-                    left.elementType is StringType && right.elementType is StringType ->
-                        left.elements().mapIndexed { i: Int, v: Value ->
-                            if (right.elements().size > i) {
-                                val rightElement = right.getElement(i + 1)
-
-                                val valueToAdd: String = if (v.asString().varying) {
-                                    (v.asString().value + rightElement.asString().value)
-                                } else {
-                                    (v.asString().value + " ".repeat(left.elementType.elementSize() - v.asString().value.length) + rightElement.asString().value)
-                                }
-                                StringValue(valueToAdd, left.elementType.hasVariableSize())
-                            } else {
-                                v
-                            }
-                        }
-                    left.elementType is NumberType && right.elementType is NumberType ->
-                        left.elements().mapIndexed { i: Int, v: Value ->
-                            if (right.elements().size > i) {
-                                val rightElement = right.getElement(i + 1)
-                                when {
-                                    v is IntValue && rightElement is IntValue -> {
-                                        (v + rightElement)
-                                    }
-
-                                    v is NumberValue && rightElement is NumberValue -> {
-                                        DecimalValue(v.bigDecimal.plus(rightElement.bigDecimal))
-                                    }
-
-                                    else -> throw UnsupportedOperationException("Unable to sum ${left.elementType} and ${right.elementType} as Array elements at ${expression.position}")
-                                }
-                            } else {
-                                v
-                            }
-                        }
-                    else -> throw UnsupportedOperationException("Unable to sum ${left.elementType} and ${right.elementType} as Array elements at ${expression.position}")
-                } as MutableList<Value>
-                ConcreteArrayValue(listValue, left.elementType)
+                sum(left, right, expression.position)
             }
             else -> {
                 throw UnsupportedOperationException("I do not know how to sum $left and $right at ${expression.position}")
             }
         }
+    }
+
+    private fun sum(left: ArrayValue, right: ArrayValue, position: Position?): ArrayValue {
+        val listValue = when {
+            left.elementType is StringType && right.elementType is StringType ->
+                left.elements().mapIndexed { i: Int, v: Value ->
+                    if (right.elements().size > i) {
+                        val rightElement = right.getElement(i + 1)
+
+                        val valueToAdd: String = if (v.asString().varying) {
+                            (v.asString().value + rightElement.asString().value)
+                        } else {
+                            (v.asString().value + " ".repeat(left.elementType.elementSize() - v.asString().value.length) + rightElement.asString().value)
+                        }
+                        StringValue(valueToAdd, left.elementType.hasVariableSize())
+                    } else {
+                        v
+                    }
+                }
+            left.elementType is NumberType && right.elementType is NumberType ->
+                left.elements().mapIndexed { i: Int, v: Value ->
+                    if (right.elements().size > i) {
+                        val rightElement = right.getElement(i + 1)
+                        when {
+                            v is IntValue && rightElement is IntValue -> {
+                                (v + rightElement)
+                            }
+
+                            v is NumberValue && rightElement is NumberValue -> {
+                                DecimalValue(v.bigDecimal.plus(rightElement.bigDecimal))
+                            }
+
+                            else -> throw UnsupportedOperationException("Unable to sum ${left.elementType} and ${right.elementType} as Array elements at $position")
+                        }
+                    } else {
+                        v
+                    }
+                }
+            else -> throw UnsupportedOperationException("Unable to sum ${left.elementType} and ${right.elementType} as Array elements at $position")
+        } as MutableList<Value>
+        return ConcreteArrayValue(listValue, left.elementType)
     }
 
     override fun eval(expression: MinusExpr): Value {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -79,4 +79,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf("A70_AR1(10) A70_AR2(20) A70_DS1(30) A70_AR3(10)")
         assertEquals(expected, "smeup/T16_A70".outputOf())
     }
+
+    @Test
+    fun executeT16_A80() {
+        val expected = listOf("A80_AR3(1)(10)A80_AR3(2)(32)A80_AR3(3)(26)")
+        assertEquals(expected, "smeup/T16_A80".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T16_A80.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T16_A80.rpgle
@@ -1,0 +1,22 @@
+     D A80_AR1         S             10I 0 DIM(5)
+     D A80_AR2         S             10I 0 DIM(15)
+     D A80_AR3         S             10I 0 DIM(20)
+     D £DBG_Str        S             52
+      *
+     C                   EVAL      A80_AR1(1)=9
+     C                   EVAL      A80_AR1(2)=5
+     C                   EVAL      A80_AR1(3)=16
+     C                   EVAL      A80_AR1(4)=13
+     C                   EVAL      A80_AR1(5)=3
+     C                   CLEAR                   A80_AR2
+     C                   CLEAR                   A80_AR3
+     C                   EVAL      A80_AR2=%SUBARR(A80_AR1 : 2)
+     C                   EVAL      A80_AR3=A80_AR2 + %SUBARR(A80_AR1:2:3)
+     C                   EVAL      £DBG_Str =
+     C                                  'A80_AR3(1)('+%CHAR(A80_AR3(1))+')'
+     C                                 +'A80_AR3(2)('+%CHAR(A80_AR3(2))+')'
+     C                                 +'A80_AR3(3)('+%CHAR(A80_AR3(3))+')'
+      * Expected 'A80_AR3(1)(10)A80_AR3(2)(32)A80_AR3(3)(26)'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description

Fix `EVAL` array + array. Fix case when right array is smaller than left array.

Related to # (issue)
MULANGT16 - A80 - P04

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
