### PR TITLE
Bugfix/nw23001440/261 percent len near eval

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -2659,6 +2659,7 @@ target:
     | base=target OPEN_PAREN index=expression CLOSE_PAREN #indexedTarget
     | bif_subst #substTarget
     | bif_subarr #subarrTarget
+    | bif_len #lenTarget
     | container=idOrKeyword DOT fieldName=idOrKeyword #qualifiedTarget
     | indic=SPLAT_INDICATOR #indicatorTarget
     | base=SPLAT_IN OPEN_PAREN index=expression CLOSE_PAREN #indexedIndicatorTarget

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -183,7 +183,7 @@ data class FileDefinition private constructor(
 @Serializable
 data class DataDefinition(
     override val name: String,
-    @SerialName(value = "dataDefType") override val type: Type,
+    @SerialName(value = "dataDefType") override var type: Type,
     var fields: List<FieldDefinition> = emptyList(),
     val initializationValue: Expression? = null,
     val inz: Boolean = false,
@@ -202,7 +202,7 @@ data class DataDefinition(
         static = static) {
 
     override fun isArray() = type is ArrayType
-    fun isCompileTimeArray() = type is ArrayType && type.compileTimeArray()
+    fun isCompileTimeArray() = type is ArrayType && (type as ArrayType).compileTimeArray()
 
     init {
         this.require(name.trim().isNotEmpty(), { "name cannot be empty" })

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -29,6 +29,7 @@ import com.smeup.rpgparser.parsing.facade.relative
 import com.smeup.rpgparser.parsing.parsetreetoast.MuteAnnotationExecutionLogEntry
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
 import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
+import com.smeup.rpgparser.parsing.parsetreetoast.todo
 import com.smeup.rpgparser.utils.ComparisonOperator.*
 import com.smeup.rpgparser.utils.chunkAs
 import com.smeup.rpgparser.utils.resizeTo
@@ -830,7 +831,7 @@ open class InternalInterpreter(
 
                 when {
                     dataDefinition.type is StringType -> dataDefinition.resizeStringSize(value.asInt().value.toInt())
-                    else -> TODO("Implements redefinition of ${dataDefinition.type.javaClass.name}")
+                    else -> target.todo("Implements redefinition of ${dataDefinition.type.javaClass.name}")
                 }
                 return value
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -824,6 +824,16 @@ open class InternalInterpreter(
                 }
                 return assign(target.array as AssignableExpression, array)
             }
+            is LenExpr -> {
+                require((target.value as? DataRefExpr)?.variable?.referred is DataDefinition)
+                val dataDefinition: DataDefinition = (target.value as DataRefExpr).variable.referred!! as DataDefinition
+
+                when {
+                    dataDefinition.type is StringType -> dataDefinition.resizeStringSize(value.asInt().value.toInt())
+                    else -> TODO("Implements redefinition of ${dataDefinition.type.javaClass.name}")
+                }
+                return value;
+            }
             is QualifiedAccessExpr -> {
                 when (val container = eval(target.container)) {
                     is DataStructValue -> {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -832,7 +832,7 @@ open class InternalInterpreter(
                     dataDefinition.type is StringType -> dataDefinition.resizeStringSize(value.asInt().value.toInt())
                     else -> TODO("Implements redefinition of ${dataDefinition.type.javaClass.name}")
                 }
-                return value;
+                return value
             }
             is QualifiedAccessExpr -> {
                 when (val container = eval(target.container)) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
@@ -66,7 +66,7 @@ fun ActivationGroupType.assignedName(current: RpgProgram, caller: RpgProgram?): 
     }
 }
 
-fun DataDefinition.resizeStringSize(newSize: Int): Unit {
+fun DataDefinition.resizeStringSize(newSize: Int) {
     require(this.initializationValue is StringLiteral)
     require(this.defaultValue is StringValue)
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
@@ -66,7 +66,13 @@ fun ActivationGroupType.assignedName(current: RpgProgram, caller: RpgProgram?): 
     }
 }
 
-fun DataDefinition.resizeStringSize(newSize: Int) {
+/**
+ * This function provides the resizing of a variable defined like String.
+ * For example: `%LEN(<variable's name>) in `EVAL` like this
+ *     C                   EVAL      %LEN(VAR) = 5
+ * changes the previous size declaration of `VAR` to a new size.
+ */
+internal fun DataDefinition.resizeStringSize(newSize: Int) {
     require(this.initializationValue is StringLiteral)
     require(this.defaultValue is StringValue)
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
@@ -67,8 +67,11 @@ fun ActivationGroupType.assignedName(current: RpgProgram, caller: RpgProgram?): 
 }
 
 /**
- * This function provides the resizing of a variable defined like String.
- * For example: `%LEN(<variable's name>) in `EVAL` like this
+ * This function provides the resizing of a variable defined like String, changing the varying to not varying.
+ * In addition, truncates the previous string if the target size is shorter, or add spaces if is longer.
+ * Throws an `IllegalArgumentException` if the `initializationValue` isn't `StringLiteral` or `defaultValue` isn't `StringValue`.
+ *
+ * For example: `%LEN(<variable's name>) in `EVAL` like this:
  *     C                   EVAL      %LEN(VAR) = 5
  * changes the previous size declaration of `VAR` to a new size.
  */
@@ -78,7 +81,7 @@ internal fun DataDefinition.resizeStringSize(newSize: Int) {
 
     val initializationValue: StringLiteral = this.initializationValue
     val defaultValue: StringValue = this.defaultValue as StringValue
-    this.type = StringType(newSize, true)
+    this.type = StringType(newSize, false)
     if (initializationValue.value.length >= newSize) {
         initializationValue.value = initializationValue.value.substring(0, newSize)
         defaultValue.value = defaultValue.value.substring(0, newSize)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
@@ -65,3 +65,20 @@ fun ActivationGroupType.assignedName(current: RpgProgram, caller: RpgProgram?): 
         else -> error("$this ActivationGroupType is not yet handled")
     }
 }
+
+fun DataDefinition.resizeStringSize(newSize: Int): Unit {
+    require(this.initializationValue is StringLiteral)
+    require(this.defaultValue is StringValue)
+
+    val initializationValue: StringLiteral = this.initializationValue
+    val defaultValue: StringValue = this.defaultValue as StringValue
+    this.type = StringType(newSize, true)
+    if (initializationValue.value.length >= newSize) {
+        initializationValue.value = initializationValue.value.substring(0, newSize)
+        defaultValue.value = defaultValue.value.substring(0, newSize)
+    } else {
+        initializationValue.value = initializationValue.value.padEnd(newSize)
+        defaultValue.value = defaultValue.value.padEnd(newSize)
+    }
+    defaultValue.varying = false
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -75,7 +75,7 @@ interface AbstractStringValue : Value {
 }
 
 @Serializable
-data class StringValue(var value: String, val varying: Boolean = false) : AbstractStringValue {
+data class StringValue(var value: String, var varying: Boolean = false) : AbstractStringValue {
 
     override fun assignableTo(expectedType: Type): Boolean {
         return when (expectedType) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -159,10 +159,16 @@ data class SubarrExpr(
 // %LEN
 @Serializable
 data class LenExpr(var value: Expression, override val position: Position? = null) :
-    Expression(position) {
+    AssignableExpression(position) {
+
     override fun render(): String {
         return "%LEN(${this.value.render()})"
     }
+
+    override fun size(): Int {
+        TODO("Not yet implemented")
+    }
+
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
@@ -58,7 +58,7 @@ data class RealLiteral(
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
 @Serializable
-data class StringLiteral(val value: String, override val position: Position? = null) : Expression(position) {
+data class StringLiteral(var value: String, override val position: Position? = null) : Expression(position) {
     override fun render() = "\"$value\""
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -134,7 +134,6 @@ private val modules = SerializersModule {
         subclass(HiValExpr::class)
         subclass(IntExpr::class)
         subclass(IntLiteral::class)
-        subclass(LenExpr::class)
         subclass(LessEqualThanExpr::class)
         subclass(LessThanExpr::class)
         subclass(LogicalAndExpr::class)
@@ -178,6 +177,7 @@ private val modules = SerializersModule {
         subclass(QualifiedAccessExpr::class)
         subclass(SubstExpr::class)
         subclass(SubarrExpr::class)
+        subclass(LenExpr::class)
     }
     polymorphic(Directive::class) {
         subclass(ActivationGroupDirective::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -134,6 +134,7 @@ private val modules = SerializersModule {
         subclass(HiValExpr::class)
         subclass(IntExpr::class)
         subclass(IntLiteral::class)
+        subclass(LenExpr::class)
         subclass(LessEqualThanExpr::class)
         subclass(LessThanExpr::class)
         subclass(LogicalAndExpr::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1673,6 +1673,7 @@ internal fun TargetContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
         )
         is SubstTargetContext -> this.bif_subst().toAst(conf)
         is SubarrTargetContext -> this.bif_subarr().toAst(conf)
+        is LenTargetContext -> this.bif_len().toAst(conf)
         is QualifiedTargetContext -> QualifiedAccessExpr(
             DataRefExpr(ReferenceByName(this.container.text), this.container!!.toPosition(conf.considerPosition)),
             ReferenceByName(this.getFieldName()),

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
@@ -1,3 +1,16 @@
 package com.smeup.rpgparser.smeup
 
-open class MULANGT15BaseBif1Test : MULANGTTest()
+import org.junit.Test
+import kotlin.test.assertEquals
+
+open class MULANGT15BaseBif1Test : MULANGTTest() {
+    /**
+     * %LEN near EVAL
+     * @see #261
+     */
+    @Test
+    fun executeT02_A50_P10() {
+        val expected = listOf("1(10 - North York) 2(5 - North) 3(15 - North          )")
+        assertEquals(expected, "smeup/T15_A80_P09".outputOf())
+    }
+}

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
@@ -9,7 +9,7 @@ open class MULANGT15BaseBif1Test : MULANGTTest() {
      * @see #261
      */
     @Test
-    fun executeT02_A50_P10() {
+    fun executeT15_A80_P09() {
         val expected = listOf("1(10 - North York) 2(5 - North) 3(15 - North          )")
         assertEquals(expected, "smeup/T15_A80_P09".outputOf())
     }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A80_P09.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T15_A80_P09.rpgle
@@ -1,0 +1,18 @@
+     D A80_V           S             40    VARYING INZ('North York')
+     D A80_N           S              5  0
+     D £DBG_Str        S            100           VARYING
+
+      * Recupero lunghezza attuale
+     C                   EVAL      A80_N = %LEN(A80_V)
+     C                   EVAL      £DBG_Str='1('+%CHAR(A80_N)+' - '+A80_V+')'
+      * Setto lunghezza a 5
+     C                   EVAL      %LEN(A80_V) = 5
+     C                   EVAL      A80_N= %LEN(A80_V)
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                     +' 2('+%CHAR(A80_N)+' - '+A80_V+')'
+      * Setto lunghezza a 15
+     C                   EVAL      %LEN(A80_V) = 15
+     C                   EVAL      A80_N= %LEN(A80_V)
+     C                   EVAL      £DBG_Str=%TRIMR(£DBG_Str)
+     C                                     +' 3('+%CHAR(A80_N)+' - '+A80_V+')'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description
In accord to [official documentation](https://www.ibm.com/docs/en/i/7.5?topic=functions-len-get-set-length), with `%LEN` is possible to set a size of a data definition, too; this means that is executed at runtime. 
This requires some change of implementation, by changing access of certain attributes, of several classes, from `val` to `var`. Also the `RpaParser.g4` was changed by adding `bif_len` as target. Then, has been implemented the logic of set with `%LEN`.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
