### PR TITLE
Bugfix/nw23001440/time inline vars

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1252,8 +1252,9 @@ data class SubStmt(
 @Serializable
 data class TimeStmt(
     val value: Expression,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
-) : Statement(position) {
+) : Statement(position), StatementThatCanDefineData {
     override fun execute(interpreter: InterpreterCore) {
         when (value) {
             is DataRefExpr -> {
@@ -1275,6 +1276,8 @@ data class TimeStmt(
             else -> throw UnsupportedOperationException("I do not know how to set TIME to ${this.value}")
         }
     }
+
+    override fun dataDefinition(): List<InStatementDataDefinition> = dataDefinition?.let { listOf(it) } ?: emptyList()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1094,7 +1094,11 @@ internal fun CsPARMContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
 internal fun CsTIMEContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): TimeStmt {
     val name = this.cspec_fixed_standard_parts().result.text
     val position = toPosition(conf.considerPosition)
-    return TimeStmt(annidatedReferenceExpression(name, toPosition(conf.considerPosition)), position)
+
+    val result = this.cspec_fixed_standard_parts().result
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result.text, position, conf)
+
+    return TimeStmt(annidatedReferenceExpression(name, toPosition(conf.considerPosition)), dataDefinition, position)
 }
 
 fun Cspec_fixed_standard_partsContext.factor2Expression(conf: ToAstConfiguration): Expression? {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -562,4 +562,12 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T12_A04_P14".outputOf())
     }
+
+    @Test
+    fun executeT04_A80_P05() {
+        val expected = listOf(
+            "A80_D1(hhmmss) A80_D2(hhmmssDDMMYY) A80_D3(hhmmssDDMMYYYY)"
+        )
+        assertEquals(expected, "smeup/T04_A80_P05".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A80_P05.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A80_P05.rpgle
@@ -1,0 +1,74 @@
+     D £DBG_Str        S            150          VARYING
+     D A80_A1          S             28
+     D A80_A2          S              1
+     D A80_F           C                   '0123456789'
+     D A80_T           C                   'xxxxxxxxxx'
+     D A80_I1          S              2  0
+
+     C                   TIME                    A80_D1            6 0
+     C                   EVAL      A80_A1=%CHAR(A80_D1)
+     C                   EXSR      SUB_A80_B
+     C                   EVAL      £DBG_Str=
+     C                                'A80_D1('+%TRIM(A80_A1)+')'
+      *
+     C                   TIME                    A80_D2           12 0
+     C                   EVAL      A80_A1=%CHAR(A80_D2)
+     C                   EXSR      SUB_A80_B
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                +' A80_D2('+%TRIM(A80_A1)+')'
+      *
+     C                   TIME                    A80_D3           14 0
+     C                   EVAL      A80_A1=%CHAR(A80_D3)
+     C                   EXSR      SUB_A80_B
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                +' A80_D3('+%TRIM(A80_A1)+')'
+
+     C     £DBG_Str      DSPLY
+
+      *---------------------------------------------------------------------
+    RD* Subsezione di SEZ_A80
+      *---------------------------------------------------------------------
+     C     SUB_A80_B     BEGSR
+      *
+     C                   IF        %REM(%LEN(A80_A1):2)<>0
+     C                   EVAL      A80_A1='0'+A80_A1
+     C                   ENDIF
+      *
+     C     A80_F:A80_T   XLATE     A80_A1        A80_A1
+     C                   DO        2
+     C                   EVAL      A80_A2='h'
+     C                   EXSR      SUB_A80_D
+     C                   ENDDO
+     C                   DO        2
+     C                   EVAL      A80_A2='m'
+     C                   EXSR      SUB_A80_D
+     C                   ENDDO
+     C                   DO        2
+     C                   EVAL      A80_A2='s'
+     C                   EXSR      SUB_A80_D
+     C                   ENDDO
+     C                   DO        2
+     C                   EVAL      A80_A2='D'
+     C                   EXSR      SUB_A80_D
+     C                   ENDDO
+     C                   DO        2
+     C                   EVAL      A80_A2='M'
+     C                   EXSR      SUB_A80_D
+     C                   ENDDO
+     C                   DO        4
+     C                   EVAL      A80_A2='Y'
+     C                   EXSR      SUB_A80_D
+     C                   ENDDO
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+    RD*
+      *---------------------------------------------------------------------
+     C     SUB_A80_D     BEGSR
+      *
+     C                   EVAL      A80_I1=%SCAN('x':A80_A1)
+     C                   IF        A80_I1<>0
+     C                   EVAL      A80_A1=%REPLACE(A80_A2:A80_A1:A80_I1)
+     C                   ENDIF
+      *
+     C                   ENDSR


### PR DESCRIPTION
## Description

Implement StatementThatCanDefineData for TimeStmt in order to allow for inline variable declarations.

Related to:
- T04_A80_P05

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
