### PR TITLE
Bugfix/tkic321249/stackoverflow

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1134,8 +1134,7 @@ data class DefineStmt(
                     .asSequence()
                     .map(StatementThatCanDefineData::dataDefinition)
                     .flatten()
-                    .find { it.name.uppercase() == originalName.uppercase() } ?: throw this.error("Data reference $originalName not found")
-
+                    .find { it.name.uppercase() == originalName.uppercase() } ?: throw Error("Data reference $originalName not found")
             return listOf(InStatementDataDefinition(newVarName, inStatementDataDefinition.type, position))
         }
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -424,6 +424,11 @@ class JarikoCallbackTest : AbstractTest() {
         })
     }
 
+    @Test
+    fun executeERROR13CallBackTest() {
+        executePgmCallBackTest("ERROR13", SourceReferenceType.Program, "ERROR13", listOf(9, 10))
+    }
+
     /**
      * This test simulates what a precompiler might do throws the use of the beforeParsing callback
      * In ERROR01.rpgle I will comment C specification to avoid a division by zero errors

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -416,6 +416,7 @@ class JarikoCallbackTest : AbstractTest() {
     @Test
     fun executeERROR13ShouldNotThrowStackOverflowError() {
         executeSourceLineTest(pgm = "ERROR13", throwableConsumer = {
+            it.printStackTrace()
             assertTrue(
                 message = "java.lang.StackOverflowError should not be present",
                 actual = it.message!!.indexOf("java.lang.StackOverflowError") == -1

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -25,6 +25,7 @@ import com.smeup.rpgparser.parsing.facade.SourceReference
 import com.smeup.rpgparser.parsing.facade.SourceReferenceType
 import org.junit.Assert
 import java.io.StringReader
+import kotlin.test.DefaultAsserter.assertTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -412,6 +413,16 @@ class JarikoCallbackTest : AbstractTest() {
         executePgmCallBackTest("ERROR12", SourceReferenceType.Program, "ERROR12", listOf(7))
     }
 
+    @Test
+    fun executeERROR13ShouldNotThrowStackOverflowError() {
+        executeSourceLineTest(pgm = "ERROR13", throwableConsumer = {
+            assertTrue(
+                message = "java.lang.StackOverflowError should not be present",
+                actual = it.message!!.indexOf("java.lang.StackOverflowError") == -1
+            )
+        })
+    }
+
     /**
      * This test simulates what a precompiler might do throws the use of the beforeParsing callback
      * In ERROR01.rpgle I will comment C specification to avoid a division by zero errors
@@ -517,7 +528,7 @@ class JarikoCallbackTest : AbstractTest() {
      * Verify that the sourceLine is properly set in case of error.
      * ErrorEvent must contain a reference of an absolute line of the source code
      * */
-    private fun executeSourceLineTest(pgm: String) {
+    private fun executeSourceLineTest(pgm: String, throwableConsumer: (Throwable) -> Unit = {}) {
         lateinit var lines: List<String>
         val errorEvents = mutableListOf<ErrorEvent>()
         val configuration = Configuration().apply {
@@ -535,6 +546,7 @@ class JarikoCallbackTest : AbstractTest() {
         }.onSuccess {
             Assert.fail("$pgm must exit with error")
         }.onFailure {
+            throwableConsumer(it)
             errorEvents.forEach {
                 Assert.assertEquals(lines[it.absoluteLine!! - 1], it.fragment)
             }

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR13.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR13.rpgle
@@ -5,7 +5,7 @@
       *
       * The stackoverflowexception is thrown when I have more than 1
       * DEFINE statement related to not found D specs.
-      * In this case KTPOR and KCDOR are not found.
+      * In this case S5TPOR and S5CDOR are not found as D specs.
      C     *LIKE         DEFINE    S5TPOR        KTPOR
      C     *LIKE         DEFINE    S5CDOR        KCDOR
 

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR13.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR13.rpgle
@@ -1,30 +1,13 @@
      V* ==============================================================
      D* Stackoverflowexception evaluation
      D*
-     V* ==============================================================     
-     FC5RREG0L  IP   E             DISK
-     FC5RATE1L  UF   E           K DISK
-      *--------------------------------------------------------------*
-  L >D £U13MB          S             10    INZ('C5UTX02   ')
-  L >D £U13FI          S             10    INZ('C5SRC     ')
-1    C                   IF        R5CAUS='206'
-     C                   MOVE      R5RIGA        XXRIGA            5
-     C                   MOVEL(P)  'E5'          KTPOR
-     C                   EVAL      KCDOR=R5PROG+XXRIGA
-     C     KEYRAT        SETLL     C5RATER
+     V* ==============================================================
       *
-2    C                   DO        *HIVAL
-     C     KEYRAT        READE     C5RATER                                51
-     C   51              LEAVE
-     C                   MOVEL(P)  'I'           S5FL19
-     C                   UPDATE    C5RATER
-2e   C                   ENDDO
-      *
-1e   C                   ENDIF
-      *
-     C     KEYRAT        KLIST
-     C                   KFLD                    KTPOR
-     C                   KFLD                    KCDOR
-      *
+      * The stackoverflowexception is thrown when I have more than 1
+      * DEFINE statement related to not found D specs.
+      * In this case KTPOR and KCDOR are not found.
      C     *LIKE         DEFINE    S5TPOR        KTPOR
      C     *LIKE         DEFINE    S5CDOR        KCDOR
+
+     C     'HI'          DSPLY
+     

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR13.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR13.rpgle
@@ -1,0 +1,30 @@
+     V* ==============================================================
+     D* Stackoverflowexception evaluation
+     D*
+     V* ==============================================================     
+     FC5RREG0L  IP   E             DISK
+     FC5RATE1L  UF   E           K DISK
+      *--------------------------------------------------------------*
+  L >D £U13MB          S             10    INZ('C5UTX02   ')
+  L >D £U13FI          S             10    INZ('C5SRC     ')
+1    C                   IF        R5CAUS='206'
+     C                   MOVE      R5RIGA        XXRIGA            5
+     C                   MOVEL(P)  'E5'          KTPOR
+     C                   EVAL      KCDOR=R5PROG+XXRIGA
+     C     KEYRAT        SETLL     C5RATER
+      *
+2    C                   DO        *HIVAL
+     C     KEYRAT        READE     C5RATER                                51
+     C   51              LEAVE
+     C                   MOVEL(P)  'I'           S5FL19
+     C                   UPDATE    C5RATER
+2e   C                   ENDDO
+      *
+1e   C                   ENDIF
+      *
+     C     KEYRAT        KLIST
+     C                   KFLD                    KTPOR
+     C                   KFLD                    KCDOR
+      *
+     C     *LIKE         DEFINE    S5TPOR        KTPOR
+     C     *LIKE         DEFINE    S5CDOR        KCDOR


### PR DESCRIPTION
## Description

Fixed a stackoverflowerror occured in `*LIKE DEFINE` when it was not possible define more than one field (result) because of missing  of referenced variable in factor 2.

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
