### PR TITLE
fix: remove unnecessary array type check

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
@@ -131,10 +131,6 @@ data class StringType(val length: Int, val varying: Boolean = false) : Type() {
     override fun hasVariableSize(): Boolean {
         return varying
     }
-
-    override fun canBeAssigned(type: Type): Boolean {
-        return type is StringType
-    }
 }
 
 @Serializable
@@ -324,11 +320,7 @@ fun Expression.type(): Type {
                     NumberType(max(leftType.entireDigits, rightType.entireDigits), max(leftType.decimalDigits, rightType.decimalDigits))
                 }
                 leftType is ArrayType && rightType is ArrayType -> {
-                    if (leftType.element.canBeAssigned(rightType.element)) {
-                        leftType
-                    } else {
-                        throw UnsupportedOperationException("Unable to sum different type of arrays in EVAL statement")
-                    }
+                    leftType
                 }
                 else -> TODO("We do not know the type of a sum of types $leftType and $rightType")
             }


### PR DESCRIPTION
## Description

Fix performance issue after #384.
Remove unnecessary type check of `ArrayType` `PlusExpr` `ArrayType`

Related to # (issue)
#384

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
