### PR TITLE
Bugfix/nw23001440/scan with colon

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1618,6 +1618,7 @@ data class ScanStmt(
         } while (index >= 0)
         if (occurrences.isEmpty()) {
             interpreter.setIndicators(this, BooleanValue.FALSE, BooleanValue.FALSE, BooleanValue.FALSE)
+            interpreter.assign(target, IntValue(0))
         } else {
             interpreter.setIndicators(this, BooleanValue.FALSE, BooleanValue.FALSE, BooleanValue.TRUE)
             if (target.type().isArray()) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1326,6 +1326,8 @@ private fun FactorContext.toIndexedExpression(conf: ToAstConfiguration): Pair<Ex
     if (this.text.contains(":")) this.text.toIndexedExpression(toPosition(conf.considerPosition)) else this.content.toAst(conf) to null
 
 private fun String.toIndexedExpression(position: Position?): Pair<Expression, Int?> {
+    fun String.isLiteral(): Boolean { return (startsWith('\'') && endsWith('\'')) }
+
     val baseStringTokens = this.split(":")
     val startPosition =
         when (baseStringTokens.size) {
@@ -1334,7 +1336,10 @@ private fun String.toIndexedExpression(position: Position?): Pair<Expression, In
             else -> null
         }
     val reference = baseStringTokens[0]
-    return DataRefExpr(ReferenceByName(reference), position) to startPosition
+    return when {
+        reference.isLiteral() -> StringLiteral(reference.trim('\''), position)
+        else -> DataRefExpr(ReferenceByName(reference), position)
+    } to startPosition
 }
 
 internal fun CsMOVEAContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MoveAStmt {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -1104,7 +1104,7 @@ Test 6
 
     @Test
     fun executeSCANTEST() {
-        assertEquals(listOf("0", "4", "1", "5", "0"), "SCANTEST".outputOf())
+        assertEquals(listOf("0", "4", "1", "5", "0", "0"), "SCANTEST".outputOf())
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -225,4 +225,14 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf("1020")
         assertEquals(expected, "smeup/T10_A20_P19".outputOf())
     }
+
+    @Test
+    fun executeT15_A20_P04_06() {
+        val expected = listOf(
+            "RicercaDaPos01(1)_Trovato(1); RicercaDaPos02(5)_Trovato(1); RicercaDaPos05(5)_Trovato(1); RicercaDaPos07(0)_Trovato(0);",
+            "RicercaDaPos01(5)_Trovato(1); RicercaDaPos01(1)_Trovato(1); RicercaDaPos01(5)_Trovato(1);",
+            "RicercaDaPos01(2)_Trovato(1);"
+        )
+        assertEquals(expected, "smeup/T15_A20_P04-06".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/SCANTEST.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/SCANTEST.rpgle
@@ -32,4 +32,11 @@
       * for three characters:  'r. '
      C                   dsply                   Msg
      *********************************************************************
+      * Test with start higher than length of word.
+     C                   EVAL      $$SVAR='Dr. Doolittle'
+     C                   EVAL      $BRACK=%SCAN('e':$$SVAR:14)
+     C                   Eval      Msg  = %CHAR($BRACK)
+      * Expected 0 the value of start higher than length of word.
+     C                   dsply                   Msg
+     *********************************************************************
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A20_P04-06.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A20_P04-06.rpgle
@@ -1,0 +1,46 @@
+     D A20_A20A        S             20    INZ('!ABC!ABCDEF')
+     D A20_N20R        S              2  0
+     D £DBG_Str        S             100          VARYING
+
+     C                   SETOFF                                       202122
+     C     '!':1         SCAN      A20_A20A      A20_N20R                 20
+     C                   EVAL      £DBG_Str='RicercaDaPos01('
+     C                               +%CHAR(A20_N20R)
+     C                               +')_Trovato('+%CHAR(*IN20)+');'
+     C     '!':1         SCAN      A20_A20A:2    A20_N20R                 21
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +' RicercaDaPos02('+%CHAR(A20_N20R)
+     C                               +')_Trovato('+%CHAR(*IN21)+');'
+     C     '!':1         SCAN      A20_A20A:5    A20_N20R                 22
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +' RicercaDaPos05('+%CHAR(A20_N20R)
+     C                               +')_Trovato('+%CHAR(*IN22)+');'
+     C                   SETOFF                                           20
+     C     '!':1         SCAN      A20_A20A:7    A20_N20R                 20
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +' RicercaDaPos07('+%CHAR(A20_N20R)
+     C                               +')_Trovato('+%CHAR(*IN20)+');'
+     C     £DBG_Str      DSPLY
+
+     C                   SETOFF                                       202122
+     C     '!ABCD'       SCAN      A20_A20A      A20_N20R                 20
+     C                   EVAL      £DBG_Str='RicercaDaPos01('
+     C                               +%CHAR(A20_N20R)
+     C                               +')_Trovato('+%CHAR(*IN20)+');'
+     C     '!ABCD':2     SCAN      A20_A20A      A20_N20R                 21
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +' RicercaDaPos01('+%CHAR(A20_N20R)
+     C                               +')_Trovato('+%CHAR(*IN21)+');'
+     C     '!ABCD':5     SCAN      A20_A20A      A20_N20R                 22
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +' RicercaDaPos01('+%CHAR(A20_N20R)
+     C                               +')_Trovato('+%CHAR(*IN22)+');'
+     C     £DBG_Str      DSPLY
+
+
+     C                   SETOFF                                           20
+     C     '!':1         SCAN      '?!/'         NW20_N20          2 0    20
+     C                   EVAL      £DBG_Str='RicercaDaPos01('
+     C                               +%CHAR(NW20_N20)
+     C                               +')_Trovato('+%CHAR(*IN20)+');'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description
I tried to fix the problem by checking if the Factor 1 is literal or not. In affirmative case, is built an `StringLiteral` expression to perform the action.
In addition, has been fixed the behavior of `expression.kt` when the number of occurrences is 0.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
