### PR TITLE
Bugfix/nw23001440/code in mock

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -81,6 +81,7 @@ private val modules = SerializersModule {
         subclass(ReadPreviousEqualStmt::class)
         subclass(ReadStmt::class)
         subclass(ResetStmt::class)
+        subclass(ExfmtStmt::class)
         subclass(ReturnStmt::class)
         subclass(ScanStmt::class)
         subclass(SelectStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -82,6 +82,7 @@ private val modules = SerializersModule {
         subclass(ReadStmt::class)
         subclass(ResetStmt::class)
         subclass(ExfmtStmt::class)
+        subclass(ReadcStmt::class)
         subclass(ReturnStmt::class)
         subclass(ScanStmt::class)
         subclass(SelectStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -84,6 +84,7 @@ private val modules = SerializersModule {
         subclass(ExfmtStmt::class)
         subclass(ReadcStmt::class)
         subclass(ReturnStmt::class)
+        subclass(UnlockStmt::class)
         subclass(ScanStmt::class)
         subclass(SelectStmt::class)
         subclass(SetStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1911,3 +1911,12 @@ data class ReadcStmt(
         // TODO
     }
 }
+
+@Serializable
+data class UnlockStmt(
+    override val position: Position? = null
+) : Statement(position) {
+    override fun execute(interpreter: InterpreterCore) {
+        // TODO
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1902,3 +1902,12 @@ data class ExfmtStmt(
         // TODO
     }
 }
+
+@Serializable
+data class ReadcStmt(
+    override val position: Position? = null
+) : Statement(position) {
+    override fun execute(interpreter: InterpreterCore) {
+        // TODO
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1893,3 +1893,12 @@ data class ResetStmt(
         interpreter.assign(dataDefinition, dataDefinition.defaultValue!!)
     }
 }
+
+@Serializable
+data class ExfmtStmt(
+    override val position: Position? = null
+) : Statement(position) {
+    override fun execute(interpreter: InterpreterCore) {
+        // TODO
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -916,6 +916,9 @@ internal fun Cspec_fixed_standardContext.toAst(conf: ToAstConfiguration = ToAstC
         this.csEXFMT() != null -> this.csEXFMT()
             .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
 
+        this.csREADC() != null -> this.csREADC()
+            .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
+
         else -> todo(conf = conf)
     }
 }
@@ -1922,6 +1925,12 @@ internal fun CsRESETContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 
 // TODO
 internal fun CsEXFMTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+    val position = toPosition(conf.considerPosition)
+    return ExfmtStmt(position)
+}
+
+// TODO
+internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
     return ExfmtStmt(position)
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -919,6 +919,9 @@ internal fun Cspec_fixed_standardContext.toAst(conf: ToAstConfiguration = ToAstC
         this.csREADC() != null -> this.csREADC()
             .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
 
+        this.csUNLOCK() != null -> this.csUNLOCK()
+            .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
+
         else -> todo(conf = conf)
     }
 }
@@ -1932,8 +1935,12 @@ internal fun CsEXFMTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 // TODO
 internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
-    return ExfmtStmt(position)
     return ReadcStmt(position)
+}
+
+// TODO
+internal fun CsUNLOCKContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+    val position = toPosition(conf.considerPosition)
     return UnlockStmt(position)
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1933,6 +1933,8 @@ internal fun CsEXFMTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
     return ExfmtStmt(position)
+    return ReadcStmt(position)
+    return UnlockStmt(position)
 }
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -913,6 +913,9 @@ internal fun Cspec_fixed_standardContext.toAst(conf: ToAstConfiguration = ToAstC
         this.csRESET() != null -> this.csRESET()
             .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
 
+        this.csEXFMT() != null -> this.csEXFMT()
+            .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
+
         else -> todo(conf = conf)
     }
 }
@@ -1916,6 +1919,13 @@ internal fun CsRESETContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
         position = position
     )
 }
+
+// TODO
+internal fun CsEXFMTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+    val position = toPosition(conf.considerPosition)
+    return ExfmtStmt(position)
+}
+
 
 /**
  * Run a block. In case of error throws an error encapsulating useful information

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1935,7 +1935,6 @@ internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
     return ExfmtStmt(position)
 }
 
-
 /**
  * Run a block. In case of error throws an error encapsulating useful information
  * like node position

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -384,6 +384,12 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
+    fun executeT52_A07_P01() {
+        val expected = listOf<String>("")
+        assertEquals(expected, "smeup/T52_A07_P01".outputOf(configuration = smeupConfig))
+    }
+
+    @Test
     fun executeT60_A10_P01_02() {
         val expected = listOf<String>()
         assertEquals(expected, "smeup/T60_A10_P01-02".outputOf(configuration = smeupConfig))

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -385,7 +385,7 @@ open class SmeupInterpreterTest : AbstractTest() {
 
     @Test
     fun executeT52_A07_P01() {
-        val expected = listOf<String>("")
+        val expected = listOf<String>()
         assertEquals(expected, "smeup/T52_A07_P01".outputOf(configuration = smeupConfig))
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -382,4 +382,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf<String>("Res(-A)=-10 Res( -A)= -10")
         assertEquals(expected, "smeup/T02_A60_P03".outputOf())
     }
+
+    @Test
+    fun executeT60_A10_P01_02() {
+        val expected = listOf<String>()
+        assertEquals(expected, "smeup/T60_A10_P01-02".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
@@ -32,4 +32,10 @@ class VideoInterpeterTest : AbstractTest() {
         val expected = listOf("W\$PERI:12", "£RASDI:HELLO_WORLD")
         assertEquals(expected = expected, actual = "video/FILEDEF".outputOf(configuration = configuration))
     }
+
+    @Test
+    fun executeEXFMT_MOCK() {
+        val expected = listOf("")
+        assertEquals(expected = expected, actual = "video/EXFMT_MOCK".outputOf(configuration = configuration))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
@@ -44,4 +44,10 @@ class VideoInterpeterTest : AbstractTest() {
         val expected = listOf("")
         assertEquals(expected = expected, actual = "video/READC_MOCK".outputOf(configuration = configuration))
     }
+
+    @Test
+    fun executeUNLOCK_MOCK() {
+        val expected = listOf("")
+        assertEquals(expected = expected, actual = "video/UNLOCK_MOCK".outputOf(configuration = configuration))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
@@ -38,4 +38,10 @@ class VideoInterpeterTest : AbstractTest() {
         val expected = listOf("")
         assertEquals(expected = expected, actual = "video/EXFMT_MOCK".outputOf(configuration = configuration))
     }
+
+    @Test
+    fun executeREADC_MOCK() {
+        val expected = listOf("")
+        assertEquals(expected = expected, actual = "video/READC_MOCK".outputOf(configuration = configuration))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T52_A07_P01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T52_A07_P01.rpgle
@@ -1,0 +1,26 @@
+     FMULANGTL  UF A E           K DISK
+
+     D KEY_A10C_SYST   S             10    INZ('IBN')
+     D KEY_A10C_TIPO   S             10    INZ('3')
+     D KEY_A10C_PROG   S             10    INZ('MULANGXX')
+
+     D A10C_PSEZ       S             10
+     D A10C_PPAS       S             10
+     D SEZ_52_INDICE   S             4  0
+     D £DBG_Str        S             100          VARYING
+
+     D* Scrittura nuove righe.
+     C                   FOR       SEZ_52_INDICE=0 TO 10
+     C                   EVAL      A10C_PSEZ='A'+
+     C                                 %SUBST(%EDITC(SEZ_52_INDICE:'X'):1:2)
+     C                   EVAL      A10C_PPAS='P'+
+     C                                 %SUBST(%EDITC(SEZ_52_INDICE:'X'):3:2)
+     C                   EVAL      MLSYST=%TRIM(KEY_A10C_SYST)
+     C                   EVAL      MLTIPO=%TRIM(KEY_A10C_TIPO)
+     C                   EVAL      MLPROG=%TRIM(KEY_A10C_PROG)
+     C                   EVAL      MLPSEZ=%TRIM(A10C_PSEZ)
+     C                   EVAL      MLPPAS=%TRIM(A10C_PPAS)
+     C                   WRITE     MULANGR
+     C                   ENDFOR
+
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+':ENDWRT:'

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T52_A07_P01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T52_A07_P01.rpgle
@@ -1,26 +1,2 @@
-     FMULANGTL  UF A E           K DISK
-
-     D KEY_A10C_SYST   S             10    INZ('IBN')
-     D KEY_A10C_TIPO   S             10    INZ('3')
-     D KEY_A10C_PROG   S             10    INZ('MULANGXX')
-
-     D A10C_PSEZ       S             10
-     D A10C_PPAS       S             10
-     D SEZ_52_INDICE   S             4  0
-     D £DBG_Str        S             100          VARYING
-
-     D* Scrittura nuove righe.
-     C                   FOR       SEZ_52_INDICE=0 TO 10
-     C                   EVAL      A10C_PSEZ='A'+
-     C                                 %SUBST(%EDITC(SEZ_52_INDICE:'X'):1:2)
-     C                   EVAL      A10C_PPAS='P'+
-     C                                 %SUBST(%EDITC(SEZ_52_INDICE:'X'):3:2)
-     C                   EVAL      MLSYST=%TRIM(KEY_A10C_SYST)
-     C                   EVAL      MLTIPO=%TRIM(KEY_A10C_TIPO)
-     C                   EVAL      MLPROG=%TRIM(KEY_A10C_PROG)
-     C                   EVAL      MLPSEZ=%TRIM(A10C_PSEZ)
-     C                   EVAL      MLPPAS=%TRIM(A10C_PPAS)
-     C                   WRITE     MULANGR
-     C                   ENDFOR
-
-     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+':ENDWRT:'
+     D* Test mock comando UNLOCK
+     C                   UNLOCK    MULANGTL

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T60_A10_P01-02.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T60_A10_P01-02.rpgle
@@ -1,0 +1,28 @@
+     D £DBG_Str        S             52
+     D $OP             S              1N   INZ(*ON)
+
+     D* Passo mock di EXFMT
+     C                   EVAL      £DBG_Str=''
+     C                   IF        $OP=*OFF
+     C                   OPEN      MLNGT60V
+     C                   ENDIF
+     C                   IF        $OP=*OFF
+     C                   EXFMT     FMT01
+     C                   EVAL      £DBG_Str='Eseguito EXFMT di FMT01'
+     C                   ENDIF
+     C                   IF        $OP=*OFF
+     C                   CLOSE     MLNGT60V
+     C                   ENDIF
+
+     D* Passo mock di READC
+     C                   EVAL      £DBG_Str=''
+     C                   IF        $OP=*OFF
+     C                   OPEN      MLNGT60V
+     C                   ENDIF
+     C                   IF        $OP=*OFF
+     C                   READC     SFL01
+     C                   EVAL      £DBG_Str='Eseguito READC di subfile SFLR'
+     C                   ENDIF
+     C                   IF        $OP=*OFF
+     C                   CLOSE     MLNGT60V
+     C                   ENDIF

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/metadata/MULANGTL.json
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/metadata/MULANGTL.json
@@ -1,0 +1,49 @@
+{"name": "MULANGTL",
+  "tableName": "MULANGTF",
+  "recordFormat": "MULANGR",
+  "fields": [
+    { "fieldName": "MLSYST",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":20, "varying":false}}
+  , { "fieldName": "MLLIBR",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLFILE",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLTIPO",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLPROG",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLPSEZ",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLPPAS",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLPDES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":256, "varying":false}}
+  , { "fieldName": "MLSQIN",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLSQFI",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLAAAT",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1024, "varying":false}}
+  , { "fieldName": "MLAAVA",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1024, "varying":false}}
+  , { "fieldName": "MLNNAT",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":21, "decimalDigits":9, "rpgType":"P"}}
+  , { "fieldName": "MLNNVA",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":21, "decimalDigits":9, "rpgType":"P"}}
+  , { "fieldName": "MLINDI",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":99, "varying":false}}
+  , { "fieldName": "MLTEES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "MLUSES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLDTES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"S"}}
+  , { "fieldName": "MLORES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":6, "decimalDigits":0, "rpgType":"S"}}
+  , { "fieldName": "MLASLA",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLASNR",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":6, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "MLLIBE",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":30000, "varying":true}}
+  ], "accessFields": [ "MLSYST", "MLTIPO", "MLPROG", "MLPSEZ", "MLPPAS"]}

--- a/rpgJavaInterpreter-core/src/test/resources/video/EXFMT_MOCK.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/video/EXFMT_MOCK.rpgle
@@ -1,0 +1,11 @@
+     FB£DIR40V  CF   E             WORKSTN USROPN
+     F                                     INFDS(DSSF01)
+
+     D MSG             S             50          VARYING
+
+     D  WFUND1         DS
+     D  WSDATA                        8  0
+
+     C                   EXFMT      W$PERI
+     C                   EVAL       MSG=''
+     C     MSG           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/video/READC_MOCK.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/video/READC_MOCK.rpgle
@@ -1,0 +1,12 @@
+     FB£DIR40V  CF   E             WORKSTN SFILE(B£DIR40VSUB:RRN)
+     F                                     INFDS(DSSF01)
+
+     D MSG             S             50          VARYING
+
+     D  WFUND1         DS
+     D  WSDATA                        8  0
+
+     C                   EXFMT      W$PERI
+     C                   READC      B£DIR40VSUB
+     C                   EVAL       MSG=''
+     C     MSG           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/video/UNLOCK_MOCK.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/video/UNLOCK_MOCK.rpgle
@@ -1,0 +1,11 @@
+     FB£DIR40V  CF   E             WORKSTN SFILE(B£DIR40VSUB:RRN)
+     F                                     INFDS(DSSF01)
+
+     D MSG             S             50          VARYING
+
+     D  WFUND1         DS
+     D  WSDATA                        8  0
+
+     C                   UNLOCK      W$PERI
+     C                   EVAL       MSG=''
+     C     MSG           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/video/metadata/B£DIR40VSUB.json
+++ b/rpgJavaInterpreter-core/src/test/resources/video/metadata/B£DIR40VSUB.json
@@ -1,0 +1,525 @@
+{
+    "name": "B£DIR40V",
+    "tableName": "CALBAS0F",
+    "recordFormat": "",
+    "fields": [
+        {
+            "fieldName": "£RASDI",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 15,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "£PDSNP",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 10,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "£PDSJN",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 10,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "£PDSNU",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 10,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$TPOG",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 12,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$TPRI",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 12,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$TRGG",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 3,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W£TRGG",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 30,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$RISG",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 15,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W£RISG",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 30,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$DAIN",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 10,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$DAFI",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 10,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$MESV",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 76,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "£RASDI",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 15,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "£PDSNP",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 10,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "£PDSJN",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 10,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "£PDSNU",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 10,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$TRGG",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 3,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W£TRGG",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 30,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$RISG",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 15,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W£RISG",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 30,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$PERI",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 8,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$GSET",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 10,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$SEAN",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 2,
+                "decimalDigits": 0,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$NURI",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 2,
+                "decimalDigits": 0,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$PLAV",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 3,
+                "decimalDigits": 0,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$ORRI",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W£ORRI",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 40,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$ECRI",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$PEUT",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 5,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$ORUT",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W£ORUT",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 40,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$ECUT",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$COCO",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 2,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W£COCO",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 30,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$ORCO",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W£ORCO",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 40,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$ECCO",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$OI01",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OF01",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$HTOT",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 6,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OI02",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OF02",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$HNET",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 6,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OI03",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OF03",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$HNTO",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 6,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OI04",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OF04",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OI05",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OF05",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W§CFCO",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 25,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$CFCO",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 9,
+                "decimalDigits": 3,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OI06",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$OF06",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 4,
+                "decimalDigits": 2,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$TOCO",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.NumberType",
+                "entireDigits": 9,
+                "decimalDigits": 3,
+                "rpgType": "S"
+            }
+        },
+        {
+            "fieldName": "W$TU01",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$TU02",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$TU03",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$TU04",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$TU05",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        },
+        {
+            "fieldName": "W$TU06",
+            "type": {
+                "type": "com.smeup.rpgparser.interpreter.StringType",
+                "length": 1,
+                "varying": false
+            }
+        }
+    ],
+    "accessFields": []
+}


### PR DESCRIPTION
## Description
For this task, I created the `ExfmtStmt`, `ReadcStmt` and `UnlockStmt` so that Jariko no longer crashes when there are `EXMT`, `READC` and `UNLOCK` operators. There are three respective `.rpgle` files with those operators.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
