### PR TITLE
Feature/nw23001440/add reset

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -175,7 +175,8 @@ data class DataDefinition(
     override val position: Position? = null,
     override var const: Boolean = false,
     var paramPassedBy: ParamPassedBy = ParamPassedBy.Reference,
-    var paramOptions: List<ParamOption> = mutableListOf()
+    var paramOptions: List<ParamOption> = mutableListOf(),
+    var defaultValue: Value? = null,
 ) :
     AbstractDataDefinition(
         name = name.apply { require(this.trim().isNotEmpty()) { "name cannot be empty" } },

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -176,7 +176,7 @@ data class DataDefinition(
     override var const: Boolean = false,
     var paramPassedBy: ParamPassedBy = ParamPassedBy.Reference,
     var paramOptions: List<ParamOption> = mutableListOf(),
-    var defaultValue: Value? = null,
+    var defaultValue: Value? = null
 ) :
     AbstractDataDefinition(
         name = name.apply { require(this.trim().isNotEmpty()) { "name cannot be empty" } },

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -176,7 +176,7 @@ data class DataDefinition(
     override var const: Boolean = false,
     var paramPassedBy: ParamPassedBy = ParamPassedBy.Reference,
     var paramOptions: List<ParamOption> = mutableListOf(),
-    var defaultValue: Value? = null
+    @Transient var defaultValue: Value? = null
 ) :
     AbstractDataDefinition(
         name = name.apply { require(this.trim().isNotEmpty()) { "name cannot be empty" } },

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -272,6 +272,9 @@ open class InternalInterpreter(
 
                 if (value != null) {
                     set(it, coerce(value, it.type))
+                    if (it is DataDefinition) {
+                        it.defaultValue = globalSymbolTable[it].copy()
+                    }
                     executeMutes(it.muteAnnotations, compilationUnit, "(data definition)")
                 }
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -675,9 +675,7 @@ object LowValValue : Value {
 
 object ZeroValue : Value {
 
-    override fun copy(): Value {
-        TODO("not implemented")
-    }
+    override fun copy() = this
 
     override fun toString(): String {
         return "ZeroValue"

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -79,6 +79,7 @@ private val modules = SerializersModule {
         subclass(ReadPreviousStmt::class)
         subclass(ReadPreviousEqualStmt::class)
         subclass(ReadStmt::class)
+        subclass(ResetStmt::class)
         subclass(ReturnStmt::class)
         subclass(ScanStmt::class)
         subclass(SelectStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -23,7 +23,10 @@ import com.smeup.dbnative.file.Result
 import com.smeup.rpgparser.MuteParser
 import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.interpreter.*
-import com.smeup.rpgparser.parsing.parsetreetoast.*
+import com.smeup.rpgparser.parsing.parsetreetoast.acceptBody
+import com.smeup.rpgparser.parsing.parsetreetoast.error
+import com.smeup.rpgparser.parsing.parsetreetoast.isInt
+import com.smeup.rpgparser.parsing.parsetreetoast.toAst
 import com.smeup.rpgparser.utils.ComparisonOperator
 import com.smeup.rpgparser.utils.divideAtIndex
 import com.smeup.rpgparser.utils.resizeTo
@@ -1743,8 +1746,8 @@ fun OccurableDataStructValue.pos(occurrence: Int, interpreter: InterpreterCore, 
 
 @Serializable
 data class OpenStmt(
-    @Transient open val name: String = "", // Factor 2
-    @Transient override val position: Position? = null,
+    val name: String = "", // Factor 2
+    override val position: Position? = null,
     val operationExtender: String?,
     val errorIndicator: IndicatorKey?
 ) : Statement(position) {
@@ -1760,8 +1763,8 @@ data class OpenStmt(
 }
 @Serializable
 data class CloseStmt(
-    @Transient open val name: String = "", // Factor 2
-    @Transient override val position: Position? = null,
+    val name: String = "", // Factor 2
+    override val position: Position? = null,
     val operationExtender: String?,
     val errorIndicator: IndicatorKey?
 ) : Statement(position) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -23,11 +23,9 @@ import com.smeup.dbnative.file.Result
 import com.smeup.rpgparser.MuteParser
 import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.interpreter.*
-import com.smeup.rpgparser.parsing.parsetreetoast.acceptBody
-import com.smeup.rpgparser.parsing.parsetreetoast.isInt
-import com.smeup.rpgparser.parsing.parsetreetoast.toAst
-import com.smeup.rpgparser.utils.divideAtIndex
+import com.smeup.rpgparser.parsing.parsetreetoast.*
 import com.smeup.rpgparser.utils.ComparisonOperator
+import com.smeup.rpgparser.utils.divideAtIndex
 import com.smeup.rpgparser.utils.resizeTo
 import com.smeup.rpgparser.utils.substringOfLength
 import com.strumenta.kolasu.model.*
@@ -1822,4 +1820,25 @@ data class XlateStmt(
     }
 
     override fun dataDefinition() = dataDefinition?.let { listOf(it) } ?: emptyList()
+}
+
+@Serializable
+data class ResetStmt(
+    val name: String,
+    override val position: Position? = null
+) : Statement(position) {
+
+    override fun execute(interpreter: InterpreterCore) {
+        val dataDefinition = interpreter.dataDefinitionByName(name)
+        require(dataDefinition != null) {
+            this.error("Data definition $name not found")
+        }
+        require(dataDefinition is DataDefinition) {
+            this.error("Data definition $name is not an instance of DataDefinition")
+        }
+        require(dataDefinition.defaultValue != null) {
+            this.error("Data definition $name has no default value")
+        }
+        interpreter.assign(dataDefinition, dataDefinition.defaultValue!!)
+    }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -528,8 +528,8 @@ private fun ProcedureContext.getDataDefinitions(conf: ToAstConfiguration = ToAst
     // First pass ignore exception and all the know definitions
     dataDefinitionProviders.addAll(this.subprocedurestatement()
         .mapNotNull {
-            it.statement()?.let { statementContext -> statementContext.toDataDefinitionProvider(conf = conf,
-                knownDataDefinitions = knownDataDefinitions) }
+            it.statement()?.toDataDefinitionProvider(conf = conf,
+                knownDataDefinitions = knownDataDefinitions)
         })
 
     // Second pass, everything, I mean everything
@@ -584,7 +584,7 @@ private fun ProcedureContext.getDataDefinitions(conf: ToAstConfiguration = ToAst
 }
 
 internal fun FunctionContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Expression {
-    return when (this.functionName().text.toUpperCase()) {
+    return when (this.functionName().text.uppercase(Locale.getDefault())) {
         "NOT" -> {
             if (this.args().expression().size != 1) {
                 throw IllegalStateException("Not should have just one parameter")
@@ -928,15 +928,15 @@ private fun annidatedReferenceExpression(
 ): AssignableExpression {
     // FIXME: This is very, very, very ugly. It should be fixed by parsing this properly
     //        in the grammar
-    if (text.toUpperCase() == "*IN") {
+    if (text.uppercase(Locale.getDefault()) == "*IN") {
         return GlobalIndicatorExpr(position)
     }
-    if (text.toUpperCase().startsWith("*IN(") && text.endsWith(")")) {
-        val index = text.toUpperCase().removePrefix("*IN(").removeSuffix(")").toInt()
+    if (text.uppercase(Locale.getDefault()).startsWith("*IN(") && text.endsWith(")")) {
+        val index = text.uppercase(Locale.getDefault()).removePrefix("*IN(").removeSuffix(")").toInt()
         return IndicatorExpr(index, position)
     }
-    if (text.toUpperCase().startsWith("*IN")) {
-        val index = text.toUpperCase().removePrefix("*IN").toInt()
+    if (text.uppercase(Locale.getDefault()).startsWith("*IN")) {
+        val index = text.uppercase(Locale.getDefault()).removePrefix("*IN").toInt()
         return IndicatorExpr(index, position)
     }
     var expr: Expression = text.indexOf("(").let {
@@ -1129,7 +1129,7 @@ internal fun indicators(cspecs: Cspec_fixed_standard_partsContext, considerPosit
             .asSequence()
             .map { it.text }
             .filter { !it.isNullOrBlank() }
-            .map(String::toUpperCase)
+            .map(String::uppercase)
             .map {
                 IndicatorExpr(it.toIndicatorKey(), cspecs.toPosition(considerPosition))
             }
@@ -1152,7 +1152,7 @@ internal fun CsRETURNContext.toAst(conf: ToAstConfiguration = ToAstConfiguration
 }
 
 internal fun CsEVALContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): EvalStmt {
-    val extenders = this.operationExtender?.extender?.text?.toUpperCase()?.toCharArray() ?: CharArray(0)
+    val extenders = this.operationExtender?.extender?.text?.uppercase(Locale.getDefault())?.toCharArray() ?: CharArray(0)
     val flags = EvalFlags(
         halfAdjust = 'H' in extenders,
         maximumNumberOfDigitsRule = 'M' in extenders,
@@ -1178,7 +1178,7 @@ internal fun CsSUBDURContext.toAst(conf: ToAstConfiguration = ToAstConfiguration
 }
 
 private fun String.toDuration(): DurationCode =
-    when (toUpperCase()) {
+    when (uppercase(Locale.getDefault())) {
         "*D", "*DAYS" -> DurationInDays
         "*MS", "*MSECONDS" -> DurationInMSecs
         "*S", "*SECONDS" -> DurationInSecs
@@ -1305,7 +1305,7 @@ private fun String.toDoubleExpression(position: Position?, index: Int, conf: ToA
     val baseStringTokens = this.split(":")
     val startPosition = 0
     var reference = baseStringTokens[index]
-    var ret: Expression
+    val ret: Expression
 
     val regexp = Regex("'(.*?)'")
     if (reference.matches(regexp)) {
@@ -1385,7 +1385,7 @@ internal fun CsMULTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
     val factor1 = leftExpr(conf)
     val factor2 = this.cspec_fixed_standard_parts().factor2Expression(conf) ?: throw UnsupportedOperationException("SUB operation requires factor 2: ${this.text} - ${position.atLine()}")
     this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
-    val extenders = this.operationExtender?.extender?.text?.toUpperCase()?.toCharArray() ?: CharArray(0)
+    val extenders = this.operationExtender?.extender?.text?.uppercase(Locale.getDefault())?.toCharArray() ?: CharArray(0)
     val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
     return MultStmt(
         target = DataRefExpr(ReferenceByName(result), position),
@@ -1403,7 +1403,7 @@ internal fun CsDIVContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
     val factor1 = leftExpr(conf)
     val factor2 = this.cspec_fixed_standard_parts().factor2Expression(conf) ?: throw UnsupportedOperationException("SUB operation requires factor 2: ${this.text} - ${position.atLine()}")
     this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
-    val extenders = this.operationExtender?.extender?.text?.toUpperCase()?.toCharArray() ?: CharArray(0)
+    val extenders = this.operationExtender?.extender?.text?.uppercase(Locale.getDefault())?.toCharArray() ?: CharArray(0)
     val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
     val mvrTarget: AssignableExpression? = this.csMVR()?.cspec_fixed_standard_parts()?.result?.text?.let {
         DataRefExpr(ReferenceByName(it), position)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -902,6 +902,9 @@ internal fun Cspec_fixed_standardContext.toAst(conf: ToAstConfiguration = ToAstC
         this.csXLATE() != null -> this.csXLATE()
             .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
 
+        this.csRESET() != null -> this.csRESET()
+            .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
+
         else -> todo(conf = conf)
     }
 }
@@ -1853,6 +1856,15 @@ internal fun CsCLOSEContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
         position = position,
         operationExtender = this.operationExtender?.text,
         errorIndicator = this.cspec_fixed_standard_parts().lo.asIndex()
+    )
+}
+
+internal fun CsRESETContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+    val position = toPosition(conf.considerPosition)
+    val name = this.cspec_fixed_standard_parts().factor2.text ?: this.error(message = "RESET operation requires factor", conf = conf)
+    return ResetStmt(
+        name = name,
+        position = position
     )
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1861,9 +1861,18 @@ internal fun CsCLOSEContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 
 internal fun CsRESETContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
-    val name = this.cspec_fixed_standard_parts().factor2.text ?: this.error(message = "RESET operation requires factor", conf = conf)
+    require(this.cspec_fixed_standard_parts().factor().text.isEmptyTrim()) {
+        "RESET operation does not support factor1"
+    }
+    require(this.cspec_fixed_standard_parts().factor2.text.isEmptyTrim()) {
+        "RESET operation does not support factor2"
+    }
+    val result = this.cspec_fixed_standard_parts().result.text
+    require(!result.isEmptyTrim()) {
+        "RESET operation requires result"
+    }
     return ResetStmt(
-        name = name,
+        name = result,
         position = position
     )
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
@@ -45,7 +45,7 @@ abstract class AbstractTest {
     @BeforeTest
     fun beforeTest() {
         // I don't like but until I won't be able to refactor the test units through
-        // the unification of the SytemInterfaces I need to use this workaround
+        // the unification of the SystemInterfaces I need to use this workaround
         SingletonRpgSystem.reset()
         // It is necessary to fix a problem where  some older tests not running in MainExecutionContext could propagate
         // the errors to the following tests
@@ -64,7 +64,7 @@ abstract class AbstractTest {
 
     /**
      * Create ast for exampleName. Let's assume that: testResourceDir is rpgJavaInterpreter-core/src/test/resources
-     * @param exampleName Relative path respect testResourceDir where is located source file-
+     * @param exampleName Relative path respect testResourceDir where is located source file
      * For example if we have to assert AST of testResourceDir/MYPGM.rpgle, you are going to specify MYPGM,
      * elsewhere if you need to test testResourceDir/QILEGEN/MYPGM.rpgle you are going to specify QILEGEN/MYPGM
      * @param considerPosition If true parsing or ast creation error include also line number, default false
@@ -93,6 +93,7 @@ abstract class AbstractTest {
 
     /**
      * Executes a program and returns the output as a list of displayed messages.
+     * **This function non provides all features of jariko, I suggest to use String.outputOf**
      *
      * @param programName The name of the program to be executed.
      * @param initialValues The initial values for the program.
@@ -102,12 +103,9 @@ abstract class AbstractTest {
      * @param trimEnd A boolean value indicating whether the output should be trimmed or not. Default value is true.
      *
      * @return A list of strings representing the output of the program. If trimEnd is true, the strings are trimmed.
+     * @see String.outputOf
+     *
      */
-    @Deprecated(
-        message = "This function does not provide all the features of Jariko",
-        replaceWith = ReplaceWith(expression = "String.outputOf()", imports = ["com.smeup.rpgparser.AbstractTest.outputOf"]),
-        level = DeprecationLevel.WARNING
-    )
     fun outputOf(
         programName: String,
         initialValues: Map<String, Value> = mapOf(),

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2196,4 +2196,10 @@ Test 6
         val expected = listOf("IF1 = True", "IF2 = True", "IF3 = True", "IF4 = True", "IF5 = False", "IF6 = False", "IF7 = False", "IF8 = True")
         assertEquals(expected, "MIXED_CONDITIONS".outputOf())
     }
+
+    @Test
+    fun executeRESET01() {
+        val expected = listOf("A1:", "A2:", "N1:1", "N2:1.1", "DSA1:", "DSA2:", "DSN1:1", "DSN2:1.1", "9")
+        assertEquals(expected, "RESET01".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2199,7 +2199,7 @@ Test 6
 
     @Test
     fun executeRESET01() {
-        val expected = listOf("A1:", "A2:", "N1:1", "N2:1.1", "DSA1:", "DSA2:", "DSN1:1", "DSN2:1.1", "9")
+        val expected = listOf("A1_OK", "A2_OK", "A3_OK", "N1_OK", "N2_OK", "N3_OK", "DS_OK", "DSA1_OK", "DSA2_OK")
         assertEquals(expected, "RESET01".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -177,4 +177,12 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T40_A10_P07".outputOf())
     }
+
+    @Test
+    fun executeT40_A10_P03D() {
+        val expected = listOf(
+            "Post-RESET: A    -44"
+        )
+        assertEquals(expected, "smeup/T40_A10_P03D".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -181,7 +181,7 @@ open class SmeupInterpreterTest : AbstractTest() {
     @Test
     fun executeT40_A10_P03D() {
         val expected = listOf(
-            "Post-RESET: A    -44"
+            "Contenuto Post-RESET: A    -44"
         )
         assertEquals(expected, "smeup/T40_A10_P03D".outputOf())
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTestCompiled.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTestCompiled.kt
@@ -1,0 +1,6 @@
+package com.smeup.rpgparser.evaluation
+
+open class SmeupInterpreterTestCompiled : SmeupInterpreterTest() {
+
+    override fun useCompiledVersion() = true
+}

--- a/rpgJavaInterpreter-core/src/test/resources/RESET01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/RESET01.rpgle
@@ -2,28 +2,41 @@
      D* 12/01/24  nn.mm author
      V* ==============================================================
 
-     D MSG             S             50          VARYING
+     D MSGOK           S             50          VARYING
+     D MSGKO           S             50          VARYING
      
      D A1              S             30
      D A2              S             30          VARYING
+     D A3              S              1          INZ('A3')
      D N1              S              5  0
      D N2              S              5  2
-    
+     D N3              S              5  2       INZ(1.1)
+
+     D A1_INZ          S             30
+     D A2_INZ          S             30          VARYING
+     D A3_INZ          S              1          INZ('A3')
+     D N1_INZ          S              5  0
+     D N2_INZ          S              5  2
+     D N3_INZ          S              5  2       INZ(1.1)
+
+   
      D DS              DS                  
      D  DSA1                        30      
-     D  DSA2                        30
-     D  DSN1                          5  0
-     D  DSN2                          5  2
+     D  DSA2                         4           INZ('DSA2')
+
+     D DS_INZ          DS                  
+     D  DSA1_INZ                    30      
+     D  DSA2_INZ                     4           INZ('DSA2')
+
+
 
      C                   EVAL      A1 = 'A1'
      C                   EVAL      A2 = 'A2'
      C                   EVAL      N1 = 1
      C                   EVAL      N2 = 1.1
 
-     C     C             EVAL      DSA1='DSA1'
-     C     C             EVAL      DSA2='DSA2'
-     C     C             EVAL      DSN1=1
-     C     C             EVAL      DSN2=1.1
+     C                   EVAL      DSA1='DSA1'
+     C                   EVAL      DSA2='DSA2'
 
      C                   RESET     A1
      C                   RESET     A2
@@ -31,35 +44,77 @@
      C                   RESET     N2
      C                   RESET     DS
 
-
-     C                   EVAL      MSG='A1:' + A1
-     C     MSG           DSPLY      
-
-     C                   EVAL      MSG='A2:' + A2
-     C     MSG           DSPLY     
+     C                   EVAL      MSGOK='A1_OK'
+     C                   EVAL      MSGKO='A1_KO'
+     C     A1            IFEQ      A1_INZ
+     C     MSGOK         DSPLY
+     C                   ELSE
+     C     MSGOK         DSPLY
+     C                   ENDIF     
      
-     C                   EVAL      MSG='N1:' + %CHAR(N1)
-     C     MSG           DSPLY     
-           
-     C                   EVAL      MSG='N2:' + %CHAR(N2)      
-     C     MSG           DSPLY     
+     C                   EVAL      MSGOK='A2_OK'
+     C                   EVAL      MSGKO='A2_KO'
+     C     A2            IFEQ      A2_INZ
+     C     MSGOK         DSPLY     
+     C                   ELSE
+     C     MSGKO         DSPLY      
+     C                   ENDIF      
      
-     C                   EVAL      MSG='DSA1:' + DSA1
-     C     MSG           DSPLY      
+     C                   EVAL      MSGOK='A3_OK'
+     C                   EVAL      MSGKO='A3_KO'
+     C     A3            IFEQ      A3_INZ
+     C     MSGOK         DSPLY     
+     C                   ELSE
+     C     MSGKO         DSPLY     
+     C                   ENDIF     
+        
+     C                   EVAL      MSGOK='N1_OK'
+     C                   EVAL      MSGKO='N1_KO'
+     C     N1            IFEQ      N1_INZ
+     C     MSGOK         DSPLY     
+     C                   ELSE
+     C     MSGKO         DSPLY     
+     C                   ENDIF      
+
+     C                   EVAL      MSGOK='N2_OK'    
+     C                   EVAL      MSGKO='N2_KO'
+     C     N2            IFEQ      N2_INZ
+     C     MSGOK         DSPLY     
+     C                   ELSE
+     C     MSGKO         DSPLY      
+     C                   ENDIF      
      
-     C                   EVAL      MSG='DSA2:' + DSA2
-     C     MSG           DSPLY     
+     C                   EVAL      MSGOK='N3_OK'
+     C                   EVAL      MSGKO='N3_KO'
+     C     N3            IFEQ      N3_INZ
+     C     MSGOK         DSPLY     
+     C                   ELSE
+     C     MSGKO         DSPLY     
+     C                   ENDIF     
+            
 
-     C                   EVAL      MSG='DSN1:' + %CHAR(DSN1)
-     C     MSG           DSPLY     
+     C                   EVAL      MSGOK='DS_OK'
+     C                   EVAL      MSGKO='DS_KO'
+     C     DS            IFEQ      DS_INZ
+     C     MSGOK         DSPLY     
+     C                   ELSE
+     C     MSGKO         DSPLY     
+     C                   ENDIF     
 
-     C                   EVAL      MSG='DSN2:' + %CHAR(DSN2)
-     C     MSG           DSPLY      
+     C                   EVAL      MSGOK='DSA1_OK'
+     C                   EVAL      MSGKO='DSA1_KO'
+     C     DSA1          IFEQ      DSA1_INZ
+     C     MSGOK         DSPLY     
+     C                   ELSE
+     C     MSGKO         DSPLY     
+     C                   ENDIF     
+
+     C                   EVAL      MSGOK='DSA2_OK'
+     C                   EVAL      MSGKO='DSA2_KO'
+     C     DSA2          IFEQ      DSA2_INZ
+     C     MSGOK         DSPLY     
+     C                   ELSE
+     C     MSGKO         DSPLY     
+     C                   ENDIF     
      
      C                   SETON                                        LR
-
-         
-    
-        
-        
-

--- a/rpgJavaInterpreter-core/src/test/resources/RESET01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/RESET01.rpgle
@@ -38,11 +38,11 @@
      C                   EVAL      DSA1='DSA1'
      C                   EVAL      DSA2='DSA2'
 
-     C                   RESET     A1
-     C                   RESET     A2
-     C                   RESET     N1
-     C                   RESET     N2
-     C                   RESET     DS
+     C                   RESET                   A1
+     C                   RESET                   A2
+     C                   RESET                   N1
+     C                   RESET                   N2
+     C                   RESET                   DS
 
      C                   EVAL      MSGOK='A1_OK'
      C                   EVAL      MSGKO='A1_KO'

--- a/rpgJavaInterpreter-core/src/test/resources/RESET01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/RESET01.rpgle
@@ -1,0 +1,65 @@
+     V* ==============================================================
+     D* 12/01/24  nn.mm author
+     V* ==============================================================
+
+     D MSG             S             50          VARYING
+     
+     D A1              S             30
+     D A2              S             30          VARYING
+     D N1              S              5  0
+     D N2              S              5  2
+    
+     D DS              DS                  
+     D  DSA1                        30      
+     D  DSA2                        30
+     D  DSN1                          5  0
+     D  DSN2                          5  2
+
+     C                   EVAL      A1 = 'A1'
+     C                   EVAL      A2 = 'A2'
+     C                   EVAL      N1 = 1
+     C                   EVAL      N2 = 1.1
+
+     C     C             EVAL      DSA1='DSA1'
+     C     C             EVAL      DSA2='DSA2'
+     C     C             EVAL      DSN1=1
+     C     C             EVAL      DSN2=1.1
+
+     C                   RESET     A1
+     C                   RESET     A2
+     C                   RESET     N1
+     C                   RESET     N2
+     C                   RESET     DS
+
+
+     C                   EVAL      MSG='A1:' + A1
+     C     MSG           DSPLY      
+
+     C                   EVAL      MSG='A2:' + A2
+     C     MSG           DSPLY     
+     
+     C                   EVAL      MSG='N1:' + %CHAR(N1)
+     C     MSG           DSPLY     
+           
+     C                   EVAL      MSG='N2:' + %CHAR(N2)      
+     C     MSG           DSPLY     
+     
+     C                   EVAL      MSG='DSA1:' + DSA1
+     C     MSG           DSPLY      
+     
+     C                   EVAL      MSG='DSA2:' + DSA2
+     C     MSG           DSPLY     
+
+     C                   EVAL      MSG='DSN1:' + %CHAR(DSN1)
+     C     MSG           DSPLY     
+
+     C                   EVAL      MSG='DSN2:' + %CHAR(DSN2)
+     C     MSG           DSPLY      
+     
+     C                   SETON                                        LR
+
+         
+    
+        
+        
+

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T40_A10_P03D.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T40_A10_P03D.rpgle
@@ -1,0 +1,11 @@
+     D £DBG_Str        S             99                                         Stringa
+     D A10_DS_P03      DS                                                               
+     D  A10_DS_P03_A                  5    INZ('A')                                     
+     D  A10_DS_P03_B                  4  0 INZ(44)                                      
+                                                                                   
+     C                   RESET                   A10_DS_P03
+     C                   EVAL      £DBG_Str='Contenuto Post-RESET: '                    
+     C                             +A10_DS_P03_A+'-'+%CHAR(A10_DS_P03_B)
+     C* Expected: Contenuto Post-RESET: A    -44
+     C     £DBG_Str      DSPLY                                                          
+     C                   SETON                                        LR  


### PR DESCRIPTION
## Description

Added `RESET` opcode implementation. This implementation supports `RESET` just for data definition.
Created `SmeupInterpreterTestCompiled` in order to test the compiled version of smeup unit tests too.

Related to:
- T40_A10_P03D


## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
