### PR TITLE
Bugfix/nw23001440/in with reference

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgLexer.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgLexer.g4
@@ -319,7 +319,8 @@ SPLAT_INIT: '*'[iI][nN][iI][tT];
 SPLAT_ALL_INDICATORS: '*' [iI] [nN] [ ] [ ];
 SPLAT_INDICATOR : 	( '*' [iI] [nN] [0-9] [0-9]
 					| '*' [iI] [nN] [a-zA-Z] [a-zA-Z]
-					| '*' [iI] [nN] '(' [0-9] [0-9] ')' );
+					| '*' [iI] [nN] '(' [0-9] [0-9] ')'
+					| '*' [iI] [nN] '(' [§£#@$a-zA-Z]+ ')' );
 SPLAT_INZSR: '*'[iI][nN][zZ][sS][rR];
 SPLAT_IN: '*'[iI][nN];
 SPLAT_INPUT: '*'[iI][nN][pP][uU][tT];

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -27,8 +27,8 @@ import com.strumenta.kolasu.model.specificProcess
 import java.math.BigDecimal
 import java.math.MathContext
 import java.math.RoundingMode
-import java.time.temporal.ChronoUnit
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import kotlin.math.abs
 import kotlin.math.sqrt
 
@@ -418,7 +418,11 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: OffRefExpr) = BooleanValue.FALSE
-    override fun eval(expression: IndicatorExpr) = interpreterStatus.indicator(expression.index)
+    override fun eval(expression: IndicatorExpr): BooleanValue {
+        // if index is passed through expression, it means that it is a dynamic indicator
+        val runtimeIndex = expression.indexExpression?.evalWith(this)?.asInt()?.value?.toInt() ?: expression.index
+        return interpreterStatus.indicator(runtimeIndex)
+    }
     override fun eval(expression: FunctionCall): Value {
         val functionToCall = expression.function.name
         val function = systemInterface.findFunction(interpreterStatus.symbolTable, functionToCall)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -843,8 +843,9 @@ open class InternalInterpreter(
                 return value
             }
             is IndicatorExpr -> {
+                val index = target.indexExpression?.let { eval(it).asInt().value.toInt() } ?: target.index
                 val coercedValue = coerce(value, BooleanType)
-                indicators[target.index] = coercedValue.asBoolean()
+                indicators[index] = coercedValue.asBoolean()
                 return coercedValue
             }
             is GlobalIndicatorExpr -> {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/indicators.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/indicators.kt
@@ -8,11 +8,20 @@ import kotlinx.serialization.Serializable
 
 // *IN01..*IN99 and *INLR *INRT
 @Serializable
-data class IndicatorExpr(val index: IndicatorKey, override val position: Position? = null) :
-    AssignableExpression(position) {
+data class IndicatorExpr(
+    val index: IndicatorKey,
+    override val position: Position? = null,
+    val indexExpression: Expression? = null
+) : AssignableExpression(position) {
 
     constructor(dataWrapUpChoice: DataWrapUpChoice, position: Position? = null) :
             this(index = dataWrapUpChoice.name.toIndicatorKey(), position = position)
+
+    /**
+     * Constructor for *IN where the index is an expression
+     * */
+    constructor(index: Expression, position: Position?) :
+            this(index = 0, position = position, indexExpression = index)
 
     override fun size(): Int = 1
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -44,17 +44,19 @@ fun RpgParser.ExpressionContext.toAst(conf: ToAstConfiguration = ToAstConfigurat
         this.MULT() != null || this.MULT_NOSPACE() != null -> MultExpr(this.expression(0).toAst(conf), this.expression(1).toAst(conf))
         this.DIV() != null -> DivExpr(this.expression(0).toAst(conf), this.expression(1).toAst(conf))
         this.EXP() != null -> ExpExpr(this.expression(0).toAst(conf), this.expression(1).toAst(conf))
-        this.indicator() != null -> (this.children[0] as RpgParser.IndicatorContext).toAst(conf)
-        // FIXME it is rather ugly that we have to do this: we should get a different parse tree here
-        this.children.size == 3 && this.children[0].text == "(" && this.children[2].text == ")"
-                && this.children[1] is RpgParser.ExpressionContext -> (this.children[1] as RpgParser.ExpressionContext).toAst(conf)
+        this.indicator() != null -> this.indicator().toAst(conf)
         else -> todo(conf = conf)
     }
 }
 
 internal fun RpgParser.IndicatorContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): IndicatorExpr {
-    //    TODO:
-    return IndicatorExpr(1)
+    // manage *IN(
+    if (this.children[0].text == "*IN" && this.children[1].text == "(") {
+        val index: Expression = (this.children[2].getChild(0) as RpgParser.ExpressionContext).toAst(conf = conf)
+        return IndicatorExpr(index = index, position = toPosition(conf.considerPosition))
+    } else {
+        todo(conf = conf)
+    }
 }
 
 internal fun RpgParser.LiteralContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): StringLiteral {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -44,11 +44,17 @@ fun RpgParser.ExpressionContext.toAst(conf: ToAstConfiguration = ToAstConfigurat
         this.MULT() != null || this.MULT_NOSPACE() != null -> MultExpr(this.expression(0).toAst(conf), this.expression(1).toAst(conf))
         this.DIV() != null -> DivExpr(this.expression(0).toAst(conf), this.expression(1).toAst(conf))
         this.EXP() != null -> ExpExpr(this.expression(0).toAst(conf), this.expression(1).toAst(conf))
+        this.indicator() != null -> (this.children[0] as RpgParser.IndicatorContext).toAst(conf)
         // FIXME it is rather ugly that we have to do this: we should get a different parse tree here
         this.children.size == 3 && this.children[0].text == "(" && this.children[2].text == ")"
                 && this.children[1] is RpgParser.ExpressionContext -> (this.children[1] as RpgParser.ExpressionContext).toAst(conf)
         else -> todo(conf = conf)
     }
+}
+
+internal fun RpgParser.IndicatorContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): IndicatorExpr {
+    //    TODO:
+    return IndicatorExpr(1)
 }
 
 internal fun RpgParser.LiteralContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): StringLiteral {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -45,6 +45,9 @@ fun RpgParser.ExpressionContext.toAst(conf: ToAstConfiguration = ToAstConfigurat
         this.DIV() != null -> DivExpr(this.expression(0).toAst(conf), this.expression(1).toAst(conf))
         this.EXP() != null -> ExpExpr(this.expression(0).toAst(conf), this.expression(1).toAst(conf))
         this.indicator() != null -> this.indicator().toAst(conf)
+        // FIXME it is rather ugly that we have to do this: we should get a different parse tree here
+        this.children.size == 3 && this.children[0].text == "(" && this.children[2].text == ")"
+                && this.children[1] is RpgParser.ExpressionContext -> (this.children[1] as RpgParser.ExpressionContext).toAst(conf)
         else -> todo(conf = conf)
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1587,10 +1587,17 @@ internal fun TargetContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
             ReferenceByName(this.getFieldName()),
             toPosition(conf.considerPosition)
         )
-        is IndicatorTargetContext -> IndicatorExpr(
-            this.indic.text.indicatorIndex()!!,
-            toPosition(conf.considerPosition)
-        )
+        is IndicatorTargetContext -> {
+            if (this.indic.text.matches(Regex("\\*IN\\([§£#@\$a-zA-Z]+\\)"))) {
+                val index: Expression = DataRefExpr(ReferenceByName(this.indic.text.removePrefix("*IN(").removeSuffix(")")), toPosition(conf.considerPosition))
+                return IndicatorExpr(index = index, position = toPosition(conf.considerPosition))
+            }
+
+            return IndicatorExpr(
+                this.indic.text.indicatorIndex()!!,
+                toPosition(conf.considerPosition)
+            )
+        }
         is GlobalIndicatorTargetContext -> GlobalIndicatorExpr(
             toPosition(conf.considerPosition)
         )

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2210,4 +2210,10 @@ Test 6
             "001000000000000000000000000000000000000000010000000000000000000000000000000000000000000100000000000")
         assertEquals(expected, "MOVEAIN".outputOf())
     }
+
+    @Test
+    fun executeINDIC01() {
+        val expected = listOf("0", "1")
+        assertEquals(expected, "INDIC01".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -225,4 +225,13 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf("1020")
         assertEquals(expected, "smeup/T10_A20_P19".outputOf())
     }
+
+    @Test
+    fun executeT03_A10_P09_10() {
+        val expected = listOf(
+            "I(15)=0 I(15)=1 I(15)=0",
+            "*IN(n)->000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        )
+        assertEquals(expected, "smeup/T03_A10_P09-10".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/INDIC01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/INDIC01.rpgle
@@ -1,0 +1,15 @@
+     D $IND            S              2  0
+     D MSG             S             10           VARYING
+
+     C                   EVAL      $IND=15
+
+      * Turn off the indicator 15 and display the value of the indicator
+     C                   SETOFF                                           15
+     C                   EVAL      MSG=%CHAR(*IN($IND))
+      * Expected: 0
+     C     MSG           DSPLY
+      * Turn on the indicator 15 and display the value of the indicator
+     C                   SETON                                            15
+     C                   EVAL      MSG=%CHAR(*IN($IND))
+      * Expected: 1
+     C     MSG           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P09-10.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P09-10.rpgle
@@ -1,0 +1,27 @@
+     D $IND            S              2  0
+     D £DBG_Str        S             110          VARYING
+
+     D* Indicatori come array con indice n *IN(n)
+     C                   SETOFF                                           15
+     C                   EVAL      $IND=15
+     C                   EVAL      £DBG_Str='I('+%CHAR($IND)+')='
+     C                               +%CHAR(*IN($IND))
+     C     £DBG_Str      DSPLY
+
+     C                   EVAL      *IN($IND)=*ON
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +' I('+%CHAR($IND)+')='
+     C                               +%CHAR(*IN($IND))
+     C                   EVAL      *IN($IND)=*OFF
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                                +' I('+%CHAR($IND)+')='
+     C                                +%CHAR(*IN($IND))
+     C     £DBG_Str      DSPLY
+     D Indicatori come array con indice n *IN(n)
+     C                   EVAL      £DBG_Str='*IN(n)->'
+     C                   EVAL      $IND=1
+     C                   DO        99
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +%CHAR(*IN($IND))
+     C                   ENDDO
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P09-10.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P09-10.rpgle
@@ -6,18 +6,17 @@
      C                   EVAL      $IND=15
      C                   EVAL      £DBG_Str='I('+%CHAR($IND)+')='
      C                               +%CHAR(*IN($IND))
-     C     £DBG_Str      DSPLY
-
      C                   EVAL      *IN($IND)=*ON
      C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
      C                               +' I('+%CHAR($IND)+')='
      C                               +%CHAR(*IN($IND))
      C                   EVAL      *IN($IND)=*OFF
      C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
-     C                                +' I('+%CHAR($IND)+')='
-     C                                +%CHAR(*IN($IND))
+     C                               +' I('+%CHAR($IND)+')='
+     C                               +%CHAR(*IN($IND))
      C     £DBG_Str      DSPLY
-     D Indicatori come array con indice n *IN(n)
+
+     D* Indicatori come array con indice n *IN(n)
      C                   EVAL      £DBG_Str='*IN(n)->'
      C                   EVAL      $IND=1
      C                   DO        99


### PR DESCRIPTION
## Description
I tried to fix the problem by adding to `SPLAT_INDICATOR` a case when `*IN` has access to a variable.
When I was following the evaluation of this code:
```
     C                   EVAL      *IN($IND)=*ON
```
I saw that the parser, in `misc.kt`, considered `*IN` like `IndexedTargetContext` rather than `IndicatorTargetContext`. It's wrong! `*IN`, even if it has parentheses, isn't an array later to consider `ArrayAccessExpr`. So, I decided to manipulate `RpgLexer.g4` by append to `SPLAT_INDICATOR` a case the argument of parentheses is a variable: 
```
SPLAT_INDICATOR :  
                                      ...
					| '*' [iI] [nN] '(' [§£#@$a-zA-Z]+ ')' );
```
The chose about value in the brackets is related to `ID`. A variable can contain letters and special chars like `§£#@`.
So, after this correction the parser finally consider `*IN` like `IndicatorTargetContext`. I decided to improve `TargetContext.toAst(...)`, branch `IndicatorTargetContext` of `when`, by checking the `indic` with a regex made like the latest case `SPLAT_INDICATOR` previously described. Progressively, I improved:

1. `expressions.kt` by adding `dynamicIndicatorIndex`;
2. `internal_interpreter.kt` by adding the logic of calculation of `indexExpression` if exists.
With this correction the test `T03_A10_P09-10.rpgle` passes, with other.

## Checklist:
- [ ] There are tests regarding this feature
- [ ] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [ ] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
