### PR TITLE
fix: %char format of the result of DivExpr

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -189,7 +189,13 @@ class ExpressionEvaluation(
 
     override fun eval(expression: CharExpr): Value {
         val value = expression.value.evalWith(this)
-        return StringValue(value.stringRepresentation(expression.format).trim())
+        return if (expression.value is DivExpr) {
+            // are always return 10 decimal digits
+            // fill with 0 if necessary
+            StringValue(value.stringRepresentation(expression.format) + "0".repeat(10 - value.asDecimal().value.scale()))
+        } else {
+            StringValue(value.stringRepresentation(expression.format).trim())
+        }
     }
 
     override fun eval(expression: LookupExpr): Value {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -79,6 +79,12 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
+    fun executeT04_A90() {
+        val expected = listOf("123.4560000000", "1234.5600000000", "123")
+        assertEquals(expected, "smeup/T04_A90".outputOf())
+    }
+
+    @Test
     fun executeT10_A20() {
         val expected = listOf("172.670-22146.863-.987000000")
         assertEquals(expected, "smeup/T10_A20".outputOf())

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A90.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A90.rpgle
@@ -1,0 +1,16 @@
+     D A90_N1          S             20  0
+     D £DBG_Str        S             52
+      *
+     C                   EVAL      A90_N1=123456
+     C                   EVAL      £DBG_Str=%CHAR(A90_N1/1000)
+      * Expected '123.4560000000'
+     C     £DBG_Str      DSPLY
+     C                   EVAL      £DBG_Str=%CHAR(A90_N1/100)
+      * Expected '1234.5600000000'
+     C     £DBG_Str      DSPLY
+     C                   EVAL      A90_N1=A90_N1/1000
+     C                   EVAL      £DBG_Str=%CHAR(A90_N1)
+      * Expected '123'
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Fix the format of the `%CHAR` expression when include a `DivExpr`.
After some testing I can confirm that the strange behavior described in the implementation is detected only in the case of the div expression.

Related to # (issue)
MULANGT04 - SEZ_A90 - P01 
MULANGT04 - SEZ_A90 - P03

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
