### PR TITLE
Bugfix/nw23001440/scan without variables

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1647,17 +1647,15 @@ data class ScanStmt(
         } while (index >= 0)
         if (occurrences.isEmpty()) {
             interpreter.setIndicators(this, BooleanValue.FALSE, BooleanValue.FALSE, BooleanValue.FALSE)
-            if (target != null) {
-                interpreter.assign(target, IntValue(0))
-            }
+            target?.let { interpreter.assign(it, IntValue(0)) }
         } else {
             interpreter.setIndicators(this, BooleanValue.FALSE, BooleanValue.FALSE, BooleanValue.TRUE)
-            if (target != null) {
-                if (target.type().isArray()) {
-                    val fullOccurrences = occurrences.resizeTo(target.type().numberOfElements(), IntValue.ZERO).toMutableList()
-                    interpreter.assign(target, ConcreteArrayValue(fullOccurrences, target.type().asArray().element))
+            target?.let {
+                if (it.type().isArray()) {
+                    val fullOccurrences = occurrences.resizeTo(it.type().numberOfElements(), IntValue.ZERO).toMutableList()
+                    interpreter.assign(it, ConcreteArrayValue(fullOccurrences, it.type().asArray().element))
                 } else {
-                    interpreter.assign(target, occurrences[0])
+                    interpreter.assign(it, occurrences[0])
                 }
             }
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1630,7 +1630,7 @@ data class ScanStmt(
     val leftLength: Int?,
     val right: Expression,
     val startPosition: Int,
-    val target: AssignableExpression,
+    val target: AssignableExpression?,
     val rightIndicators: WithRightIndicators,
     @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
@@ -1647,14 +1647,18 @@ data class ScanStmt(
         } while (index >= 0)
         if (occurrences.isEmpty()) {
             interpreter.setIndicators(this, BooleanValue.FALSE, BooleanValue.FALSE, BooleanValue.FALSE)
-            interpreter.assign(target, IntValue(0))
+            if (target != null) {
+                interpreter.assign(target, IntValue(0))
+            }
         } else {
             interpreter.setIndicators(this, BooleanValue.FALSE, BooleanValue.FALSE, BooleanValue.TRUE)
-            if (target.type().isArray()) {
-                val fullOccurrences = occurrences.resizeTo(target.type().numberOfElements(), IntValue.ZERO).toMutableList()
-                interpreter.assign(target, ConcreteArrayValue(fullOccurrences, target.type().asArray().element))
-            } else {
-                interpreter.assign(target, occurrences[0])
+            if (target != null) {
+                if (target.type().isArray()) {
+                    val fullOccurrences = occurrences.resizeTo(target.type().numberOfElements(), IntValue.ZERO).toMutableList()
+                    interpreter.assign(target, ConcreteArrayValue(fullOccurrences, target.type().asArray().element))
+                } else {
+                    interpreter.assign(target, occurrences[0])
+                }
             }
         }
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1304,12 +1304,16 @@ internal fun CsSCANContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
     val rightIndicators = cspec_fixed_standard_parts().rightIndicators()
     val result = this.cspec_fixed_standard_parts().result.text
     val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
+    val target = when {
+        result.isNotBlank() -> this.cspec_fixed_standard_parts()!!.result!!.toAst(conf)
+        else -> null
+    }
     return ScanStmt(
         left = compareExpression,
         leftLength = compareLength,
         right = baseExpression,
         startPosition = startPosition ?: 1,
-        target = this.cspec_fixed_standard_parts()!!.result!!.toAst(conf),
+        target = target,
         rightIndicators = rightIndicators,
         dataDefinition = dataDefinition,
         position = position

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -382,4 +382,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf<String>("Res(-A)=-10 Res( -A)= -10")
         assertEquals(expected, "smeup/T02_A60_P03".outputOf())
     }
+
+    @Test
+    fun executeT10_A35_P07() {
+        val expected = listOf<String>("Src1=1 Src2=0")
+        assertEquals(expected, "smeup/T10_A35_P07".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A35_P07.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A35_P07.rpgle
@@ -1,0 +1,11 @@
+     D A35_A20A        S             20    INZ('!ABC!ABCDEF')
+     D £DBG_Str        S             100
+
+     D* SCAN senza variabile
+     C                   SETOFF                                           20
+     C     '!'           SCAN      A35_A20A                               20
+     C                   EVAL      £DBG_Str='Src1='+%CHAR(*IN20)
+     C     '?'           SCAN      A35_A20A                               20
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                                 +' Src2='+%CHAR(*IN20)
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description
In accordance with the [official documentation](https://www.ibm.com/docs/en/i/7.5?topic=codes-scan-scan-string), operator `SCAN` mightn't have a Result variable set. Before this fix, the interpreter thrown an exception because "The variable name should not blank". To fix, this problem I made optional the `target` parameter of `ScanStmt`, with several check in `execute` method.
Going in depth, by analyzing the code of case of study:
```
     C     '!'            SCAN     A35_A20A                               20
     C                   EVAL      £DBG_Str='Src1='+%CHAR(*IN20)
```
the result of `SCAN` (founded or not) is set to Indicator number 20.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
