### PR TITLE
Update assertion for unit test T04_A80_P05

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -636,14 +636,6 @@ open class SmeupInterpreterTest : AbstractTest() {
     }
 
     @Test
-    fun executeT04_A80_P05() {
-        val expected = listOf(
-            "A80_D1(hhmmss) A80_D2(hhmmssDDMMYY) A80_D3(hhmmssDDMMYYYY)"
-        )
-        assertEquals(expected, "smeup/T04_A80_P05".outputOf())
-    }
-
-    @Test
     fun executeT02_A30_P04() {
         val expected = listOf<String>("AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCDDDDDDDDDDDDDDDDDDDDEEEEEEEEEEEEEEEEEEEEFFFFFFFFFFFFFFFFFFFF")
         assertEquals(expected, "smeup/T02_A30_P04".outputOf())

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -1,3 +1,20 @@
 package com.smeup.rpgparser.smeup
 
-open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest()
+import org.junit.Test
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
+    /**
+     * TIME with inline number declarations
+     */
+    @Test
+    fun executeT04_A80_P05() {
+        val isEarly = LocalDateTime.now().hour < 10
+        val suffixLength = if (isEarly) 1 else 2
+        val expected = listOf(
+            "A80_D1(hhmm${"s".repeat(suffixLength)}) A80_D2(hhmmssDDMM${"Y".repeat(suffixLength)}) A80_D3(hhmmssDDMMYY${"Y".repeat(suffixLength)})"
+        )
+        assertEquals(expected, "smeup/T04_A80_P05".outputOf())
+    }
+}


### PR DESCRIPTION
## Description

Updated `executeT04_A80_P05()` assertion in order to prevent pipeline failure happening prior to 10 a.m. 
Also moved test to appropriate file.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
