### PR TITLE
bugfix/NW23001440/CASEQ-without-other-220 

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
@@ -217,7 +217,7 @@ internal fun RpgParser.WhenstatementContext.toAst(conf: ToAstConfiguration = ToA
 
 internal fun RpgParser.CasestatementContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): CaseStmt {
     val casClauses = this.csCASxx().map { it.toAst(conf) }
-    val otherClause = this.csCASother().toAst()
+    val otherClause = if (this.csCASother() != null) this.csCASother().toAst() else null
     return CaseStmt(
         cases = casClauses,
         other = otherClause,

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -420,6 +420,12 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
+    fun executeT12_A08_P02() {
+        val expected = listOf("1", "2", "2")
+        assertEquals(expected, "smeup/T12_A08_P02".outputOf())
+    }
+
+    @Test
     fun executeT10_A35_P07() {
         val expected = listOf<String>("Src1=1 Src2=0")
         assertEquals(expected, "smeup/T10_A35_P07".outputOf())

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A08_P02.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A08_P02.rpgle
@@ -1,0 +1,33 @@
+     D £DBG_Str        S              1
+      *
+     C                   MOVEL     '1'           CHOISE            1
+     C                   EXSR      SEZ_T12_A08
+      *
+     C                   MOVEL     '2'           CHOISE
+     C                   EXSR      SEZ_T12_A08
+      *
+     C                   MOVEL     ' '           CHOISE
+     C                   EXSR      SEZ_T12_A08
+      *
+     C                   SETON                                          LR
+      *---------------------------------------------------------------
+     C     SEZ_T12_A08   BEGSR
+      *---------------------------------------------------------------
+      *
+     C     CHOISE        CASEQ     '1'           CHOISER1
+     C     CHOISE        CASEQ     '2'           CHOISER2
+     C                   ENDCS
+      *
+     C     £DBG_Str      DSPLY
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------
+     C     CHOISER1      BEGSR
+      *--------------------------------------------------------------*
+     c                   EVAL      £DBG_Str='1'
+     C                   ENDSR
+      *---------------------------------------------------------------
+     C     CHOISER2      BEGSR
+      *--------------------------------------------------------------*
+     c                   EVAL      £DBG_Str='2'
+     C                   ENDSR


### PR DESCRIPTION
## Description
In this branch has been fixed the null exception when the CASxx block does not have the CAS condition

Related to:
T12_A08_P02

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
