### PR TITLE
Bugfix/zero number literal initialization

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
@@ -281,7 +281,7 @@ fun Expression.type(): Type {
             NumberType(BigDecimal.valueOf(this.value).precision(), decimalDigits = 0)
         }
         is RealLiteral -> {
-            NumberType(this.value.precision() - this.value.scale(), this.value.scale())
+            NumberType(this.precision - this.value.scale(), this.value.scale())
         }
         is ArrayAccessExpr -> {
             val type = this.array.type().asArray()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
@@ -39,12 +39,21 @@ abstract class Expression(@Transient override val position: Position? = null) : 
 abstract class NumberLiteral(@Transient override val position: Position? = null) : Expression(position)
 
 @Serializable
-data class IntLiteral(val value: Long, override val position: Position? = null) : NumberLiteral(position) {
+data class IntLiteral(
+    val value: Long,
+    override val position: Position? = null,
+    val precision: Int = BigDecimal(value).precision()
+) : NumberLiteral(position) {
     override fun render() = value.toString()
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
 @Serializable
-data class RealLiteral(@Contextual val value: BigDecimal, override val position: Position? = null) : NumberLiteral(position) {
+data class RealLiteral(
+    @Contextual val value: BigDecimal,
+    override val position: Position? = null,
+    val precision: Int = value.precision()
+) : NumberLiteral(position) {
+
     override fun render() = value.toString()
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -85,21 +85,7 @@ internal fun RpgParser.LiteralContext.toAst(conf: ToAstConfiguration = ToAstConf
 internal fun RpgParser.NumberContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): NumberLiteral {
     val position = this.toPosition(conf.considerPosition)
     require(this.NumberPart().isEmpty()) { "Number not empty $position" }
-    val text = (this.MINUS()?.text ?: "") + this.NUMBER().text
-
-    // When assigning a value to a numeric field we could either use
-    // a comma or a dot as decimal separators
-
-    // TODO Rifattorizzare con literalToNumber(text, position)
-    return when {
-        text.contains('.') -> {
-            text.toRealLiteral(position, Locale.US)
-        }
-        text.contains(',') -> {
-            text.toRealLiteral(position, Locale.ITALIAN)
-        }
-        else -> text.toIntLiteral(position)
-    }
+    return literalToNumber(this.text, position)
 }
 
 fun String.toRealLiteral(position: Position?, locale: Locale): RealLiteral {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -647,7 +647,7 @@ fun literalToNumber(
             value.toRealLiteral(position, Locale.ITALIAN)
         }
         else -> {
-            IntLiteral(value.toLong(), position)
+            value.toIntLiteral(position)
         }
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -630,7 +630,7 @@ internal fun FactorContentContext.toAst(conf: ToAstConfiguration): Expression {
 fun literalToNumber(
     text: String,
     position: Position?
-): Expression {
+): NumberLiteral {
     // fix minus at right
     val value = if (text.endsWith('-')) {
         "-" + text.replaceFirst("-", "")

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ExpressionsTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ExpressionsTest.kt
@@ -1,9 +1,11 @@
 package com.smeup.rpgparser.parsing.ast
 
-import com.smeup.rpgparser.*
+import com.smeup.rpgparser.assertExpressionCanBeParsed
+import com.smeup.rpgparser.dataRef
 import com.smeup.rpgparser.parsing.parsetreetoast.ToAstConfiguration
 import com.smeup.rpgparser.parsing.parsetreetoast.toAst
 import com.strumenta.kolasu.model.ReferenceByName
+import java.math.BigDecimal
 import kotlin.test.Ignore
 import kotlin.test.assertEquals
 import org.junit.Test as test
@@ -143,5 +145,21 @@ class ExpressionsTest {
 
     @test fun parseIndicatorsInParenthesis() {
         assertExpressionCanBeParsed("X=*IN(01)")
+    }
+
+    @test fun intLiteralParsingNumberWithPrecision() {
+        assertEquals(IntLiteral(value = 100, precision = 3), expression("100"))
+    }
+
+    @test fun intLiteralParsingZeroWithPrecision() {
+        assertEquals(IntLiteral(value = 0, precision = 3), expression("000"))
+    }
+
+    @test fun realLiteralParsingNumberWithPrecision() {
+        assertEquals(RealLiteral(value = BigDecimal("100.00"), precision = 5), expression("100.00"))
+    }
+
+    @test fun realLiteralParsingZeroWithPrecision() {
+        assertEquals(RealLiteral(value = BigDecimal("0.00"), precision = 3), expression("0.00"))
     }
 }


### PR DESCRIPTION
## Description

If the rpg code contains `0` formatted as `0000 `or `00.00`, the precision of such constants, computed through `IntLiteral` or `RealLiteral`, is always 1.  

This behavior is due to the fact that:
- for the integer constant: `"0000".toLong()` is `0` and the precision is `1`
- for the real constant: `BigDecimal("00.00")` has precision `1` and scale `2`

While the first case was (more on less) predictable, the second one, honestly was not.

However, to fix this issue I have added property `precision` both for `IntLiteral` and `RealLiteral` and lightly changed the `Expression.type()` implementation.

This fix is necessary because `Expression.type()` is vital in the `EDITC` fixing which is in work in progress.

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
