### PR TITLE
Bugfix/nw23001440/160 like defined inline

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -83,4 +83,22 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("1")
         assertEquals(expected, "smeup/T02_A80_P06".outputOf())
     }
+
+    /**
+     * ###################
+     * ATOMIC TEST SECTION.
+     * ###################
+     */
+
+    /**
+     * Definition with Like to a variable defined also with like.
+     * @see #160
+     */
+    @Test
+    fun executeMU025002() {
+        val expected = listOf("A50_A3(       ) A50_A4(       )")
+        assertEquals(expected, "smeup/MU025002".outputOf(configuration = smeupConfig))
+    }
+
+
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -86,7 +86,7 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
 
     /**
      * ###################
-     * ATOMIC TEST SECTION.
+     * ATOMIC TEST SECTION
      * ###################
      */
 
@@ -99,6 +99,4 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("A50_A3(       ) A50_A4(       )")
         assertEquals(expected, "smeup/MU025002".outputOf(configuration = smeupConfig))
     }
-
-
 }

--- a/rpgJavaInterpreter-core/src/test/resources/QILEGEN/MULANG_D_C.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/QILEGEN/MULANG_D_C.rpgle
@@ -1,0 +1,9 @@
+      * This is a dummy and mocked implementation.
+     C     £DBG          BEGSR
+
+     C     *BLANK        IFNE       £DBG_Str
+     C     £DBG_Str      DSPLY
+     C                   EVAL       £DBG_Str = *BLANKS
+     C                   ENDIF
+
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU025002.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU025002.rpgle
@@ -1,0 +1,46 @@
+      *====================================================================
+      * smeup V6R1.021DV
+      * Nome sorgente       : MU025002
+      * Sorgente di origine : QTEMP/SRC(MU025002)
+      * Esportato il        : 20240403 145832
+      *====================================================================
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 25/03/24  MUTEST  GUAGIA Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * DEFINE da variabile dichiarata con DEFINE
+     V* ==============================================================
+     D A50_A1          S              7
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      /COPY QILEGEN,£TABB£1DS
+      /COPY QILEGEN,£PDS
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU025002'
+     C                   EVAL      £DBG_Sez = 'A50'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A50
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico DS
+      *---------------------------------------------------------------------
+     C     SEZ_A50       BEGSR
+    OA* A£.CDOP(DEFINE  )
+     D* DEFINE da variabile dichiarata con DEFINE
+     C                   EVAL      £DBG_Pas='P02'
+     C     *LIKE         DEFINE    A50_A1        A50_A3
+     C     *LIKE         DEFINE    A50_A3        A50_A4
+     C                   EVAL      £DBG_Str= 'A50_A3('+A50_A3+')'
+     C                                     +' A50_A4('+A50_A4+')'
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C


### PR DESCRIPTION
## Description
This work fixes the utilization of `DEFINE` operator when is used into a subroutine. The main problem was the resolution of `InStatementDataDefinition` that happened from main statements and not from the subroutine.
In addition, were added the mocked `.rplge` files used by atomic tests.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
