### PR TITLE
Bugfix/nw23001440/move indicator with variable

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -940,8 +940,14 @@ private fun annidatedReferenceExpression(
         return GlobalIndicatorExpr(position)
     }
     if (text.uppercase(Locale.getDefault()).startsWith("*IN(") && text.endsWith(")")) {
-        val index = text.uppercase(Locale.getDefault()).removePrefix("*IN(").removeSuffix(")").toInt()
-        return IndicatorExpr(index, position)
+        val content = text.uppercase(Locale.getDefault()).removePrefix("*IN(").removeSuffix(")")
+        var index = 0
+        if (content.isInt()) {
+            index = content.toInt()
+            return IndicatorExpr(index, position)
+        } else {
+            return IndicatorExpr(DataRefExpr(ReferenceByName(content), position), position)
+        }
     }
     if (text.uppercase(Locale.getDefault()).startsWith("*IN")) {
         val index = text.uppercase(Locale.getDefault()).removePrefix("*IN").toInt()

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -397,7 +397,7 @@ open class SmeupInterpreterTest : AbstractTest() {
 
     @Test
     fun executeT03_A30() {
-        val expected = listOf<String>("*IN33=0,*IN34=1","*IN33=0,*IN34=1")
+        val expected = listOf<String>("*IN33=0,*IN34=1", "*IN33=0,*IN34=1")
         assertEquals(expected, "smeup/T03_A30".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -388,4 +388,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf<String>("£C5")
         assertEquals(expected, "smeup/T02_A50_P05".outputOf(configuration = smeupConfig))
     }
+
+    @Test
+    fun executeT03_A30() {
+        val expected = listOf<String>("*IN33=0,*IN34=1","*IN33=0,*IN34=1")
+        assertEquals(expected, "smeup/T03_A30".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A30.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A30.rpgle
@@ -1,4 +1,7 @@
-     D £DBG_Str        S             100          VARYING
+     D £DBG_Str        S            100
+     D IN33            S              1
+     D IN34            S              1
+     D A90_A3          S              8
       * MOVEL ON/OFF indicatore con valore da variabile
      C                   EVAL      £DBG_Str=' '
      C                   SETON                                        33
@@ -8,11 +11,10 @@
      C                   MOVEL     *OFF          *IN($2)
      C                   Z-ADD     34            $2
      C                   MOVEL     *ON           *IN($2)
-     C                   EVAL      £DBG_Str='*IN33='+*IN33+','+
-     C                                      '*IN34='+*IN34
+     C                   EVAL      £DBG_Str='*IN33='+%CHAR(*IN(33))+','+
+     C                                      '*IN34='+%CHAR(*IN(34))
      C        £DBG_Str   DSPLY
       * MOVE ON/OFF indicatore con valore da variabile
-     C                   EVAL      £DBG_Pas='P02'
      C                   EVAL      £DBG_Str=' '
      C                   SETON                                        33
      C                   SETOFF                                       34
@@ -21,6 +23,9 @@
      C                   MOVE      *OFF          *IN($2)
      C                   Z-ADD     34            $2
      C                   MOVE      *ON           *IN($2)
-     C                   EVAL      £DBG_Str='*IN33='+*IN33+','+
-     C                                      '*IN34='+*IN34
+     C                   EVAL      £DBG_Str='*IN33='+%CHAR(*IN(33))+','+
+     C                                      '*IN34='+%CHAR(*IN(34))
+     C        £DBG_Str   DSPLY
+      *
      C                   SETON                                          LR
+      *

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A30.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A30.rpgle
@@ -1,0 +1,26 @@
+     D £DBG_Str        S             100          VARYING
+      * MOVEL ON/OFF indicatore con valore da variabile
+     C                   EVAL      £DBG_Str=' '
+     C                   SETON                                        33
+     C                   SETOFF                                       34
+      *
+     C                   Z-ADD     33            $2                5 0
+     C                   MOVEL     *OFF          *IN($2)
+     C                   Z-ADD     34            $2
+     C                   MOVEL     *ON           *IN($2)
+     C                   EVAL      £DBG_Str='*IN33='+*IN33+','+
+     C                                      '*IN34='+*IN34
+     C        £DBG_Str   DSPLY
+      * MOVE ON/OFF indicatore con valore da variabile
+     C                   EVAL      £DBG_Pas='P02'
+     C                   EVAL      £DBG_Str=' '
+     C                   SETON                                        33
+     C                   SETOFF                                       34
+      *
+     C                   Z-ADD     33            $2                5 0
+     C                   MOVE      *OFF          *IN($2)
+     C                   Z-ADD     34            $2
+     C                   MOVE      *ON           *IN($2)
+     C                   EVAL      £DBG_Str='*IN33='+*IN33+','+
+     C                                      '*IN34='+*IN34
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
Fixed the case of IndicatorExpression with a variable expression

Related to: 
T03_A30

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
