### PR TITLE
Feature/nw23001440/monitor stmt

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -206,21 +206,19 @@ class ExpressionEvaluation(
 
     override fun eval(expression: CharExpr): Value {
         val value = expression.value.evalWith(this)
-        return if (expression.value is DivExpr) {
-            // are always return 10 decimal digits
-            // fill with 0 if necessary
-            if (value.asDecimal().value.scale() != 0) {
-                val numeDecimals = value.asDecimal().value.scale()
-                if (numeDecimals < 10) {
-                    StringValue(value.stringRepresentation(expression.format) + "0".repeat(10 - numeDecimals))
-                } else {
-                    StringValue(value.stringRepresentation(expression.format).trim())
-                }
-            } else {
-                StringValue(value.stringRepresentation(expression.format) + ".0000000000")
-            }
-        } else {
-            StringValue(value.stringRepresentation(expression.format))
+        val representation = value.stringRepresentation(expression.format)
+
+        if (expression.value !is DivExpr) {
+            return StringValue(representation)
+        }
+
+        // Decimals are always returned with 10 decimal digits
+        // fill with 0 if necessary
+        val numDecimals = value.asDecimal().value.scale()
+        return when {
+            numDecimals == 0 -> StringValue("$representation.0000000000")
+            numDecimals < 10 -> StringValue(representation + "0".repeat(10 - numDecimals))
+            else -> StringValue(representation.trim())
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/logs.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/logs.kt
@@ -411,6 +411,17 @@ class CasOtherExecutionLogEntry(programName: String, val other: CaseOtherClause,
     }
 }
 
+class MonitorExecutionLogEntry(programName: String, val statement: MonitorStmt) : LogEntry(programName) {
+    override fun toString(): String {
+        return "executing MONITOR"
+    }
+
+    override fun renderStatement(channel: String, filename: String, sep: String): String {
+        val data = "MONITOR"
+        return renderHeader(channel, filename, statement.startLine(), sep) + data
+    }
+}
+
 class IfExecutionLogEntry(programName: String, val statement: IfStmt, val result: Value) : LogEntry(programName) {
     override fun toString(): String {
         return "executing IF"
@@ -438,6 +449,16 @@ class ElseExecutionLogEntry(programName: String, val statement: ElseClause, val 
     }
     override fun renderStatement(channel: String, filename: String, sep: String): String {
         val data = "ELSE"
+        return renderHeader(channel, filename, statement.startLine(), sep) + data
+    }
+}
+
+class OnErrorExecutionLogEntry(programName: String, val statement: OnErrorClause) : LogEntry(programName) {
+    override fun toString(): String {
+        return "executing ON-ERROR"
+    }
+    override fun renderStatement(channel: String, filename: String, sep: String): String {
+        val data = "ON-ERROR"
         return renderHeader(channel, filename, statement.startLine(), sep) + data
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -68,6 +68,7 @@ private val modules = SerializersModule {
         subclass(LeaveSrStmt::class)
         subclass(LeaveStmt::class)
         subclass(LookupStmt::class)
+        subclass(MonitorStmt::class)
         subclass(MoveAStmt::class)
         subclass(MoveLStmt::class)
         subclass(MoveStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1121,10 +1121,7 @@ internal fun Cspec_fixed_standard_partsContext.toDataDefinition(
     position: Position?,
     conf: ToAstConfiguration
 ): InStatementDataDefinition? {
-    val len = this.len.asInt()
-    if (len == null) {
-        return null
-    }
+    val len = this.len.asInt() ?: return null
     val decimals = this.decimalPositions.asInt()
     val initialValue = this.factor2Expression(conf)
     return InStatementDataDefinition(name, dataType(len, decimals), position, initializationValue = initialValue)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -666,4 +666,28 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf("PROVA")
         assertEquals(expected, "smeup/T02_A80_P02".outputOf())
     }
+
+    @Test
+    fun executeT11_A10_P01() {
+        val expected = listOf("BLOCCO; ERR_ZERO_DIV;")
+        assertEquals(expected, "smeup/T11_A10_P01".outputOf())
+    }
+
+    @Test
+    fun executeT11_A10_P02() {
+        val expected = listOf("BLOCCO1; BLOCCO2; BLOCCO3; ERR_ZERO_DIV; FINE_BLOCCO3;; ERR_ZERO_DIV; FINE_BLOCCO2;; ERR_ZERO_DIV; FINE_BLOCCO1;")
+        assertEquals(expected, "smeup/T11_A10_P02".outputOf())
+    }
+
+    @Test
+    fun executeT11_A10_P03() {
+        val expected = listOf("DENTRO_IF(BLOCCO; ERR_ZERO_DIV;) DENTRO_DO(BLOCCO; ERR_ZERO_DIV;BLOCCO; ERR_ZERO_DIV;) DENTRO_WHEN(BLOCCO; ERR_ZERO_DIV;) DENTRO_OTHER(BLOCCO; ERR_ZERO_DIV;)")
+        assertEquals(expected, "smeup/T11_A10_P03".outputOf())
+    }
+
+    @Test
+    fun executeT11_A10_P04() {
+        val expected = listOf("DENTRO_IF(BLOCCO; ERR_ZERO_DIV;) DENTRO_DO(BLOCCO; ERR_ZERO_DIV;) DENTRO_WHEN(BLOCCO; ERR_ZERO_DIV;) DENTRO_OTHER(BLOCCO; ERR_ZERO_DIV;)")
+        assertEquals(expected, "smeup/T11_A10_P04".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -666,28 +666,4 @@ open class SmeupInterpreterTest : AbstractTest() {
         val expected = listOf("Lunghezza: 32580 Contenuto:                     -          -          -          -          -          -          -")
         assertEquals(expected, "smeup/T40_A30_P01".outputOf(configuration = smeupConfig))
     }
-
-    @Test
-    fun executeT11_A10_P01() {
-        val expected = listOf("BLOCCO; ERR_ZERO_DIV;")
-        assertEquals(expected, "smeup/T11_A10_P01".outputOf())
-    }
-
-    @Test
-    fun executeT11_A10_P02() {
-        val expected = listOf("BLOCCO1; BLOCCO2; BLOCCO3; ERR_ZERO_DIV; FINE_BLOCCO3;; ERR_ZERO_DIV; FINE_BLOCCO2;; ERR_ZERO_DIV; FINE_BLOCCO1;")
-        assertEquals(expected, "smeup/T11_A10_P02".outputOf())
-    }
-
-    @Test
-    fun executeT11_A10_P03() {
-        val expected = listOf("DENTRO_IF(BLOCCO; ERR_ZERO_DIV;) DENTRO_DO(BLOCCO; ERR_ZERO_DIV;BLOCCO; ERR_ZERO_DIV;) DENTRO_WHEN(BLOCCO; ERR_ZERO_DIV;) DENTRO_OTHER(BLOCCO; ERR_ZERO_DIV;)")
-        assertEquals(expected, "smeup/T11_A10_P03".outputOf())
-    }
-
-    @Test
-    fun executeT11_A10_P04() {
-        val expected = listOf("DENTRO_IF(BLOCCO; ERR_ZERO_DIV;) DENTRO_DO(BLOCCO; ERR_ZERO_DIV;) DENTRO_WHEN(BLOCCO; ERR_ZERO_DIV;) DENTRO_OTHER(BLOCCO; ERR_ZERO_DIV;)")
-        assertEquals(expected, "smeup/T11_A10_P04".outputOf())
-    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT11Codop2Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT11Codop2Test.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 open class MULANGT11Codop2Test : MULANGTTest() {
     /**
-     * Monitoraggio e cattura errore
+     * MONITOR and error catching
      * @see #241
      */
     @Test
@@ -15,7 +15,7 @@ open class MULANGT11Codop2Test : MULANGTTest() {
     }
 
     /**
-     * Specifiche MONITOR annidiate
+     * Nested MONITOR statements
      * @see #241
      */
     @Test
@@ -25,7 +25,7 @@ open class MULANGT11Codop2Test : MULANGTTest() {
     }
 
     /**
-     * Specifiche MONITOR annidiate in IF, DO e SELECT
+     * MONITOR nested in IF, DO and SELECT
      * @see #241
      */
     @Test
@@ -35,7 +35,7 @@ open class MULANGT11Codop2Test : MULANGTTest() {
     }
 
     /**
-     * Specifiche IF, DO e SELECT in MONITOR
+     * IF, DO and SELECT in MONITOR
      * @see #241
      */
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT11Codop2Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT11Codop2Test.kt
@@ -1,3 +1,46 @@
 package com.smeup.rpgparser.smeup
 
-open class MULANGT11Codop2Test : MULANGTTest()
+import org.junit.Test
+import kotlin.test.assertEquals
+
+open class MULANGT11Codop2Test : MULANGTTest() {
+    /**
+     * Monitoraggio e cattura errore
+     * @see #241
+     */
+    @Test
+    fun executeT11_A10_P01() {
+        val expected = listOf("BLOCCO; ERR_ZERO_DIV;")
+        assertEquals(expected, "smeup/T11_A10_P01".outputOf())
+    }
+
+    /**
+     * Specifiche MONITOR annidiate
+     * @see #241
+     */
+    @Test
+    fun executeT11_A10_P02() {
+        val expected = listOf("BLOCCO1; BLOCCO2; BLOCCO3; ERR_ZERO_DIV; FINE_BLOCCO3;; ERR_ZERO_DIV; FINE_BLOCCO2;; ERR_ZERO_DIV; FINE_BLOCCO1;")
+        assertEquals(expected, "smeup/T11_A10_P02".outputOf())
+    }
+
+    /**
+     * Specifiche MONITOR annidiate in IF, DO e SELECT
+     * @see #241
+     */
+    @Test
+    fun executeT11_A10_P03() {
+        val expected = listOf("DENTRO_IF(BLOCCO; ERR_ZERO_DIV;) DENTRO_DO(BLOCCO; ERR_ZERO_DIV;BLOCCO; ERR_ZERO_DIV;) DENTRO_WHEN(BLOCCO; ERR_ZERO_DIV;) DENTRO_OTHER(BLOCCO; ERR_ZERO_DIV;)")
+        assertEquals(expected, "smeup/T11_A10_P03".outputOf())
+    }
+
+    /**
+     * Specifiche IF, DO e SELECT in MONITOR
+     * @see #241
+     */
+    @Test
+    fun executeT11_A10_P04() {
+        val expected = listOf("DENTRO_IF(BLOCCO; ERR_ZERO_DIV;) DENTRO_DO(BLOCCO; ERR_ZERO_DIV;) DENTRO_WHEN(BLOCCO; ERR_ZERO_DIV;) DENTRO_OTHER(BLOCCO; ERR_ZERO_DIV;)")
+        assertEquals(expected, "smeup/T11_A10_P04".outputOf())
+    }
+}

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T11_A10_P01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T11_A10_P01.rpgle
@@ -1,0 +1,13 @@
+     D £DBG_Str        S            150          VARYING
+     D T11_A10_A20A    S              2  0 INZ(10)
+     D T11_A10_A20B    S              2  0 INZ(0)
+     C                   MONITOR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'BLOCCO'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; '+
+     C                               %CHAR(T11_A10_A20A/T11_A10_A20B)
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; FINE_BLOCCO;'
+     C                   ON-ERROR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+
+     C                                '; ERR_ZERO_DIV;'
+     C                   ENDMON
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T11_A10_P02.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T11_A10_P02.rpgle
@@ -1,0 +1,31 @@
+     D £DBG_Str        S            150          VARYING
+     D T11_A10_A20A    S              2  0 INZ(10)
+     D T11_A10_A20B    S              2  0 INZ(0)
+     C                   MONITOR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'BLOCCO1;'
+     C                   MONITOR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+' BLOCCO2;'
+     C                   MONITOR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+' BLOCCO3'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; '+
+     C                               %CHAR(T11_A10_A20A/T11_A10_A20B)
+     C                   ON-ERROR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+
+     C                                '; ERR_ZERO_DIV;'
+     C                   ENDMON
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+' FINE_BLOCCO3;'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; '+
+     C                               %CHAR(T11_A10_A20A/T11_A10_A20B)
+     C                   ON-ERROR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+
+     C                                '; ERR_ZERO_DIV;'
+     C                   ENDMON
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+' FINE_BLOCCO2;'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; '+
+     C                               %CHAR(T11_A10_A20A/T11_A10_A20B)
+     C                   ON-ERROR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+
+     C                                '; ERR_ZERO_DIV;'
+     C                   ENDMON
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+' FINE_BLOCCO1;'
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T11_A10_P03.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T11_A10_P03.rpgle
@@ -1,0 +1,36 @@
+     D £DBG_Str        S            180          VARYING
+     D T11_A10_A20A    S              2  0 INZ(10)
+     D T11_A10_A20B    S              2  0 INZ(0)
+     C                   EVAL      £DBG_Str='DENTRO_IF('
+     C                   IF        'A'='A'
+     C                   EXSR      SUB_SEZ_A10
+     C                   ENDIF
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+') DENTRO_DO('
+     C                   DO        2
+     C                   EXSR      SUB_SEZ_A10
+     C                   ENDDO
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+') DENTRO_WHEN('
+     C                   SELECT
+     C                   WHEN      'A'='A'
+     C                   EXSR      SUB_SEZ_A10
+     C                   ENDSL
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+') DENTRO_OTHER('
+     C                   SELECT
+     C                   WHEN      'A'='B'
+     C                   OTHER
+     C                   EXSR      SUB_SEZ_A10
+     C                   ENDSL
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+')'
+     C     £DBG_Str      DSPLY
+
+     C     SUB_SEZ_A10   BEGSR
+     C                   MONITOR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'BLOCCO'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; '+
+     C                               %CHAR(T11_A10_A20A/T11_A10_A20B)
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; FINE_BLOCCO;'
+     C                   ON-ERROR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+
+     C                                '; ERR_ZERO_DIV;'
+     C                   ENDMON
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T11_A10_P04.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T11_A10_P04.rpgle
@@ -1,0 +1,62 @@
+     D £DBG_Str        S            150          VARYING
+     D T11_A10_A20A    S              2  0 INZ(10)
+     D T11_A10_A20B    S              2  0 INZ(0)
+     C                   MONITOR
+     C                   EVAL      £DBG_Str='DENTRO_IF('
+     C                   IF        'A'='A'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'BLOCCO'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; '+
+     C                               %CHAR(T11_A10_A20A/T11_A10_A20B)
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; FINE_BLOCCO;'
+     C                   ENDIF
+     C                   ON-ERROR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+
+     C                                '; ERR_ZERO_DIV;'
+     C                   ENDMON
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+')'
+      *
+     C                   MONITOR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+' DENTRO_DO('
+     C                   DO        2
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'BLOCCO'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; '+
+     C                               %CHAR(T11_A10_A20A/T11_A10_A20B)
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; FINE_BLOCCO;'
+     C                   ENDDO
+     C                   ON-ERROR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+
+     C                                '; ERR_ZERO_DIV;'
+     C                   ENDMON
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+')'
+      *
+     C                   MONITOR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+' DENTRO_WHEN('
+     C                   SELECT
+     C                   WHEN      'A'='A'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'BLOCCO'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; '+
+     C                               %CHAR(T11_A10_A20A/T11_A10_A20B)
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; FINE_BLOCCO;'
+     C                   ENDSL
+     C                   ON-ERROR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+
+     C                                '; ERR_ZERO_DIV;'
+     C                   ENDMON
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+')'
+      *
+     C                   MONITOR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+' DENTRO_OTHER('
+     C                   SELECT
+     C                   WHEN      'A'='B'
+     C                   OTHER
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'BLOCCO'
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; '+
+     C                               %CHAR(T11_A10_A20A/T11_A10_A20B)
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+'; FINE_BLOCCO;'
+     C                   ENDSL
+     C                   ON-ERROR
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+
+     C                                '; ERR_ZERO_DIV;'
+     C                   ENDMON
+     C                   EVAL      £DBG_Str=%TRIM(£DBG_Str)+')'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

MONITOR directives were only supported by grammar. Added base MonitorStmt runtime implementation.

Related to:
- T11_A10_P01~P04

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
