### PR TITLE
Bugfix/nw23001440/incongr definition

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1983,7 +1983,7 @@ internal fun getProgramNameToCopyBlocks(): ProgramNameToCopyBlocks {
 
 internal fun <T : AbstractDataDefinition> List<T>.removeDuplicatedDataDefinition(): List<T> {
     val dataDefinitionMap = mutableMapOf<String, AbstractDataDefinition>()
-    return this.filter {
+    return removeUnnecessaryRecordFormat().filter {
         val dataDefinition = dataDefinitionMap[it.name]
         if (dataDefinition == null) {
             dataDefinitionMap[it.name] = it
@@ -1994,5 +1994,19 @@ internal fun <T : AbstractDataDefinition> List<T>.removeDuplicatedDataDefinition
             }
             false
         }
+    }
+}
+
+/**
+  * This function is used to remove unnecessary record formats from a list of data definitions.
+  * Data definitions of type RecordFormatType are necessary where in the AST we don't have a DS
+  * named like the record format, and we have operations such as CLEAR RECORD_FORMAT_NAME.
+  * In that case the record format in the data definitions list is necessary just to retrieve the fields that must be clean.
+  *
+  * @return A list of data definitions excluding the ones of type `RecordFormat`.
+ */
+private fun <T : AbstractDataDefinition> List<T>.removeUnnecessaryRecordFormat(): List<T> {
+    return this.filterNot { dataDef ->
+        dataDef.type is RecordFormatType && this.any { it.type is DataStructureType && it.name.uppercase() == dataDef.name.uppercase() }
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/FileDefinitionTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/FileDefinitionTest.kt
@@ -62,6 +62,16 @@ class FileDefinitionTest : AbstractTest() {
     }
 
     @Test
+    fun resolveEXTNAME03() {
+        assertASTCanBeProduced(
+            exampleName = "db/EXTNAME03",
+            considerPosition = true,
+            afterAstCreation = { compilationUnit ->
+                assertEquals(listOf(), compilationUnit.resolveAndValidate())
+            })
+    }
+
+    @Test
     fun resolveLIKEDSPEC01() {
         assertASTCanBeProduced(
             exampleName = "db/LIKEDSPEC01",

--- a/rpgJavaInterpreter-core/src/test/resources/db/EXTNAME03.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/db/EXTNAME03.rpgle
@@ -3,5 +3,5 @@
       *Fix error: Incongruous definitions of BRARTIR: RecordFormatType vs DataStructureType...
       *
      DBRARTIR        E DS                  EXTNAME(BRARTI0L) INZ
-     C                   CLEAR                   BRART
+     C                   CLEAR                   BRARTIR
      C     A§ARTI         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/db/EXTNAME03.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/db/EXTNAME03.rpgle
@@ -1,0 +1,7 @@
+      *
+      *BRARTIR is the name of record format of the file BRARTI0L
+      *Fix error: Incongruous definitions of BRARTIR: RecordFormatType vs DataStructureType...
+      *
+     DBRARTIR        E DS                  EXTNAME(BRARTI0L) INZ
+     C                   CLEAR                   BRART
+     C     A§ARTI         DSPLY


### PR DESCRIPTION
## Description

Fix error: `Incongruous definitions of BRARTIR: RecordFormatType vs DataStructureType...`

This issue is a side effect related #375 where to fix an error related the missing resolution of `record_format_name` referenced by a `CLEAR` operation, we had added in the data dafinitions list a new instance of `DataDefinition` with name as `record_format_name`  and type `RecordFormatType.`
The problem has been solved by removing all instances of `DataDefiniton` typed as `RecordFormatType` for which we already have a `DataDefinition` typed as `DataStructType` with the same name.


## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
