### PR TITLE
Bugfix/nw23001440/indicators letter case

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/indicators.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/indicators.kt
@@ -5,6 +5,7 @@ import com.smeup.rpgparser.interpreter.Value
 import com.smeup.rpgparser.parsing.parsetreetoast.isInt
 import com.strumenta.kolasu.model.Position
 import kotlinx.serialization.Serializable
+import java.util.*
 
 // *IN01..*IN99 and *INLR *INRT
 @Serializable
@@ -98,7 +99,7 @@ fun String.toIndicatorKey(): IndicatorKey {
             require(IndicatorType.Predefined.range.contains(it.toInt()))
             it.toInt()
         }
-        else -> IndicatorType.valueOf(this).range.first
+        else -> IndicatorType.valueOf(this.uppercase()).range.first
     }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -204,7 +204,7 @@ internal fun RpgParser.Multipart_identifier_elementContext.toAst(conf: ToAstConf
 }
 
 internal fun String.indicatorIndex(): Int? {
-    val uCaseIndicatorString = this.toUpperCase()
+    val uCaseIndicatorString = this.uppercase()
     return when {
         uCaseIndicatorString.startsWith("*IN") ->
             this.substring("*IN".length).toIndicatorKey()
@@ -214,9 +214,9 @@ internal fun String.indicatorIndex(): Int? {
 
 internal fun String.dataWrapUpChoice(): DataWrapUpChoice? {
     val indicator = when {
-        this.toUpperCase().startsWith("*IN(") && this.endsWith(")") ->
-            this.toUpperCase().removePrefix("*IN(").removeSuffix(")")
-        this.toUpperCase().startsWith("*IN") -> this.substring("*IN".length)
+        this.uppercase().startsWith("*IN(") && this.endsWith(")") ->
+            this.uppercase().removePrefix("*IN(").removeSuffix(")")
+        this.uppercase().startsWith("*IN") -> this.substring("*IN".length)
         else -> null
     }
     return when (indicator) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -665,7 +665,7 @@ internal fun SymbolicConstantsContext.toAst(conf: ToAstConfiguration = ToAstConf
         this.SPLAT_ON() != null -> OnRefExpr(position)
         this.SPLAT_INDICATOR() != null -> {
             IndicatorExpr(
-                index = children[0].text.replace("*IN", "").toIndicatorKey(),
+                index = children[0].text.uppercase().replace("*IN", "").toIndicatorKey(),
                 position = position
             )
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -308,6 +308,22 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
+    fun executeT03_A10_P11() {
+        val expected = listOf(
+            "*INLR->1"
+        )
+        assertEquals(expected, "smeup/T03_A10_P11".outputOf())
+    }
+
+    @Test
+    fun executeT03_A10_P12() {
+        val expected = listOf(
+            "*IN35->1, *INLR->1"
+        )
+        assertEquals(expected, "smeup/T03_A10_P12".outputOf())
+    }
+
+    @Test
     fun executeT15_A20_P04_06() {
         val expected = listOf(
             "RicercaDaPos01(1)_Trovato(1); RicercaDaPos02(5)_Trovato(1); RicercaDaPos05(5)_Trovato(1); RicercaDaPos07(0)_Trovato(0);",

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -292,12 +292,19 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
-    fun executeT03_A10_P09_10() {
+    fun executeT03_A10_P09() {
         val expected = listOf(
-            "I(15)=0 I(15)=1 I(15)=0",
+            "I(15)=0 I(15)=1 I(15)=0"
+        )
+        assertEquals(expected, "smeup/T03_A10_P09".outputOf())
+    }
+
+    @Test
+    fun executeT03_A10_P10() {
+        val expected = listOf(
             "*IN(n)->000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         )
-        assertEquals(expected, "smeup/T03_A10_P09-10".outputOf())
+        assertEquals(expected, "smeup/T03_A10_P10".outputOf())
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P09.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P09.rpgle
@@ -15,12 +15,3 @@
      C                               +' I('+%CHAR($IND)+')='
      C                               +%CHAR(*IN($IND))
      C     £DBG_Str      DSPLY
-
-     D* Indicatori come array con indice n *IN(n)
-     C                   EVAL      £DBG_Str='*IN(n)->'
-     C                   EVAL      $IND=1
-     C                   DO        99
-     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
-     C                               +%CHAR(*IN($IND))
-     C                   ENDDO
-     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P10.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P10.rpgle
@@ -1,0 +1,11 @@
+     D $IND            S              2  0
+     D £DBG_Str        S             110          VARYING
+
+     D* Indicatori come array con indice n *IN(n)
+     C                   EVAL      £DBG_Str='*IN(n)->'
+     C                   EVAL      $IND=1
+     C                   DO        99
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +%CHAR(*IN($IND))
+     C                   ENDDO
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P11.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P11.rpgle
@@ -1,0 +1,9 @@
+     D £DBG_Str        S             10          VARYING
+      * Indicatori con letter case differente
+     C                   EVAL      *inlr=*On
+      *
+     C                   EVAL      £DBG_Str='*INLR->'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +%CHAR(*INLR)
+      *
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P12.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T03_A10_P12.rpgle
@@ -1,0 +1,16 @@
+     D £DBG_Str        S             20           VARYING
+      * Indicatori con letter case differente
+     C                   EVAL      *in35=*On
+      *
+     C     *In35         IFEQ      *ON
+     C                   EVAL      *inlr=*On
+     c                   ENDIF
+     C                   EVAL      £DBG_Str='*IN35->'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +%CHAR(*IN35)
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +', *INLR->'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)
+     C                               +%CHAR(*INLR)
+      *
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description
In this branch has been fixed the letter case problem when the rpg source contained "*inXX" (note the lower case).  
I fixed it by using the "uppercase" method before any test that looked for "*IN" string.
The "uppercase" method was used almost everywhere with some exception. 
I also replaced the obsolete "toUpperCase" method with the new "uppercase".

Related to:
- T03_A10_P11
- T03_A10_P12 

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
