### PR TITLE
Bugfix/nw23001440/like with arrays

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -401,7 +401,8 @@ internal fun RpgParser.DspecContext.toAst(
                 it.ascend = ascend
             }
         } else {
-            baseType
+            val el = compileTimeInterpreter.evaluate(this.rContext(), dim!!).asInt().value.toInt()
+            (baseType as ArrayType).copy(nElements = el)
         }
     } else {
         baseType

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -121,7 +121,7 @@ open class SmeupInterpreterTest : AbstractTest() {
 
     @Test
     fun executeT16_A70() {
-        val expected = listOf("A70_AR1(10) A70_AR2(20) A70_DS1(30) A70_AR3(10)")
+        val expected = listOf("A70_AR1(10) A70_AR2(20) A70_DS1(30) A70_AR3(10) A70_AR4(40)")
         assertEquals(expected, "smeup/T16_A70".outputOf())
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -193,4 +193,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T40_A10_P03D".outputOf())
     }
+
+    @Test
+    fun executeT02_A50_P03() {
+        val expected = listOf("A50_AR1(10) A50_AR2(40)")
+        assertEquals(expected, "smeup/T02_A50_P03".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A50_P03.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A50_P03.rpgle
@@ -1,0 +1,17 @@
+     D £DBG_Pas        S              3
+     D £DBG_Str        S            100
+      *
+     D A50_AR1         S             10    DIM(10)
+     D A50_AR2         S                   LIKE(A50_AR1) DIM(40)
+     D A50_N3          S              2  0
+      *
+     C                   EVAL      A50_N3 = %ELEM(A50_AR1)
+     C                   EVAL      £DBG_Str='A50_AR1('+%CHAR(A50_N3)+')'
+     C                   EVAL      A50_N3 = %ELEM(A50_AR2)
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                      +' A50_AR2('+%CHAR(A50_N3)+')'
+      * Expected:
+      * 'A50_AR1(10) A50_AR2(40)'
+      *
+     C     £DBG_Str      DSPLY
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T16_A70.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T16_A70.rpgle
@@ -2,9 +2,10 @@
      D A70_AR2         S             10    DIM(20)
      D A70_DS1         DS            20    OCCURS(30)
      D A70_AR3         S             30    DIM(%ELEM(A70_AR1))
+     D A70_AR4         S                   LIKE(A70_AR1) DIM(40)
       *
      D A70_N50         S              5P 0
-     D £DBG_Str        S             72
+     D £DBG_Str        S            100
       *
      C                   EVAL      A70_N50 = %ELEM(A70_AR1)
      C                   EVAL      £DBG_Str ='A70_AR1('+%CHAR(A70_N50)+')'
@@ -17,7 +18,10 @@
      C                   EVAL      A70_N50=%ELEM(A70_AR3)
      C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
      C                                      +' A70_AR3('+%CHAR(A70_N50)+')'
-      * Expect 'A70_AR1(10) A70_AR2(20) A70_DS1(30) A70_AR3(10)'
+     C                   EVAL      A70_N50=%ELEM(A70_AR4)
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                      +' A70_AR4('+%CHAR(A70_N50)+')'
+      * Expect 'A70_AR1(10) A70_AR2(20) A70_DS1(30) A70_AR3(10) A70_AR4(40)'
      C     £DBG_Str      DSPLY
       *
      C                   SETON                                        LR


### PR DESCRIPTION
## Description
In this branch has been fixed the problem of sizing an array when there are both DIM and LIKE keywords

Related to:
- T02_A50_P03 

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
