### PR TITLE
Bugfix/nw24000512/when with complex expression

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -159,7 +159,7 @@ keyword_likerec : KEYWORD_LIKEREC OPEN_PAREN intrecname=simpleExpression
 	(COLON (SPLAT_ALL | SPLAT_INPUT | SPLAT_OUTPUT | SPLAT_KEY))?
 	CLOSE_PAREN; 
 keyword_noopt : KEYWORD_NOOPT;
-keyword_occurs : KEYWORD_OCCURS OPEN_PAREN (numeric_constant=number | function | identifier) CLOSE_PAREN; 
+keyword_occurs : KEYWORD_OCCURS OPEN_PAREN (numeric_constant=number | function | identifier) CLOSE_PAREN;
 keyword_opdesc : KEYWORD_OPDESC;
 keyword_options : KEYWORD_OPTIONS OPEN_PAREN identifier (COLON identifier)* CLOSE_PAREN; 
 keyword_overlay : KEYWORD_OVERLAY OPEN_PAREN name=simpleExpression (COLON (SPLAT_NEXT | pos=simpleExpression))? CLOSE_PAREN; 
@@ -394,10 +394,11 @@ onError:
 	statement*
 ;
 selectstatement:
-	beginselect
-	whenstatement*
+    (beginselect endselect) |
+	(beginselect
+	whenstatement+
 	other?
-	endselect
+	endselect)
 ;
 
 other:
@@ -439,9 +440,10 @@ when:
 	indicators=cs_indicators 
 	factor1=factor 
 	csWHEN
+	andConds=csANDxx*
+    orConds=csORxx*
 	)
 	| (op_when FREE_SEMI free_linecomments? )
-	statement*
 ;
 csWHENxx:
 CS_FIXED
@@ -1755,7 +1757,7 @@ csOperationAndExtendedFactor2:
 	// operation=OP_EVAL
 
 	//|operation=OP_IF
-	|operation=OP_CALLP operationExtender=cs_operationExtender?
+	operation=OP_CALLP operationExtender=cs_operationExtender?
 	//|operation=OP_DOW
 	//|operation=OP_ELSEIF
 	;
@@ -2374,7 +2376,7 @@ bif_code: BIF_ABS
 
 
 free: ((baseExpression FREE_SEMI free_linecomments? ) | exec_sql); // (NEWLINE |COMMENTS_EOL);
-c_free: (((expression) free_linecomments? ) | exec_sql);
+c_free: ((expression free_linecomments? ) | exec_sql);
 
 control: opCode indicator_expr;
 exec_sql: EXEC_SQL WORDS+ SEMI ;

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
@@ -23,4 +23,14 @@ open class MULANGT12LoopFlowGotoTest : MULANGTTest() {
         val expected = listOf("DO_1(A04_N50_CNT(10) A04_STR(1) A04_END(10) A04_CNT(11)) DO_2(A04_N50_CNT(15) A04_CNT(16))")
         assertEquals(expected, "smeup/T12_A04_P19".outputOf())
     }
+
+    /**
+     * SELECT-WHEN with complex boolean expression
+     * @see #236
+     */
+    @Test
+    fun executeT12_A05_P12() {
+        val expected = listOf("PrimoWhen")
+        assertEquals(expected, "smeup/T12_A05_P12".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A05_P12.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/T12_A05_P12.rpgle
@@ -1,0 +1,14 @@
+     D £DBG_Str        S            150          VARYING
+
+     C                   SETOFF                                       1011
+     C                   SETON                                        12
+     C                   SELECT
+     C                   WHEN      *IN12
+     C                   EVAL      £DBG_Str='PrimoWhen'
+     C                   WHEN      (*IN10 AND *IN11)
+     C                             OR *IN12
+     C                   EVAL      £DBG_Str='SecondoWhen'
+     C                   OTHER
+     C                   EVAL      £DBG_Str='Other'
+     C                   ENDSL
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Fix an issue with grammar improperly matching complex WHEN statements as common C specs.

Related to:
- T12_A05_P12

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
