### PR TITLE
Bugfix/nw23001440/238 data reference to procedure

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -164,7 +164,7 @@ private fun RpgParser.IdentifierContext.variableExpression(conf: ToAstConfigurat
     }
 }
 
-fun RpgParser.IdentifierContext.isFunctionWithoutParams(referenceName: String): Boolean {
+private fun RpgParser.IdentifierContext.isFunctionWithoutParams(referenceName: String): Boolean {
     return runCatching {
         rContext().children.filterIsInstance<Dcl_prContext>()
                 .flatMap { it.children.filterIsInstance<PrBeginContext>() }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -144,6 +144,11 @@ internal fun RpgParser.IdentifierContext.toAst(conf: ToAstConfiguration = ToAstC
     if (this.text.toUpperCase().startsWith("*ALL")) {
         return AllExpr(this.all().literal().toAst(conf), toPosition(conf.considerPosition))
     }
+
+    if (isFunctionWithoutParams(this.text)) {
+        return FunctionCall(ReferenceByName(this.text), listOf(), toPosition(conf.considerPosition))
+    }
+
     return when (this.text.toUpperCase()) {
         "*BLANK", "*BLANKS" -> BlanksRefExpr(toPosition(conf.considerPosition))
         "*ZERO", "*ZEROS" -> ZeroExpr(toPosition(conf.considerPosition))
@@ -159,7 +164,6 @@ private fun RpgParser.IdentifierContext.variableExpression(conf: ToAstConfigurat
     return when {
         this.text.indicatorIndex() != null -> IndicatorExpr(this.text.indicatorIndex()!!, toPosition(conf.considerPosition))
         this.multipart_identifier() != null -> this.multipart_identifier().toAst(conf)
-        isFunctionWithoutParams(this.text) -> FunctionCall(ReferenceByName(this.text), listOf())
         else -> DataRefExpr(variable = ReferenceByName(this.text), position = toPosition(conf.considerPosition))
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -64,13 +64,7 @@ private fun Node.resolveDataRefs(cu: CompilationUnit) {
                         currentCu = currentCu.parent?.let { it as CompilationUnit }
                     }
                     if (!resolved) {
-                        /* Maybe is a procedure without parenthesis. */
-                        val procedureFound = cu.procedures?.firstOrNull() { it.procedureName == dre.variable.name }
-                        if (procedureFound != null) {
-                            procedureFound.resolve()
-                        } else {
-                            kotlin.runCatching { dre.error("Data reference not resolved: ${dre.variable.name}") }
-                        }
+                        kotlin.runCatching { dre.error("Data reference not resolved: ${dre.variable.name}") }
                     }
                 }
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -64,7 +64,13 @@ private fun Node.resolveDataRefs(cu: CompilationUnit) {
                         currentCu = currentCu.parent?.let { it as CompilationUnit }
                     }
                     if (!resolved) {
-                        kotlin.runCatching { dre.error("Data reference not resolved: ${dre.variable.name}") }
+                        /* Maybe is a procedure without parenthesis. */
+                        val procedureFound = cu.procedures?.firstOrNull() { it.procedureName == dre.variable.name }
+                        if (procedureFound != null) {
+                            procedureFound.resolve()
+                        } else {
+                            kotlin.runCatching { dre.error("Data reference not resolved: ${dre.variable.name}") }
+                        }
                     }
                 }
             }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -562,4 +562,10 @@ open class SmeupInterpreterTest : AbstractTest() {
         )
         assertEquals(expected, "smeup/T12_A04_P14".outputOf())
     }
+
+    @Test
+    fun executeT18_A10_P01() {
+        val expected = listOf("Ritorno_Procedura")
+        assertEquals(expected, "smeup/T18_A10_P01".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T18_A10_P01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T18_A10_P01.rpgle
@@ -1,7 +1,7 @@
      D A10_PR01        PR            25A
      D £DBG_Str        S             50          VARYING
 
-     C                   EVAL      £DBG_Str=A10_PR01()
+     C                   EVAL      £DBG_Str=A10_PR01
      C     £DBG_Str      DSPLY
 
      P A10_PR01        B

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T18_A10_P01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T18_A10_P01.rpgle
@@ -1,0 +1,10 @@
+     D A10_PR01        PR            25A
+     D £DBG_Str        S             50          VARYING
+
+     C                   EVAL      £DBG_Str=A10_PR01()
+     C     £DBG_Str      DSPLY
+
+     P A10_PR01        B
+     D A10_PR01        PI            25A
+     C                   RETURN    'Ritorno_Procedura'
+     P A10_PR01        E


### PR DESCRIPTION
## Description
In this context, a procedure could be called by its name without parenthesis. Jariko, in this case, recognizes the name like identifier instead a function. So, in `expressions` the is a check if the name is a procedure or not.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
