### PR TITLE
Bugfix/nw23001440/dow with blanks

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -198,9 +198,15 @@ data class StringValue(var value: String, val varying: Boolean = false) : Abstra
         return s1.compareTo(s2)
     }
 
+    fun compare(other: BlanksValue, charset: Charset?, descend: Boolean = false): Int {
+        require(charset != null)
+        return if (this.isBlank()) EQUAL else SMALLER
+    }
+
     override operator fun compareTo(other: Value): Int =
         when (other) {
             is StringValue -> compare(other, DEFAULT_CHARSET)
+            is BlanksValue -> compare(other, DEFAULT_CHARSET)
             else -> super.compareTo(other)
         }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -198,15 +198,10 @@ data class StringValue(var value: String, val varying: Boolean = false) : Abstra
         return s1.compareTo(s2)
     }
 
-    fun compare(other: BlanksValue, charset: Charset?, descend: Boolean = false): Int {
-        require(charset != null)
-        return if (this.isBlank()) EQUAL else SMALLER
-    }
-
     override operator fun compareTo(other: Value): Int =
         when (other) {
             is StringValue -> compare(other, DEFAULT_CHARSET)
-            is BlanksValue -> compare(other, DEFAULT_CHARSET)
+            is BlanksValue -> if (this.isBlank()) EQUAL else SMALLER
             else -> super.compareTo(other)
         }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
@@ -71,19 +71,21 @@ internal fun RpgParser.CsDOWxxContext.toAst(blockContext: BlockContext, conf: To
         else -> todo(conf = conf)
     }
     val factor2 = when {
-        this.csDOWEQ() != null -> this.csDOWEQ().cspec_fixed_standard_parts().factor2.content.toAst(conf = conf)
-        this.csDOWNE() != null -> this.csDOWNE().cspec_fixed_standard_parts().factor2.content.toAst(conf = conf)
-        this.csDOWGT() != null -> this.csDOWGT().cspec_fixed_standard_parts().factor2.content.toAst(conf = conf)
-        this.csDOWGE() != null -> this.csDOWGE().cspec_fixed_standard_parts().factor2.content.toAst(conf = conf)
-        this.csDOWLT() != null -> this.csDOWLT().cspec_fixed_standard_parts().factor2.content.toAst(conf = conf)
-        this.csDOWLE() != null -> this.csDOWLE().cspec_fixed_standard_parts().factor2.content.toAst(conf = conf)
+        this.csDOWEQ() != null -> this.csDOWEQ().cspec_fixed_standard_parts().factor2
+        this.csDOWNE() != null -> this.csDOWNE().cspec_fixed_standard_parts().factor2
+        this.csDOWGT() != null -> this.csDOWGT().cspec_fixed_standard_parts().factor2
+        this.csDOWGE() != null -> this.csDOWGE().cspec_fixed_standard_parts().factor2
+        this.csDOWLT() != null -> this.csDOWLT().cspec_fixed_standard_parts().factor2
+        this.csDOWLE() != null -> this.csDOWLE().cspec_fixed_standard_parts().factor2
         else -> todo(conf = conf)
     }
+
+    val factor2Ast = factor2.toAstIfSymbolicConstant() ?: factor2.content.toAst(conf)
 
     return DOWxxStmt(
         comparisonOperator = comparison,
         factor1 = this.factor1.content.toAst(conf = conf),
-        factor2 = factor2,
+        factor2 = factor2Ast,
         position = toPosition(conf.considerPosition),
         body = blockContext.statement().map { it.toAst(conf) }
     )

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -528,4 +528,20 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf<String>("KA(0)KB(0)KC(0)KD(0)KE(0)KF(0)KG(0)KH(0)KI(0)KJ(0)KK(0)KL(0)KM(0)KN(0)KP(0)KQ(0)KR(0)KS(0)KT(0)KU(0)KV(0)KW(0)KX(0)KY(0)")
         assertEquals(expected, "smeup/T60_A10_P01".outputOf(configuration = smeupConfig))
     }
+
+    @Test
+    fun executeT12_A04_P13() {
+        val expected = listOf(
+            "CNT()"
+        )
+        assertEquals(expected, "smeup/T12_A04_P13".outputOf())
+    }
+
+    @Test
+    fun executeT12_A04_P14() {
+        val expected = listOf(
+            "CNT()"
+        )
+        assertEquals(expected, "smeup/T12_A04_P14".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P13.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P13.rpgle
@@ -1,0 +1,9 @@
+     D A04_A01_CNT     S              1    INZ('')
+     D £DBG_Str        S            150          VARYING
+
+     C                   EVAL      A04_A01_CNT = 'A'
+     C     A04_A01_CNT   DOWNE     *BLANKS
+     C                   EVAL      A04_A01_CNT = *BLANKS
+     C                   ENDDO
+     C                   EVAL      £DBG_Str='CNT('+%TRIM(A04_A01_CNT)+')'
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P14.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P14.rpgle
@@ -1,0 +1,9 @@
+     D A04_A01_CNT     S              1    INZ('')
+     D £DBG_Str        S            150          VARYING
+
+     C                   EVAL      A04_A01_CNT = 'A'
+     C     A04_A01_CNT   DOWNE     *BLANK
+     C                   EVAL      A04_A01_CNT = *BLANK
+     C                   ENDDO
+     C                   EVAL      £DBG_Str='CNT('+%TRIM(A04_A01_CNT)+')'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Fix an issue causing `DOWxx` statements evaluation not to produce appropriate AST when using a symbolic constant instead of a value as factor 2 causing syntax like `DOWNE *BLANKS` to fail.

Also implemented a comparison method to compare `StringValue`s with `BlanksValue`s.

Related to:
- T12_A04_P13
- T12_A04_P14

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
