### PR TITLE
Fixed delta issue in occur statement

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -917,12 +917,23 @@ data class ClearStmt(
     override fun execute(interpreter: InterpreterCore) {
         return when (value) {
             is DataRefExpr -> {
-                val value = interpreter.assign(value, BlanksRefExpr())
+                val newValue: Value
+                /*
+                 If DataRef is referred to an OccurableDataStructureType read the
+                 last cursor position and assisgn it to new blanck object
+                 */
+                if (this.value.variable.referred?.type is OccurableDataStructureType) {
+                    val origValue = interpreter.eval(value) as OccurableDataStructValue
+                    newValue = interpreter.assign(value, BlanksRefExpr()) as OccurableDataStructValue
+                    newValue.pos(origValue.occurrence)
+                } else {
+                    newValue = interpreter.assign(value, BlanksRefExpr())
+                }
                 interpreter.log {
                     ClearStatemenExecutionLog(
                             interpreter.getInterpretationContext().currentProgramName,
                             this,
-                            value
+                            newValue
                     )
                 }
             }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -164,4 +164,11 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T04_A70".outputOf())
     }
+    @Test
+    fun executeT40_A10_P07() {
+        val expected = listOf(
+            "1B"
+        )
+        assertEquals(expected, "smeup/T40_A10_P07".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T40_A10_P07.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T40_A10_P07.rpgle
@@ -1,0 +1,28 @@
+      **************************************************************************
+     D £DBG_Str        S           2560                                         Stringa
+      *
+     D A10_DS2         DS                  OCCURS(3)
+     D  DS2_FL1                       3  0
+     D  DS2_FL2                      10
+     D  DS2_FL3                       1
+      *
+     D A10_A1          S             15
+      *
+     C     3             OCCUR     A10_DS2
+     C                   EVAL      DS2_FL1 = 114
+     C                   EVAL      DS2_FL2 = 'PROVA 3'
+     C                   EVAL      DS2_FL3 = 'C'
+      * The problem was on next statement: on AS400 the CLEAR statement clean
+      * the DS content but don't reset the OCCOUR index to 1.
+     C                   CLEAR                   A10_DS2
+     C                   EVAL      DS2_FL1=1
+     C                   EVAL      DS2_FL2='PROVA 2'
+     C                   EVAL      DS2_FL3='B'
+     C     3             OCCUR     A10_DS2
+     C                   EVAL      A10_A1=%CHAR(DS2_FL1)
+     C                   OCCUR     A10_DS2
+     C                   EVAL      A10_A1=%TRIMR(A10_A1)+DS2_FL3
+     C                   EVAL      £DBG_Str=A10_A1
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Resolved the delta type issue in the OCCUR statement.
The problem was not related to the OCCUR statement but was attributed to the CLEAR statement: on AS400, the CLEAR statement invoked on a DS with OCCURS erases the content of all elements but leaves the OCCUR pointer position unchanged. In Jariko, however, the CLEAN statement not only cleans all elements of the DS but also moves the pointer to the first element.
To solve the problem, the clean procedure of a DS with OCCURS was modified.

Related to:

- MULANGT40-A10-P07

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
