### PR TITLE
Bugfix/nw23001440/262 mock oc feod

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -164,6 +164,10 @@ data class JarikoCallback(
     var onCallPgmError: (errorEvent: ErrorEvent) -> Unit = { },
     var logInfo: ((channel: String, message: String) -> Unit)? = null,
     var channelLoggingEnabled: ((channel: String) -> Boolean)? = null,
+    /**
+     * This is called for those statements mocked.
+     * @param mockStatement "Statement" where is get its name for the `println`.
+     */
     var onMockStatement: ((mockStatement: MockStatement) -> Unit) = { System.err.println("Executing mock: ${it.javaClass.simpleName}") }
 )
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -19,6 +19,7 @@ package com.smeup.rpgparser.execution
 import com.smeup.dbnative.DBNativeAccessConfig
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
+import com.smeup.rpgparser.parsing.ast.MockStatement
 import com.smeup.rpgparser.parsing.facade.CopyBlocks
 import com.smeup.rpgparser.parsing.facade.CopyId
 import com.smeup.rpgparser.parsing.facade.SourceReference
@@ -162,7 +163,8 @@ data class JarikoCallback(
     },
     var onCallPgmError: (errorEvent: ErrorEvent) -> Unit = { },
     var logInfo: ((channel: String, message: String) -> Unit)? = null,
-    var channelLoggingEnabled: ((channel: String) -> Boolean)? = null
+    var channelLoggingEnabled: ((channel: String) -> Boolean)? = null,
+    var onMockStatement: ((mockStatement: MockStatement) -> Unit) = { System.err.println("Executing mock: ${it.javaClass.simpleName}") }
 )
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -411,7 +411,12 @@ open class InternalInterpreter(
                         MainExecutionContext.getConfiguration().jarikoCallback.onEnterStatement(it.first, it.second)
                     }
                 }
-                statement.execute(this)
+
+                if (statement is MockStatement) {
+                    MainExecutionContext.getConfiguration().jarikoCallback.onMockStatement
+                } else {
+                    statement.execute(this)
+                }
             }
         } catch (e: ControlFlowException) {
             throw e

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -39,6 +39,12 @@ private val modules = SerializersModule {
         subclass(FieldDefinition::class)
         subclass(DataDefinition::class)
     }
+    polymorphic(MockStatement::class) {
+        subclass(ExfmtStmt::class)
+        subclass(ReadcStmt::class)
+        subclass(UnlockStmt::class)
+        subclass(FeodStmt::class)
+    }
     polymorphic(Statement::class) {
         subclass(AddStmt::class)
         subclass(CabStmt::class)
@@ -60,7 +66,6 @@ private val modules = SerializersModule {
         subclass(DOWxxStmt::class)
         subclass(EvalStmt::class)
         subclass(ExecuteSubroutine::class)
-        subclass(FeodStmt::class)
         subclass(ForStmt::class)
         subclass(GotoStmt::class)
         subclass(IfStmt::class)
@@ -84,10 +89,7 @@ private val modules = SerializersModule {
         subclass(ReadPreviousEqualStmt::class)
         subclass(ReadStmt::class)
         subclass(ResetStmt::class)
-        subclass(ExfmtStmt::class)
-        subclass(ReadcStmt::class)
         subclass(ReturnStmt::class)
-        subclass(UnlockStmt::class)
         subclass(ScanStmt::class)
         subclass(SelectStmt::class)
         subclass(CaseStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -60,6 +60,7 @@ private val modules = SerializersModule {
         subclass(DOWxxStmt::class)
         subclass(EvalStmt::class)
         subclass(ExecuteSubroutine::class)
+        subclass(FeodStmt::class)
         subclass(ForStmt::class)
         subclass(GotoStmt::class)
         subclass(IfStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -39,12 +39,6 @@ private val modules = SerializersModule {
         subclass(FieldDefinition::class)
         subclass(DataDefinition::class)
     }
-    polymorphic(MockStatement::class) {
-        subclass(ExfmtStmt::class)
-        subclass(ReadcStmt::class)
-        subclass(UnlockStmt::class)
-        subclass(FeodStmt::class)
-    }
     polymorphic(Statement::class) {
         subclass(AddStmt::class)
         subclass(CabStmt::class)
@@ -66,6 +60,8 @@ private val modules = SerializersModule {
         subclass(DOWxxStmt::class)
         subclass(EvalStmt::class)
         subclass(ExecuteSubroutine::class)
+        subclass(ExfmtStmt::class)
+        subclass(FeodStmt::class)
         subclass(ForStmt::class)
         subclass(GotoStmt::class)
         subclass(IfStmt::class)
@@ -84,6 +80,7 @@ private val modules = SerializersModule {
         subclass(OccurStmt::class)
         subclass(OpenStmt::class)
         subclass(PlistStmt::class)
+        subclass(ReadcStmt::class)
         subclass(ReadEqualStmt::class)
         subclass(ReadPreviousStmt::class)
         subclass(ReadPreviousEqualStmt::class)
@@ -102,6 +99,7 @@ private val modules = SerializersModule {
         subclass(SubstStmt::class)
         subclass(TagStmt::class)
         subclass(TimeStmt::class)
+        subclass(UnlockStmt::class)
         subclass(UpdateStmt::class)
         subclass(XFootStmt::class)
         subclass(XlateStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -85,6 +85,9 @@ abstract class Statement(
     abstract fun execute(interpreter: InterpreterCore)
 }
 
+/**
+ * For statements with this interface there isn't execution but will be called the callback `onMockStatement`.
+ */
 interface MockStatement
 
 interface CompositeStatement {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -2081,7 +2081,7 @@ data class UnlockStmt(
 
 @Serializable
 data class FeodStmt(
-        override val position: Position? = null
+    override val position: Position? = null
 ) : Statement(position) {
     override fun execute(interpreter: InterpreterCore) {
         // TODO

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -85,10 +85,7 @@ abstract class Statement(
     abstract fun execute(interpreter: InterpreterCore)
 }
 
-@Serializable
-abstract class MockStatement (
-    @Transient override val position: Position? = null,
-) : Statement(position) { }
+interface MockStatement
 
 interface CompositeStatement {
     val body: List<Statement>
@@ -2060,27 +2057,27 @@ data class ResetStmt(
 @Serializable
 data class ExfmtStmt(
     override val position: Position? = null
-) : MockStatement(position) {
+) : Statement(position), MockStatement {
     override fun execute(interpreter: InterpreterCore) { }
 }
 
 @Serializable
 data class ReadcStmt(
     override val position: Position? = null
-) : MockStatement(position) {
+) : Statement(position), MockStatement {
     override fun execute(interpreter: InterpreterCore) { }
 }
 
 @Serializable
 data class UnlockStmt(
     override val position: Position? = null
-) : MockStatement(position) {
+) : Statement(position), MockStatement {
     override fun execute(interpreter: InterpreterCore) { }
 }
 
 @Serializable
 data class FeodStmt(
     override val position: Position? = null
-) : MockStatement(position) {
+) : Statement(position), MockStatement {
     override fun execute(interpreter: InterpreterCore) { }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -85,6 +85,11 @@ abstract class Statement(
     abstract fun execute(interpreter: InterpreterCore)
 }
 
+@Serializable
+abstract class MockStatement (
+    @Transient override val position: Position? = null,
+) : Statement(position) { }
+
 interface CompositeStatement {
     val body: List<Statement>
 }
@@ -2055,35 +2060,27 @@ data class ResetStmt(
 @Serializable
 data class ExfmtStmt(
     override val position: Position? = null
-) : Statement(position) {
-    override fun execute(interpreter: InterpreterCore) {
-        // TODO
-    }
+) : MockStatement(position) {
+    override fun execute(interpreter: InterpreterCore) { }
 }
 
 @Serializable
 data class ReadcStmt(
     override val position: Position? = null
-) : Statement(position) {
-    override fun execute(interpreter: InterpreterCore) {
-        // TODO
-    }
+) : MockStatement(position) {
+    override fun execute(interpreter: InterpreterCore) { }
 }
 
 @Serializable
 data class UnlockStmt(
     override val position: Position? = null
-) : Statement(position) {
-    override fun execute(interpreter: InterpreterCore) {
-        // TODO
-    }
+) : MockStatement(position) {
+    override fun execute(interpreter: InterpreterCore) { }
 }
 
 @Serializable
 data class FeodStmt(
     override val position: Position? = null
-) : Statement(position) {
-    override fun execute(interpreter: InterpreterCore) {
-        // TODO
-    }
+) : MockStatement(position) {
+    override fun execute(interpreter: InterpreterCore) { }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -2078,3 +2078,12 @@ data class UnlockStmt(
         // TODO
     }
 }
+
+@Serializable
+data class FeodStmt(
+        override val position: Position? = null
+) : Statement(position) {
+    override fun execute(interpreter: InterpreterCore) {
+        // TODO
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1983,25 +1983,25 @@ internal fun CsRESETContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 }
 
 // TODO
-internal fun CsEXFMTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+internal fun CsEXFMTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MockStatement {
     val position = toPosition(conf.considerPosition)
     return ExfmtStmt(position)
 }
 
 // TODO
-internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MockStatement {
     val position = toPosition(conf.considerPosition)
     return ReadcStmt(position)
 }
 
 // TODO
-internal fun CsUNLOCKContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+internal fun CsUNLOCKContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MockStatement {
     val position = toPosition(conf.considerPosition)
     return UnlockStmt(position)
 }
 
 // TODO
-internal fun CsFEODContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+internal fun CsFEODContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MockStatement {
     val position = toPosition(conf.considerPosition)
     return FeodStmt(position)
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1983,25 +1983,25 @@ internal fun CsRESETContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 }
 
 // TODO
-internal fun CsEXFMTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MockStatement {
+internal fun CsEXFMTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
     return ExfmtStmt(position)
 }
 
 // TODO
-internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MockStatement {
+internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
     return ReadcStmt(position)
 }
 
 // TODO
-internal fun CsUNLOCKContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MockStatement {
+internal fun CsUNLOCKContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
     return UnlockStmt(position)
 }
 
 // TODO
-internal fun CsFEODContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): MockStatement {
+internal fun CsFEODContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
     return FeodStmt(position)
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -921,6 +921,9 @@ internal fun Cspec_fixed_standardContext.toAst(conf: ToAstConfiguration = ToAstC
         this.csUNLOCK() != null -> this.csUNLOCK()
             .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
 
+        this.csFEOD() != null -> this.csFEOD()
+            .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
+
         else -> todo(conf = conf)
     }
 }
@@ -1995,6 +1998,12 @@ internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 internal fun CsUNLOCKContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
     return UnlockStmt(position)
+}
+
+// TODO
+internal fun CsFEODContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+    val position = toPosition(conf.considerPosition)
+    return FeodStmt(position)
 }
 
 /**

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT52FileAccess2Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT52FileAccess2Test.kt
@@ -1,3 +1,16 @@
 package com.smeup.rpgparser.smeup
 
-open class MULANGT52FileAccess2Test : MULANGTTest()
+import org.junit.Test
+import kotlin.test.assertEquals
+
+open class MULANGT52FileAccess2Test : MULANGTTest() {
+    /**
+     * Mock FEOD operation code
+     * @see #262
+     */
+    @Test
+    fun executeT52_A07_P02() {
+        val expected = listOf("")
+        assertEquals(expected, "smeup/T52_A07_P02".outputOf())
+    }
+}

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T52_A07_P02.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T52_A07_P02.rpgle
@@ -1,0 +1,2 @@
+     C                   FEOD      MULANGTL
+     C     ''            DSPLY


### PR DESCRIPTION
## Description
Firstly, for this task was created an interface for those operators mocked, with a refactoring of previous implementation. Then, created the `FeodStmt` so that Jariko no longer crashes.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
