### PR TITLE
bugfix/NW23001440/error indicator on nonexistent program call

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -177,4 +177,13 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T40_A10_P07".outputOf())
     }
+
+    @Test
+    fun executeT20_A10_P05() {
+        val expected = listOf(
+            "1",
+            "0"
+        )
+        assertEquals(expected, "smeup/T20_A10_P05".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T20_A10_P05.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T20_A10_P05.rpgle
@@ -1,0 +1,15 @@
+     D £DBG_Str        S           2560                                         Stringa
+     D TXT             S             10
+      * Test indicator 35 activation when CALL non existent pgm
+     C                   CALL      'XXXXXX_YY'                          35
+     C                   EVAL      £DBG_Str=%CHAR(*IN35)
+     C     £DBG_Str      DSPLY
+      *
+     C                   EVAL      TXT='PING'
+     C                   CALL      'ECHO_PGM'                           35
+     C                   PARM                    TXT
+     C
+     C                   EVAL      £DBG_Str=%CHAR(*IN35)
+     C     £DBG_Str      DSPLY
+      *
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Modified CALL statement implementation for manage error indicator when calling a nonexistent program.

Related to:

MULANGT90-T20_A10_P05 

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
