### PR TITLE
Bugfix/nw23001440/check with inline vars

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -610,8 +610,9 @@ data class CheckStmt(
     val baseString: Expression,
     val start: Int = 1,
     val wrongCharPosition: AssignableExpression?,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
-) : Statement(position) {
+) : Statement(position), StatementThatCanDefineData {
     override fun execute(interpreter: InterpreterCore) {
         var baseString = interpreter.eval(this.baseString).asString().value
         if (this.baseString is DataRefExpr) {
@@ -633,6 +634,8 @@ data class CheckStmt(
             }
         }
     }
+
+    override fun dataDefinition(): List<InStatementDataDefinition> = dataDefinition?.let { listOf(it) } ?: emptyList()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1335,11 +1335,16 @@ internal fun CsCHECKContext.toAst(conf: ToAstConfiguration): Statement {
     val position = toPosition(conf.considerPosition)
     val factor1 = this.factor1Context()?.content?.toAst(conf) ?: throw UnsupportedOperationException("CHECK operation requires factor 1: ${this.text} - ${position.atLine()}")
     val (expression, startPosition) = this.cspec_fixed_standard_parts().factor2.toIndexedExpression(conf)
+
+    val result = this.cspec_fixed_standard_parts().result
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result.text, position, conf)
+
     return CheckStmt(
         factor1,
         expression,
         startPosition ?: 1,
         this.cspec_fixed_standard_parts()?.result?.toAst(conf),
+        dataDefinition,
         position
     )
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -528,4 +528,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf<String>("KA(0)KB(0)KC(0)KD(0)KE(0)KF(0)KG(0)KH(0)KI(0)KJ(0)KK(0)KL(0)KM(0)KN(0)KP(0)KQ(0)KR(0)KS(0)KT(0)KU(0)KV(0)KW(0)KX(0)KY(0)")
         assertEquals(expected, "smeup/T60_A10_P01".outputOf(configuration = smeupConfig))
     }
+
+    @Test
+    fun executeT10_A45_P03() {
+        val expected = listOf<String>("NUM(4)")
+        assertEquals(expected, "smeup/T10_A45_P03".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A45_P03.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A45_P03.rpgle
@@ -1,0 +1,8 @@
+     D £DBG_Str        S            150          VARYING
+     D A45_A04         S              4    INZ('    ')
+     D A45_A10         C                   '0123456789'
+
+     C                   EVAL      A45_A04='201A'
+     C     A45_A10       CHECK     A45_A04       A45_N20           1 0
+     C                   EVAL      £DBG_Str='NUM('+%CHAR(A45_N20)+')'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Implement StatementThatCanDefineData for CheckStmt in order to allow for inline variable declarations.

Related to:
- T10_A45_P03

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
