### PR TITLE
feat: add missing case with integer

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -192,7 +192,11 @@ class ExpressionEvaluation(
         return if (expression.value is DivExpr) {
             // are always return 10 decimal digits
             // fill with 0 if necessary
-            StringValue(value.stringRepresentation(expression.format) + "0".repeat(10 - value.asDecimal().value.scale()))
+            if (value.asDecimal().value.scale() != 0) {
+                StringValue(value.stringRepresentation(expression.format) + "0".repeat(10 - value.asDecimal().value.scale()))
+            } else {
+                StringValue(value.stringRepresentation(expression.format) + ".0000000000")
+            }
         } else {
             StringValue(value.stringRepresentation(expression.format).trim())
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -80,7 +80,7 @@ open class SmeupInterpreterTest : AbstractTest() {
 
     @Test
     fun executeT04_A90() {
-        val expected = listOf("123.4560000000", "1234.5600000000", "123")
+        val expected = listOf("123.4560000000", "1234.5600000000", "123456.0000000000", "123")
         assertEquals(expected, "smeup/T04_A90".outputOf())
     }
 

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A90.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A90.rpgle
@@ -5,9 +5,17 @@
      C                   EVAL      £DBG_Str=%CHAR(A90_N1/1000)
       * Expected '123.4560000000'
      C     £DBG_Str      DSPLY
+      *
      C                   EVAL      £DBG_Str=%CHAR(A90_N1/100)
       * Expected '1234.5600000000'
      C     £DBG_Str      DSPLY
+      *
+     C                   EVAL      A90_N1=123456000
+     C                   EVAL      £DBG_Str=%CHAR(A90_N1/1000)
+      * Expected '123456.0000000000'
+     C     £DBG_Str      DSPLY
+      *
+     C                   EVAL      A90_N1=123456
      C                   EVAL      A90_N1=A90_N1/1000
      C                   EVAL      £DBG_Str=%CHAR(A90_N1)
       * Expected '123'


### PR DESCRIPTION
## Description

Little fix for the previous PR (https://github.com/smeup/jariko/pull/387) to handle Integer exception. The result of `DivExpr` is `DecimalValue` but with no decimal digits. The previous implementation doesn't add decimal separator automatically.

Related to # (issue)
MULANGT04 - SEZ_A90 - P01
MULANGT04 - SEZ_A90 - P03

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
