### PR TITLE
Bugfix/nw23001440/subdur inline vars

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -280,9 +280,10 @@ data class SubDurStmt(
     val target: AssignableExpression,
     val factor2: Expression,
     val durationCode: DurationCode,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
 ) :
-    Statement(position) {
+    Statement(position), StatementThatCanDefineData {
     override fun execute(interpreter: InterpreterCore) {
         when (target) {
             is DataRefExpr -> {
@@ -293,6 +294,8 @@ data class SubDurStmt(
             else -> throw UnsupportedOperationException("Data reference required: $this")
         }
     }
+
+    override fun dataDefinition(): List<InStatementDataDefinition> = dataDefinition?.let { listOf(it) } ?: emptyList()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1216,7 +1216,9 @@ internal fun CsSUBDURContext.toAst(conf: ToAstConfiguration = ToAstConfiguration
     // TODO handle duration code after the :
     val target = this.cspec_fixed_standard_parts().result.text.split(":")
     val durationCode = if (target.size > 1) target[1].toDuration() else DurationInMSecs
-    return SubDurStmt(left, DataRefExpr(ReferenceByName(target[0]), position), factor2, durationCode, position)
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(target.first(), position, conf)
+
+    return SubDurStmt(left, DataRefExpr(ReferenceByName(target[0]), position), factor2, durationCode, dataDefinition, position)
 }
 
 private fun String.toDuration(): DurationCode =

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -562,4 +562,12 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T12_A04_P14".outputOf())
     }
+
+    @Test
+    fun executeT04_A90_P05() {
+        val expected = listOf(
+            "Microsecondi(98085763813000) Secondi(98085763) Minuti(1634762) Ore(27246) Giorni(1135) Mesi(37) Anni(3)"
+        )
+        assertEquals(expected, "smeup/T04_A90_P05".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A90_P05.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T04_A90_P05.rpgle
@@ -1,0 +1,31 @@
+     D £DBG_Str        S            150          VARYING
+     D A90_A1          S             30    INZ
+     D A90_A2          S             30    INZ
+     D A90_Z1          S               Z   INZ
+     D A90_Z2          S               Z   INZ
+     D A90_N1          S             10I 0
+     D A90_N2          S             10I 0
+     D A90_N3          S             10I 0
+     D A90_N4          S             10I 0
+
+     C                   EVAL      A90_A1='2020-11-01-14.11.17.725000'
+     C                   EVAL      A90_Z1=%TIMESTAMP(A90_A1)
+     C                   EVAL      A90_A2='2023-12-11-20.14.01.538000'
+     C                   EVAL      A90_Z2=%TIMESTAMP(A90_A2)
+     C     A90_Z2        SUBDUR    A90_Z1        A90_D1:*MS       20 0
+     C     A90_Z2        SUBDUR    A90_Z1        A90_D2:*S        20 0
+     C     A90_Z2        SUBDUR    A90_Z1        A90_D3:*MN       20 0
+     C     A90_Z2        SUBDUR    A90_Z1        A90_D4:*H        20 0
+     C     A90_Z2        SUBDUR    A90_Z1        A90_D5:*D        10 0
+     C     A90_Z2        SUBDUR    A90_Z1        A90_D6:*M        10 0
+     C     A90_Z2        SUBDUR    A90_Z1        A90_D7:*Y         5 0
+     C                   EVAL      £DBG_Str=
+     C                              'Microsecondi('+%CHAR(A90_D1)+') '
+     C                             +'Secondi('+%CHAR(A90_D2)+') '
+     C                             +'Minuti('+%CHAR(A90_D3)+') '
+     C                             +'Ore('+%CHAR(A90_D4)+') '
+     C                             +'Giorni('+%CHAR(A90_D5)+') '
+     C                             +'Mesi('+%CHAR(A90_D6)+') '
+     C                             +'Anni('+%CHAR(A90_D7)+') '
+
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Implement StatementThatCanDefineData for SubDurStmt in order to allow for inline variables declarations

Related to:
- T04_A90_P05

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
