### PR TITLE
Bugfix/nw23001440/fix stringLiteral in case of multiple quote marks

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -71,7 +71,11 @@ internal fun RpgParser.LiteralContext.toAst(conf: ToAstConfiguration = ToAstConf
        children[n] = "'"
      */
     val stringContent = if (this.children.size > 3) {
-        this.children.asSequence().filter { it.text != "'" }.joinToString(separator = "")
+        if (children[0].text == "'" && children[this.children.size - 1].text == "'") {
+            this.children.subList(1, this.children.size - 1).joinToString(separator = "")
+        } else {
+            this.content?.text ?: ""
+        }
     } else {
         this.content?.text ?: ""
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -177,4 +177,12 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T40_A10_P07".outputOf())
     }
+
+    @Test
+    fun executeT02_S10_P01() {
+        val expected = listOf(
+            "abcdefghijklmnopqrstuvwxyzèéàòùABCDEFGHIJKLMNOPQRS        TUVWXYZEEAOUABCDEFGHIJKLMNOPQRSTUVWXYZEEAOUABCDEFGHIJKLMNOPQRSTUVWXYZEEAOUABCDEFGHIJKLMNOPQRSTUVWXYZEEAOUABCDEFGH'''*%"
+        )
+        assertEquals(expected, "smeup/T02_S10_P01".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T02_S10_P01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T02_S10_P01.rpgle
@@ -1,0 +1,33 @@
+     D A10_A1          C                   'abcdefghijklmnopqrs-
+     D                                     tuvwxyzèéàòù'
+     D A10_A2          C                   'ABCDEFGHIJKLMNOPQRS-
+     D                                             TUVWXYZEEAOU'
+     D A10_A3          C                   'ABCDEFGHIJKLMNOPQRS+
+     D                                     TUVWXYZEEAOU'
+     D A10_A4          C                   'ABCDEFGHIJKLMNOPQRS+
+     D                                             TUVWXYZEEAOU'
+     D A10_A5          C                   'ABCDEFGHIJKLMNOPQRSTUVWXYZEEAOU'
+     D A10_A6          C                   CONST('ABCDEFGH')
+     D A10_A7          C                   ''''
+     D A10_A8          C                   ''''''
+     D A10_A9          C                   '*%'
+      *
+     D £DBG_Str        S            180
+      *
+     C                   EVAL      £DBG_Str=A10_A1+A10_A2+A10_A3
+     C                                     +A10_A4+A10_A5+A10_A6
+     C                                     +A10_A7+A10_A8+A10_A9
+     C     £DBG_Str      DSPLY
+      *
+      * Expected:
+      * abcdefghijklmnopqrstuvwxyzèéàòùABCDEFGHIJKLMNOPQRS        TU
+      * VWXYZEEAOUABCDEFGHIJKLMNOPQRSTUVWXYZEEAOUABCDEFGHIJKLMNOPQRS
+      * TUVWXYZEEAOUABCDEFGHIJKLMNOPQRSTUVWXYZEEAOUABCDEFGH'''*%
+      *
+      * Note:
+      * A10_A7: should contain 1 quotation mark:   '
+      * A10_A8: should contain 2 quotation marks:  ''
+      *
+      *
+     C                   SETON                                          LR
+      *


### PR DESCRIPTION
## Description
In this branch has been fixed the problem of wrong parsing of literal expressions containing multiple quotes marks

Related to
- T02_S10_P01

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
