### PR TITLE
Feature/inth bif

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
@@ -72,6 +72,7 @@ interface Evaluator {
     fun eval(expression: AbsExpr): Value
     fun eval(expression: EditwExpr): Value
     fun eval(expression: IntExpr): Value
+    fun eval(expression: InthExpr): Value
     fun eval(expression: RemExpr): Value
     fun eval(expression: QualifiedAccessExpr): Value
     fun eval(expression: ReplaceExpr): Value

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -30,6 +30,7 @@ import java.math.RoundingMode
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import kotlin.math.abs
+import kotlin.math.roundToLong
 import kotlin.math.sqrt
 
 class ExpressionEvaluation(
@@ -647,6 +648,17 @@ class ExpressionEvaluation(
             is UnlimitedStringValue ->
                 IntValue(cleanNumericString(value.value).asLong())
             else -> throw UnsupportedOperationException("I do not know how to handle $value with %INT")
+        }
+
+    override fun eval(expression: InthExpr): Value =
+        when (val value = expression.value.evalWith(this)) {
+            is StringValue ->
+                IntValue(value.value.toDouble().roundToLong())
+            is DecimalValue ->
+                IntValue(value.value.toDouble().roundToLong())
+            is UnlimitedStringValue ->
+                IntValue(value.value.toDouble().roundToLong())
+            else -> throw UnsupportedOperationException("I do not know how to handle $value with %INTH")
         }
 
     override fun eval(expression: RemExpr): Value {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -201,6 +201,17 @@ data class IntExpr(
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
 
+// %INTH
+@Serializable
+data class InthExpr(
+    var value: Expression,
+    override val position: Position? = null
+) :
+    Expression(position) {
+    override fun render(): String = this.value.render()
+    override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
+}
+
 // %SQRT
 @Serializable
 data class SqrtExpr(var value: Expression, override val position: Position? = null) :

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -133,6 +133,7 @@ private val modules = SerializersModule {
         subclass(GreaterThanExpr::class)
         subclass(HiValExpr::class)
         subclass(IntExpr::class)
+        subclass(InthExpr::class)
         subclass(IntLiteral::class)
         subclass(LenExpr::class)
         subclass(LessEqualThanExpr::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/bif.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/bif.kt
@@ -48,6 +48,7 @@ internal fun RpgParser.BifContext.toAst(conf: ToAstConfiguration = ToAstConfigur
         this.bif_equal() != null -> this.bif_equal().toAst(conf)
         this.bif_abs() != null -> this.bif_abs().toAst(conf)
         this.bif_int() != null -> this.bif_int().toAst(conf)
+        this.bif_inth() != null -> this.bif_inth().toAst(conf)
         this.bif_editw() != null -> this.bif_editw().toAst(conf)
         this.bif_rem() != null -> this.bif_rem().toAst(conf)
         this.bif_replace() != null -> this.bif_replace().toAst(conf)
@@ -129,6 +130,12 @@ internal fun RpgParser.Bif_decContext.toAst(conf: ToAstConfiguration = ToAstConf
 
 internal fun RpgParser.Bif_intContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): IntExpr {
     return IntExpr(
+        this.expression().toAst(conf),
+        toPosition(conf.considerPosition))
+}
+
+internal fun RpgParser.Bif_inthContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): InthExpr {
+    return InthExpr(
         this.expression().toAst(conf),
         toPosition(conf.considerPosition))
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
@@ -1,3 +1,46 @@
 package com.smeup.rpgparser.smeup
 
-open class MULANGT15BaseBif1Test : MULANGTTest()
+import org.junit.Test
+import kotlin.test.assertEquals
+
+open class MULANGT15BaseBif1Test : MULANGTTest() {
+    /**
+     * %INTH with half adjustment
+     * @see #260
+     */
+    @Test
+    fun executeT15_A30_P03() {
+        val expected = listOf("12346")
+        assertEquals(expected, "smeup/T15_A30_P03".outputOf())
+    }
+
+    /**
+     * %INTH with half adjustment (100.000 times)
+     * @see #260
+     */
+    @Test
+    fun executeT15_A30_P05() {
+        val expected = listOf("12346")
+        assertEquals(expected, "smeup/T15_A30_P05".outputOf())
+    }
+
+    /**
+     * %INTH with seconds half adjustment
+     * @see #258
+     */
+    @Test
+    fun executeT15_A30_P06() {
+        val expected = listOf("219120.00000")
+        assertEquals(expected, "smeup/T15_A30_P06".outputOf())
+    }
+
+    /**
+     * %INTH with pre-half adjustment
+     * @see #259
+     */
+    @Test
+    fun executeT15_A30_P07() {
+        val expected = listOf("Min(219120.00000) Cen(219132.00000)")
+        assertEquals(expected, "smeup/T15_A30_P07".outputOf())
+    }
+}

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A30_P03.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A30_P03.rpgle
@@ -1,0 +1,18 @@
+     D £DBG_Str        S            150          VARYING
+     D A30_SEC         S             15  5
+     D A30_N70         S             30  0
+     D A30_A08         S              8    INZ('12345.67')
+
+     C                   EXSR      SUB_A30_B
+     C                   EVAL      £DBG_Str=%CHAR(A30_N70)
+
+     C     £DBG_Str      DSPLY
+
+      *---------------------------------------------------------------------
+    RD* Subsezione di SEZ_A30 P03 e P05
+      *---------------------------------------------------------------------
+     C     SUB_A30_B     BEGSR
+      *
+     C                   EVAL      A30_N70=%INTH(A30_A08)
+      *
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A30_P05.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A30_P05.rpgle
@@ -1,0 +1,21 @@
+     D £DBG_Str        S            150          VARYING
+     D A30_SEC         S             15  5
+     D NNN             S              6  0 INZ(100000)
+     D A30_N70         S             30  0
+     D A30_A08         S              8    INZ('12345.67')
+
+     C                   DO        NNN
+     C                   EXSR      SUB_A30_B
+     C                   ENDDO
+     C                   EVAL      £DBG_Str=%CHAR(A30_N70)
+
+     C     £DBG_Str      DSPLY
+
+      *---------------------------------------------------------------------
+    RD* Subsezione di SEZ_A30 P03 e P05
+      *---------------------------------------------------------------------
+     C     SUB_A30_B     BEGSR
+      *
+     C                   EVAL      A30_N70=%INTH(A30_A08)
+      *
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A30_P06.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A30_P06.rpgle
@@ -1,0 +1,8 @@
+     D £DBG_Str        S            150          VARYING
+     D A30_SEC         S             15  5
+
+     C                   EVAL      A30_SEC=219120.38
+     C                   EVAL      A30_SEC=%INTH(A30_SEC)
+     C                   EVAL      £DBG_Str=%CHAR(A30_SEC)
+
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A30_P07.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A30_P07.rpgle
@@ -1,0 +1,13 @@
+     D £DBG_Str        S            150          VARYING
+     D A30_SEC         S             15  5
+
+     C                   EVAL      A30_SEC=219120.38
+     C                   EVAL      A30_SEC=%INTH(A30_SEC/60)*60
+     C                   EVAL      £DBG_Str='Min('+%CHAR(A30_SEC)+') '
+      * Arrotondamento ai centesimi
+     C                   EVAL      A30_SEC=219120.38
+     C                   EVAL      A30_SEC=%INTH(A30_SEC/36)*36
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                     +' Cen('+%CHAR(A30_SEC)+') '
+
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Implement missing `%INTH` bif.

Related to:
- T15_A30_P03
- T15_A30_P05
- T15_A30_P06
- T15_A30_P07

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
