### PR TITLE
Bugfix/nw23001440/239 data reference to procedure

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -64,7 +64,13 @@ private fun Node.resolveDataRefs(cu: CompilationUnit) {
                         currentCu = currentCu.parent?.let { it as CompilationUnit }
                     }
                     if (!resolved) {
-                        kotlin.runCatching { dre.error("Data reference not resolved: ${dre.variable.name}") }
+                        /* Maybe is a procedure without parenthesis. */
+                        val procedureFound = cu.procedures?.firstOrNull() { it.procedureName == dre.variable.name }
+                        if (procedureFound != null) {
+                            procedureFound.resolve()
+                        } else {
+                            kotlin.runCatching { dre.error("Data reference not resolved: ${dre.variable.name}") }
+                        }
                     }
                 }
             }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -562,4 +562,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T12_A04_P14".outputOf())
     }
+
+    @Test
+    fun executeT18_A10_P01() {
+        val expected = listOf("Ritorno_Procedura")
+        assertEquals(expected, "smeup/T18_A10_P01".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T18_A10_P01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T18_A10_P01.rpgle
@@ -1,0 +1,10 @@
+     D A10_PR01        PR            25A
+     D £DBG_Str        S             50          VARYING
+
+     C                   EVAL      £DBG_Str=A10_PR01()
+     C     £DBG_Str      DSPLY
+
+     P A10_PR01        B
+     D A10_PR01        PI            25A
+     C                   RETURN    'Ritorno_Procedura'
+     P A10_PR01        E


### PR DESCRIPTION
## Description
In this context, a procedure could be called by its name without parenthesis. Jariko, in this case, recognizes the name like variable instead a procedure. So, in case of not resolution, there will be a new attempt by searching the procedure by its name. If it is found, will be executed.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
