### PR TITLE
Bugfix/nw23001440/229 data reference inline do

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -717,19 +717,11 @@ open class InternalInterpreter(
         // calculation of rest
         // NB. rest based on type of quotient
         if (statement.mvrStatement != null) {
-            val restType = when {
-                statement.mvrStatement.dataDefinition != null -> statement.mvrStatement.dataDefinition.type
-                statement.mvrStatement.target != null -> statement.mvrStatement.target.type()
-                else -> null
-            }
+            val restType = statement.mvrStatement.target?.type()
             require(restType is NumberType)
             val truncatedQuotient: BigDecimal = quotient.setScale(type.decimalDigits, RoundingMode.DOWN)
-            // rest = divident - (truncatedQuotient * divisor)
             val rest: BigDecimal = dividend.subtract(truncatedQuotient.multiply(divisor))
-            when {
-                statement.mvrStatement.dataDefinition != null -> assign(statement.mvrStatement.dataDefinition, DecimalValue(rest.setScale(restType.decimalDigits, RoundingMode.DOWN)))
-                statement.mvrStatement.target != null -> assign(statement.mvrStatement.target, DecimalValue(rest.setScale(restType.decimalDigits, RoundingMode.DOWN)))
-            }
+            assign(statement.mvrStatement.target, DecimalValue(rest.setScale(restType.decimalDigits, RoundingMode.DOWN)))
         }
         return if (statement.halfAdjust) {
             DecimalValue(quotient.setScale(type.decimalDigits, RoundingMode.HALF_UP))

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -716,13 +716,20 @@ open class InternalInterpreter(
         require(type is NumberType)
         // calculation of rest
         // NB. rest based on type of quotient
-        if (statement.mvrTarget != null) {
-            val restType = statement.mvrTarget.type()
+        if (statement.mvrStatement != null) {
+            val restType = when {
+                statement.mvrStatement.dataDefinition != null -> statement.mvrStatement.dataDefinition.type
+                statement.mvrStatement.target != null -> statement.mvrStatement.target.type()
+                else -> null
+            }
             require(restType is NumberType)
             val truncatedQuotient: BigDecimal = quotient.setScale(type.decimalDigits, RoundingMode.DOWN)
             // rest = divident - (truncatedQuotient * divisor)
             val rest: BigDecimal = dividend.subtract(truncatedQuotient.multiply(divisor))
-            assign(statement.mvrTarget, DecimalValue(rest.setScale(restType.decimalDigits, RoundingMode.DOWN)))
+            when {
+                statement.mvrStatement.dataDefinition != null -> assign(statement.mvrStatement.dataDefinition, DecimalValue(rest.setScale(restType.decimalDigits, RoundingMode.DOWN)))
+                statement.mvrStatement.target != null -> assign(statement.mvrStatement.target, DecimalValue(rest.setScale(restType.decimalDigits, RoundingMode.DOWN)))
+            }
         }
         return if (statement.halfAdjust) {
             DecimalValue(quotient.setScale(type.decimalDigits, RoundingMode.HALF_UP))

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -72,6 +72,7 @@ private val modules = SerializersModule {
         subclass(MoveLStmt::class)
         subclass(MoveStmt::class)
         subclass(MultStmt::class)
+        subclass(MvrStmt::class)
         subclass(OtherStmt::class)
         subclass(OccurStmt::class)
         subclass(OpenStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1179,6 +1179,16 @@ data class DivStmt(
 }
 
 @Serializable
+data class MvrStmt(
+    val target: AssignableExpression?,
+    @Derived val dataDefinition: InStatementDataDefinition? = null,
+    override val position: Position? = null
+) : Statement(position), StatementThatCanDefineData {
+    override fun dataDefinition() = dataDefinition?.let { listOf(it) } ?: emptyList()
+    override fun execute(interpreter: InterpreterCore) { }
+}
+
+@Serializable
 data class AddStmt(
     val left: Expression?,
     val result: AssignableExpression,

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1157,7 +1157,7 @@ data class DivStmt(
     val halfAdjust: Boolean = false,
     val factor1: Expression?,
     val factor2: Expression,
-    val mvrTarget: AssignableExpression? = null,
+    val mvrStatement: MvrStmt? = null,
     @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
 ) : Statement(position), StatementThatCanDefineData {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1461,17 +1461,30 @@ internal fun CsDIVContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
     this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
     val extenders = this.operationExtender?.extender?.text?.uppercase(Locale.getDefault())?.toCharArray() ?: CharArray(0)
     val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result, position, conf)
-    val mvrTarget: AssignableExpression? = this.csMVR()?.cspec_fixed_standard_parts()?.result?.text?.let {
-        DataRefExpr(ReferenceByName(it), position)
-    }
     return DivStmt(
         target = this.cspec_fixed_standard_parts().result.toAst(conf),
         halfAdjust = 'H' in extenders,
         factor1 = factor1,
         factor2 = factor2,
-        mvrTarget = mvrTarget,
+        mvrStatement = this.csMVR()?.toAst(conf),
         dataDefinition = dataDefinition,
         position = position
+    )
+}
+
+internal fun CsMVRContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MvrStmt {
+    val result = this.cspec_fixed_standard_parts().result.text
+    val target = result?.let {
+        DataRefExpr(ReferenceByName(it), toPosition(conf.considerPosition))
+    }
+    val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(
+        name = result,
+        position = toPosition(conf.considerPosition),
+        conf = conf
+    )
+    return MvrStmt(
+        target = target,
+        dataDefinition = dataDefinition
     )
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -562,4 +562,12 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T12_A04_P14".outputOf())
     }
+
+    @Test
+    fun executeT12_A04_P17() {
+        val expected = listOf(
+            "A04_N50_CNT(50)A04_N1(2)A04_N2(50)A04_N4(51)"
+        )
+        assertEquals(expected, "smeup/T12_A04_P17".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -570,4 +570,12 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T12_A04_P17".outputOf())
     }
+
+    @Test
+    fun executeT10_A20_P47() {
+        val expected = listOf(
+            "A20_D7(53.33) A20_D8(.002) A20_D9(2) A20_D0(3)"
+        )
+        assertEquals(expected, "smeup/T10_A20_P47".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A20_P47.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A20_P47.rpgle
@@ -1,0 +1,15 @@
+     D A20_D1          S              3  0 INZ(32)
+     D A20_D2          S              3  1 INZ(0.6)
+     D A20_D3          S              2  0 INZ(25)
+     D A20_D4          S              2  0 INZ(11)
+     D £DBG_Str        S             50          VARYING
+
+     C     A20_D1        DIV       A20_D2        A20_D7           11 2
+     C                   MVR                     A20_D8            5 3
+     C     A20_D3        DIV       A20_D4        A20_D9            2 0
+     C                   MVR                     A20_D0            2 0
+     C                   EVAL      £DBG_Str='A20_D7('+%CHAR(A20_D7)+')'
+     C                                    +' A20_D8('+%CHAR(A20_D8)+')'
+     C                                    +' A20_D9('+%CHAR(A20_D9)+')'
+     C                                    +' A20_D0('+%CHAR(A20_D0)+')'
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P17.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P17.rpgle
@@ -1,0 +1,20 @@
+     D A04_N50_LIM     S              6  0 INZ(100000)
+     D A04_N50_CNT     S                   LIKE(A04_N50_LIM)
+     D A04_N1          S              3  0 INZ(2)
+     D A04_N2          S              3  0 INZ(50)
+     D £DBG_Str        S             50          VARYING
+
+
+     C                   EVAL      A04_N50_CNT = 0
+     C                   SELECT
+     C     A04_N50_CNT   WHENEQ    0
+     C     A04_N1        DO        A04_N2        A04_N4            3 0
+     C                   EVAL      A04_N50_CNT = A04_N4
+     C                   ENDDO
+     C                   ENDSL
+     C                   EVAL      £DBG_Str=
+     C                                 'A04_N50_CNT('+%CHAR(A04_N50_CNT)+')'
+     C                                +'A04_N1('+%CHAR(A04_N1)+')'
+     C                                +'A04_N2('+%CHAR(A04_N2)+')'
+     C                                +'A04_N4('+%CHAR(A04_N4)+')'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description
To fix this problem, was necessary to improve `findInStatementDataDefinitions` in `resolution.kt`. The main view is that a statement could have a `dataDefinition` (for inline variable) but also a `body` with nested statements with other `dataDefinition`. With this fix is resolved task `229`.

But task `230` is particular. Considering this code:
```
     D A20_D1          S              3  0 INZ(32)
     D A20_D2          S              3  1 INZ(0.6)

     C     A20_D1        DIV       A20_D2        A20_D7           11 2
     C                   MVR                     A20_D8            5 3
```
here we have a `MVR` with a data declared inline. To fix this problem, `MVR` must be a statement, specifically a `StatementThatCanDefineData`. For `DivStmt` is not necessary to know only the `result` like a variable, but also like a `dataDefinition` if is declared inline like other cases. For this reason, `mvrResult` is replaced with `mvrStatement`. With this fix is resolved task `230`

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
