### PR TITLE
Bugfix/nw23001440/blank variables checkstmt

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -314,6 +314,10 @@ data class IntValue(val value: Long) : NumberValue() {
         return StringValue(render())
     }
 
+    override fun asBoolean(): BooleanValue {
+        return BooleanValue(value > 0)
+    }
+
     operator fun plus(other: IntValue) = IntValue(this.bigDecimal.plus(other.bigDecimal).longValueExact())
 
     operator fun minus(other: IntValue) = IntValue(this.bigDecimal.minus(other.bigDecimal).longValueExact())

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1031,10 +1031,10 @@ internal fun ResultTypeContext.toAst(conf: ToAstConfiguration = ToAstConfigurati
     // what kind of expression is this
     val position = toPosition(conf.considerPosition)
 
-    if (text.contains('.')) {
-        return handleParsingOfTargets(text, position)
+    return if (text.contains('.')) {
+        handleParsingOfTargets(text, position)
     } else {
-        return annidatedReferenceExpression(text, position)
+        annidatedReferenceExpression(text, position)
     }
 }
 
@@ -1345,11 +1345,19 @@ internal fun CsCHECKContext.toAst(conf: ToAstConfiguration): Statement {
     val result = this.cspec_fixed_standard_parts().result
     val dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(result.text, position, conf)
 
+    val eqIndicator = this.cspec_fixed_standard_parts().resultIndicator(2)?.text
+
+    val wrongCharExpression = when {
+        result != null && result.text.isNotBlank() -> result.toAst(conf)
+        !eqIndicator.isNullOrBlank() -> IndicatorExpr(eqIndicator.toIndicatorKey(), position)
+        else -> null
+    }
+
     return CheckStmt(
         factor1,
         expression,
         startPosition ?: 1,
-        this.cspec_fixed_standard_parts()?.result?.toAst(conf),
+        wrongCharExpression,
         dataDefinition,
         position
     )

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -660,4 +660,22 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf("123")
         assertEquals(expected, "smeup/T02_A80_P03".outputOf())
     }
+
+    @Test
+    fun executeT10_A45_P04() {
+        val expected = listOf("IND(0)")
+        assertEquals(expected, "smeup/T10_A45_P04".outputOf())
+    }
+
+    @Test
+    fun executeT10_A45_P05() {
+        val expected = listOf("IND(1)")
+        assertEquals(expected, "smeup/T10_A45_P05".outputOf())
+    }
+
+    @Test
+    fun executeT10_A45_P06() {
+        val expected = listOf("IND(0)")
+        assertEquals(expected, "smeup/T10_A45_P06".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A45_P04.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A45_P04.rpgle
@@ -1,0 +1,12 @@
+     D £DBG_Str        S            150          VARYING
+
+     D A45_A10         C                   '0123456789'
+     D A45_A04         S              4    INZ('    ')
+     D A45_N10         S              1  0
+
+     C                   SETOFF                                       40
+     C                   EVAL      A45_A04='2019'
+     C     A45_A10       CHECK     A45_A04                                40
+     C                   EVAL      £DBG_Str='IND('+%CHAR(*IN40)+')'
+
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A45_P05.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A45_P05.rpgle
@@ -1,0 +1,12 @@
+     D £DBG_Str        S            150          VARYING
+
+     D A45_A10         C                   '0123456789'
+     D A45_A04         S              4    INZ('    ')
+     D A45_N10         S              1  0
+
+     C                   SETOFF                                       40
+     C                   EVAL      A45_A04='201A'
+     C     A45_A10       CHECK     A45_A04                                40
+     C                   EVAL      £DBG_Str='IND('+%CHAR(*IN40)+')'
+
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A45_P06.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T10_A45_P06.rpgle
@@ -1,0 +1,12 @@
+     D £DBG_Str        S            150          VARYING
+
+     D A45_A10         C                   '0123456789'
+     D A45_A04         S              4    INZ('    ')
+     D A45_N10         S              1  0
+
+     C                   SETOFF                                       40
+     C                   EVAL      A45_A04='201A'
+     C     A45_A10       CHECK     A45_A04                              40
+     C                   EVAL      £DBG_Str='IND('+%CHAR(*IN40)+')'
+
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add support for general indicators in position 75-76.

Related to:
- T10_A45_P04
- T10_A45_P05
- T10_A45_P06

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
