### PR TITLE
Bugfix/nw23001440/231 size array by variable

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -75,14 +75,10 @@ open class BaseCompileTimeInterpreter(
             is NumberOfElementsExpr -> IntValue(evaluateNumberOfElementsOf(rContext, expression.value).toLong())
             is IntLiteral -> IntValue(expression.value)
             is StringLiteral -> StringValue(expression.value)
-            is DataRefExpr -> {
-                expression.variable.tryToResolve(knownDataDefinitions)
-                if (expression.variable.referred != null) {
-                    return this.evaluate(rContext, (expression.variable.referred as? DataDefinition)?.initializationValue as Expression)
-                }
-
+            is DataRefExpr -> if (expression.variable.tryToResolve(knownDataDefinitions))
+                return this.evaluate(rContext, (expression.variable.referred as? DataDefinition)?.initializationValue as Expression)
+                    else
                 TODO(expression.toString())
-            }
             else -> TODO(expression.toString())
         }
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -23,6 +23,7 @@ import com.smeup.rpgparser.parsing.ast.*
 import com.smeup.rpgparser.parsing.facade.findAllDescendants
 import com.smeup.rpgparser.parsing.parsetreetoast.*
 import com.smeup.rpgparser.utils.asInt
+import com.strumenta.kolasu.model.tryToResolve
 
 /**
  * This is a very limited interpreter used at compile time, mainly
@@ -74,6 +75,14 @@ open class BaseCompileTimeInterpreter(
             is NumberOfElementsExpr -> IntValue(evaluateNumberOfElementsOf(rContext, expression.value).toLong())
             is IntLiteral -> IntValue(expression.value)
             is StringLiteral -> StringValue(expression.value)
+            is DataRefExpr -> {
+                expression.variable.tryToResolve(knownDataDefinitions)
+                if (expression.variable.referred != null) {
+                    return this.evaluate(rContext, (expression.variable.referred as? DataDefinition)?.initializationValue as Expression)
+                }
+
+                TODO(expression.toString())
+            }
             else -> TODO(expression.toString())
         }
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -528,4 +528,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf<String>("KA(0)KB(0)KC(0)KD(0)KE(0)KF(0)KG(0)KH(0)KI(0)KJ(0)KK(0)KL(0)KM(0)KN(0)KP(0)KQ(0)KR(0)KS(0)KT(0)KU(0)KV(0)KW(0)KX(0)KY(0)")
         assertEquals(expected, "smeup/T60_A10_P01".outputOf(configuration = smeupConfig))
     }
+
+    @Test
+    fun executeT02_A30_P04() {
+        val expected = listOf<String>("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCDDDDDDDDDDDDDDDDDDDDEEEEEEEEEEEEEEEEEEEEFFFFFFFFFFFFFFFFFFFF")
+        assertEquals(expected, "smeup/T02_A30_P04".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -532,6 +532,6 @@ open class SmeupInterpreterTest : AbstractTest() {
     @Test
     fun executeT02_A30_P04() {
         val expected = listOf<String>("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCDDDDDDDDDDDDDDDDDDDDEEEEEEEEEEEEEEEEEEEEFFFFFFFFFFFFFFFFFFFF")
-        assertEquals(expected, "smeup/T02_A30_P04".outputOf(configuration = smeupConfig))
+        assertEquals(expected, "smeup/T02_A30_P04".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A30_P04.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A30_P04.rpgle
@@ -1,0 +1,13 @@
+     D A30_C04         C                   CONST(6)
+     D A30_AR4         S             20    DIM(A30_C04)
+     D £DBG_Str        S             150         VARYING
+
+     C                   EVAL      A30_AR4(01) = 'AAAAAAAAAAAAAAAAAAAA'
+     C                   EVAL      A30_AR4(02) = 'BBBBBBBBBBBBBBBBBBBB'
+     C                   EVAL      A30_AR4(03) = 'CCCCCCCCCCCCCCCCCCCC'
+     C                   EVAL      A30_AR4(04) = 'DDDDDDDDDDDDDDDDDDDD'
+     C                   EVAL      A30_AR4(05) = 'EEEEEEEEEEEEEEEEEEEE'
+     C                   EVAL      A30_AR4(06) = 'FFFFFFFFFFFFFFFFFFFF'
+     c                   EVAL      £DBG_Str=A30_AR4(01)+A30_AR4(02)+A30_AR4(03)
+     C                                     +A30_AR4(04)+A30_AR4(05)+A30_AR4(06)
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A30_P04.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A30_P04.rpgle
@@ -8,6 +8,6 @@
      C                   EVAL      A30_AR4(04) = 'DDDDDDDDDDDDDDDDDDDD'
      C                   EVAL      A30_AR4(05) = 'EEEEEEEEEEEEEEEEEEEE'
      C                   EVAL      A30_AR4(06) = 'FFFFFFFFFFFFFFFFFFFF'
-     c                   EVAL      £DBG_Str=A30_AR4(01)+A30_AR4(02)+A30_AR4(03)
+     C                   EVAL      £DBG_Str=A30_AR4(01)+A30_AR4(02)+A30_AR4(03)
      C                                     +A30_AR4(04)+A30_AR4(05)+A30_AR4(06)
      C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A30_P04.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T02_A30_P04.rpgle
@@ -1,6 +1,6 @@
      D A30_C04         C                   CONST(6)
      D A30_AR4         S             20    DIM(A30_C04)
-     D £DBG_Str        S             150         VARYING
+     D £DBG_Str        S            150         VARYING
 
      C                   EVAL      A30_AR4(01) = 'AAAAAAAAAAAAAAAAAAAA'
      C                   EVAL      A30_AR4(02) = 'BBBBBBBBBBBBBBBBBBBB'


### PR DESCRIPTION
## Description
By analyzing the code:
```
     D A30_AR4         S             20    DIM(A30_C04)
```
we have a reference that, in actual state of Jariko, isn't solved in compile time. To solve this problem, I implemented the logic to do that, in `compile_time_interpreter` where for `DataRefExpr` (in this case `A30_C04` previously defined) is called `tryToResolve` with the data definitions previously resolved. 


## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [x] There is a specific documentation in the `docs` directory
