### PR TITLE
Bugfix/nw23001440/263 problem parsing end

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -317,9 +317,14 @@ elseClause:
 ;
 
 casestatement:
-	csCASxx*
-	csCASother?
-	casestatementend
+    (
+        csCASxx+
+        csCASother?
+        casestatementend
+    ) | (
+        csCASother
+        casestatementend
+    )
 ;
 
 csCASxx:

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
@@ -13,4 +13,14 @@ open class MULANGT12LoopFlowGotoTest : MULANGTTest() {
         val expected = listOf("A04_N50_CNT(10) A04_STR(1) A04_END(10) A04_CNT(11)")
         assertEquals(expected, "smeup/T12_A04_P18".outputOf())
     }
+
+    /**
+     * If followed by Do
+     * @see #264
+     */
+    @Test
+    fun executeT12_A04_P19() {
+        val expected = listOf("DO_1(A04_N50_CNT(10) A04_STR(1) A04_END(10) A04_CNT(11)) DO_2(A04_N50_CNT(15) A04_CNT(16))")
+        assertEquals(expected, "smeup/T12_A04_P19".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 open class MULANGT12LoopFlowGotoTest : MULANGTTest() {
     /**
-     * DO- Operation not implemented
+     * If followed by Do
      * @see #263
      */
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
@@ -1,6 +1,5 @@
 package com.smeup.rpgparser.smeup
 
-import com.smeup.rpgparser.assertCanBeParsed
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -11,7 +10,6 @@ open class MULANGT12LoopFlowGotoTest : MULANGTTest() {
      */
     @Test
     fun executeT12_A04_P18() {
-//        assertCanBeParsed("smeup/T12_A04_P18", printTree = true)
         val expected = listOf("A04_N50_CNT(10) A04_STR(1) A04_END(10) A04_CNT(11)")
         assertEquals(expected, "smeup/T12_A04_P18".outputOf())
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
@@ -1,3 +1,18 @@
 package com.smeup.rpgparser.smeup
 
-open class MULANGT12LoopFlowGotoTest : MULANGTTest()
+import com.smeup.rpgparser.assertCanBeParsed
+import org.junit.Test
+import kotlin.test.assertEquals
+
+open class MULANGT12LoopFlowGotoTest : MULANGTTest() {
+    /**
+     * DO- Operation not implemented
+     * @see #263
+     */
+    @Test
+    fun executeT12_A04_P18() {
+//        assertCanBeParsed("smeup/T12_A04_P18", printTree = true)
+        val expected = listOf("A04_N50_CNT(10) A04_STR(1) A04_END(10) A04_CNT(11)")
+        assertEquals(expected, "smeup/T12_A04_P18".outputOf())
+    }
+}

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P18.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P18.rpgle
@@ -1,0 +1,21 @@
+     D A04_N50_LIM     S              6  0 INZ(100000)
+     D A04_N50_CNT     S                   LIKE(A04_N50_LIM)
+     D A04_STR         S              2  0
+     D A04_CNT         S              2  0
+     D A04_END         S              2  0
+     D £DBG_Str        S            100          VARYING
+
+     C                   EVAL      A04_STR = 2
+     C                   EVAL      A04_END = 10
+     C     A04_STR       IFGT      1                                            -commento
+     C                   EVAL      A04_STR = 1
+     C                   END
+     C     A04_STR       DO        A04_END       A04_CNT                        -commento
+     C                   EVAL      A04_N50_CNT = A04_CNT
+     C                   END
+     C                   EVAL      £DBG_Str=
+     C                                 'A04_N50_CNT('+%CHAR(A04_N50_CNT)+') '
+     C                                +'A04_STR('+%CHAR(A04_STR)+') '
+     C                                +'A04_END('+%CHAR(A04_END)+') '
+     C                                +'A04_CNT('+%CHAR(A04_CNT)+') '
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P19.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A04_P19.rpgle
@@ -1,0 +1,25 @@
+     D A04_N50_LIM     S              6  0 INZ(100000)
+     D A04_N50_CNT     S                   LIKE(A04_N50_LIM)
+     D A04_STR         S              2  0
+     D A04_CNT         S              2  0
+     D A04_END         S              2  0
+     D £DBG_Str        S            100          VARYING
+
+     C                   EVAL      A04_STR = 1
+     C                   EVAL      A04_END = 10
+     C     A04_STR       DO        A04_END       A04_CNT                        -commento
+     C                   EVAL      A04_N50_CNT = A04_CNT
+     C                   END
+     C                   EVAL      £DBG_Str='DO_1('
+     C                                +'A04_N50_CNT('+%CHAR(A04_N50_CNT)+') '
+     C                                +'A04_STR('+%CHAR(A04_STR)+') '
+     C                                +'A04_END('+%CHAR(A04_END)+') '
+     C                                +'A04_CNT('+%CHAR(A04_CNT)+')) '
+      *
+     C                   DO        15            A04_CNT
+     C                   EVAL      A04_N50_CNT = A04_CNT
+     C                   END
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)+' DO_2('
+     C                                +'A04_N50_CNT('+%CHAR(A04_N50_CNT)+') '
+     C                                +'A04_CNT('+%CHAR(A04_CNT)+'))'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description
With Domenico, while we were analyzing the parse tree of `T12_A04_P18`, we saw an incorrect definition of `csEND` under  `casestatementend`, and not under `ifend`:
```
<statement>
  <block>
    <casestatement>
      <casestatementend>
        C
        <cs_controlLevel/>
        <onOffIndicatorsFlag/>
        <cs_indicators/>
        <factor/>
        <csEND>
          END
          <cspec_fixed_standard_parts>
            <factor/>
            <resultType/>
            <resultIndicator/>
            <resultIndicator/>
            <resultIndicator/>
          </cspec_fixed_standard_parts>
        </csEND>
      </casestatementend>
    </casestatement>
  </block>
</statement>
```
Considering the **T12_A04_P18** test, there is not any `CAS` or `CASxx` statement. So, the problem was inside `RpgParser.g4`.
The previous implementation of `casestatement` was:
```
casestatementend:
    csCASxx*
    csCASother?
    casestatementend
```
Was assumed that could be:
 - _0_ or _n_ `CASxx`
 - _0_ or _1_ `CAS`
 - _1_ CASEND

Isn't not true! We could have:
 - _1_ or _n_ `CASxx` with _0_ or _1_ `CAS`
 - _0_ `CASxx` but _1_ `CAS`
 - 1 CASEND
So, I decided to change the implementation of `casestatementend` like this:
```
casestatement:
    (
        csCASxx+
        csCASother?
        casestatementend
    ) | (
        csCASother
        casestatementend
    )
;
```

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
