### PR TITLE
Bugfix/nw23001440/269 data reference

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1150,14 +1150,9 @@ data class DefineStmt(
     }
 
     private fun findInGlobalScope(cu: CompilationUnit, search: String): InStatementDataDefinition? {
-        var inStatementDataDefinition = cu.main.stmts.findInStatementDataDefinition(originalName, this)
-        if (inStatementDataDefinition == null) {
-            inStatementDataDefinition = cu.subroutines.firstNotNullOf {
-                it.stmts.findInStatementDataDefinition(search, this)
-            }
+        return cu.main.stmts.findInStatementDataDefinition(originalName, this) ?: cu.subroutines.firstNotNullOf {
+            it.stmts.findInStatementDataDefinition(search, this)
         }
-
-        return inStatementDataDefinition
     }
 
     private fun findInLocalScope(search: String): InStatementDataDefinition? {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1153,7 +1153,7 @@ data class DefineStmt(
  */
 private fun List<Statement>.findInStatementDataDefinition(originalName: String, contextToExclude: DefineStmt): InStatementDataDefinition {
     return this.filterIsInstance<StatementThatCanDefineData>()
-                .filter { it != contextToExclude }
+                .filter { !contextToExclude.getStack().contains(it) }
                 .asSequence()
                 .map(StatementThatCanDefineData::dataDefinition)
                 .flatten()
@@ -1179,6 +1179,12 @@ private fun DefineStmt.exitFromStack(): Boolean {
         mutableSetOf<DefineStmt>()
     } as MutableSet<DefineStmt>
     return stack.remove(this)
+}
+
+private fun DefineStmt.getStack(): List<DefineStmt> {
+    return (MainExecutionContext.getAttributes().computeIfAbsent("DefineStmt.callStack") {
+        mutableSetOf<DefineStmt>()
+    } as MutableSet<DefineStmt>).toList()
 }
 
 interface WithRightIndicators {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1163,6 +1163,37 @@ data class DefineStmt(
     private fun findInLocalScope(search: String): InStatementDataDefinition? {
         return (this.parent as Subroutine).stmts.findInStatementDataDefinition(search, this)
     }
+
+    /**
+     * Get the list of stack. This could be necessary, in example, to avoid recursive calls.
+     * @return List of `DefineStmt` or empty list.
+     */
+    fun getStack(): List<DefineStmt> {
+        return (MainExecutionContext.getAttributes().computeIfAbsent("DefineStmt.callStack") {
+            mutableSetOf<DefineStmt>()
+        } as MutableSet<DefineStmt>).toList()
+    }
+
+    /**
+     * Receiver wants to enter in call stack
+     * @return false if the receiver cannot enter
+     */
+    private fun enterInStack(): Boolean {
+        val stack = MainExecutionContext.getAttributes().computeIfAbsent("DefineStmt.callStack") {
+            mutableSetOf<DefineStmt>()
+        } as MutableSet<DefineStmt>
+        return stack.add(this)
+    }
+
+    /**
+     * Receiver will exit from call stack
+     */
+    private fun exitFromStack(): Boolean {
+        val stack = MainExecutionContext.getAttributes().computeIfAbsent("DefineStmt.callStack") {
+            mutableSetOf<DefineStmt>()
+        } as MutableSet<DefineStmt>
+        return stack.remove(this)
+    }
 }
 
 /**
@@ -1175,33 +1206,6 @@ private fun List<Statement>.findInStatementDataDefinition(originalName: String, 
                 .map(StatementThatCanDefineData::dataDefinition)
                 .flatten()
                 .firstOrNull { it.name == originalName }
-}
-
-/**
- * Receiver wants to enter in call stack
- * @return false if the receiver cannot enter
- */
-private fun DefineStmt.enterInStack(): Boolean {
-    val stack = MainExecutionContext.getAttributes().computeIfAbsent("DefineStmt.callStack") {
-        mutableSetOf<DefineStmt>()
-    } as MutableSet<DefineStmt>
-    return stack.add(this)
-}
-
-/**
- * Receiver will exit from call stack
- * */
-private fun DefineStmt.exitFromStack(): Boolean {
-    val stack = MainExecutionContext.getAttributes().computeIfAbsent("DefineStmt.callStack") {
-        mutableSetOf<DefineStmt>()
-    } as MutableSet<DefineStmt>
-    return stack.remove(this)
-}
-
-private fun DefineStmt.getStack(): List<DefineStmt> {
-    return (MainExecutionContext.getAttributes().computeIfAbsent("DefineStmt.callStack") {
-        mutableSetOf<DefineStmt>()
-    } as MutableSet<DefineStmt>).toList()
 }
 
 interface WithRightIndicators {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -710,6 +710,7 @@ internal fun RpgParser.Parm_fixedContext.calculateExplicitElementType(arraySizeD
         }
         RpgType.BOOLEAN.rpgType -> BooleanType
         RpgType.UNLIMITED_STRING.rpgType -> UnlimitedStringType
+        RpgType.TIMESTAMP.rpgType -> TimeStampType
         else -> todo("Support RPG code type '$rpgCodeType', field $name", conf = conf)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -99,4 +99,15 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("A50_A3(       ) A50_A4(       )")
         assertEquals(expected, "smeup/MU025002".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Data definition with `Z` RPG type and resolution of inline definition,
+     *  from DEFINE that uses *LIKE, from data definition of a subroutine defined in main.
+     * @see #269
+     */
+    @Test
+    fun executeMU025014() {
+        val expected = listOf("A50_A14(A) A50_B14(ABCDEFGHIJ)")
+        assertEquals(expected, "smeup/MU025014".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR06.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR06.rpgle
@@ -4,8 +4,8 @@
      D* Jariko must fire an ErrorEvent for each error
      V* ==============================================================
      D £40TDS          DS                  INZ
-     D  £40TIN                         Z
-     D  £40TFI                         Z
+     D  £40TIN                         E
+     D  £40TFI                         E
 
      D B£FIND        E DS                  EXTNAME(B£FIND0F)
      D XOGG            S                   LIKE(B1TIP2)

--- a/rpgJavaInterpreter-core/src/test/resources/QILEGEN/£G40.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/QILEGEN/£G40.rpgle
@@ -1,0 +1,173 @@
+      *====================================================================
+      * smeup V6R1.021DV
+      * Nome sorgente       : £G40
+      * Sorgente di origine : SMEDEV/QILEGEN(£G40)
+      * Esportato il        : 20240409 121042
+      *====================================================================
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 05/09/07  V2R3    BS Gestione PARM specifica per gestione liste estese
+     V* 18/02/08  V2R3    BS Gestione livello di chiamata
+     V* 16/01/10  V2R3    BS Gestione ricezione nome programma
+     V* 17/01/10  V2R3    BS Forzatura Programma di default in base alla funzione
+     V* 06/02/10  V2R3    BS Forzatura entry estesa se programma B£G40E
+     V* 17/02/10  V2R3    BS Forzatura programma di default in base alla funzione
+     V* 21/02/10  V2R3    BS Rilascio modifiche a partire dal 17/01/10 in DEV
+     V* 21/02/10  V2R3    BS Forzatura programma di default per funzione PRE
+     V* 28/02/10  V2R3    BS Forzatura programma di default per funzione FON
+     V* 07/03/10  V2R3    BS Parametri estesi se programma B£G40I
+     V* 12/03/10  V2R3    BS Su funzioni DEC/SCA forzato utilizzo parametor esteso
+     V* 12/07/10  V2R3    BS Forzatura su funzione GES/JOB
+     V* B£00722A  V3R1    CM Rimozione Gestione Interna degli errori
+     V* 14/09/15  V4R1    BS Rettifica risalita utilizzo campi estesi
+     V* 15/09/15  V4R1    BS Forzatura su funzione TES
+     D*----------------------------------------------------------------
+     D* OBIETTIVO
+     D*  Gestire e memorizzare liste di oggetti
+     D* NOTA
+     D*
+     D* FLUSSO
+     D*  prerequisiti:
+     D*/COPY £G40E
+     D*
+     D* FUNZIONI/METODI
+     D*----------------------------------------------------------------
+     D* ESEMPIO DI CHIAMATA
+      *C                   MOVEL     '<          >'£G40FU                         P
+      *C                   MOVEL     '<          >'£G40ME                         P
+      *C                   MOVEL     '<          >'£G40TP                         P
+      *C                   MOVEL     '<          >'£G40PA                         P
+      *C                   MOVEL     '<          >'£G40CD                         P
+      *C                   MOVEL     '<          >'£G40MV                         P
+      *C                   EXSR      £G40
+      *C                   MOVEL     £G04DM        '<          >'
+      *----------------------------------------------------------------
+     C     £G40          BEGSR
+      *
+     C                   IF        £G40PG=' '
+     C                   SELECT
+     C                   WHEN      %SUBST(£G40FU:1:3)='LIS' OR £G40FU='SQL'
+     C                   EVAL      £G40PG='B£G40E'
+     C                   WHEN      £G40FU='PRE'
+     C                   EVAL      £G40PG='B£G40P'
+     C                   WHEN      £G40FU='TST'
+     C                   EVAL      £G40PG='B£G40T'
+     C                   WHEN      £G40FU='FON'
+     C                   EVAL      £G40PG='B£G40F'
+     C                   OTHER
+     C                   EVAL      £G40PG='B£G40G'
+     C                   ENDSL
+     C                   ENDIF
+      *
+     C*****              IF        £G40FU='GES' AND £G40ME='JOB'
+     C                   IF        £G40FU='GES' OR £G40FU='COM' OR £G40FU='TES'
+     C                   EVAL      £G40AE='1'
+     C                   ENDIF
+      *
+     C                   EVAL      £G40PG=%TRIMR(£G40PG)+£G40LC
+      *
+     C                   MOVEL     '0'           £G4035
+     C                   MOVEL     '0'           £G4036
+      *
+     C                   IF        £G40AE=''
+     C                             AND %SUBST(£G40PG:1:6)<>'B£G40E'
+     C                             AND %SUBST(£G40PG:1:6)<>'B£G40P'
+     C                             AND %SUBST(£G40PG:1:6)<>'B£G40T'
+     C                             AND %SUBST(£G40PG:1:6)<>'B£G40F'
+     C                             AND %SUBST(£G40PG:1:6)<>'B£G40I'
+     C                             AND £G40FU<>'DEC'
+     C                             AND £G40FU<>'SCA'
+  MO>C                   IF        ££B£2J = '1'
+  MO>C                   CALL      £G40PG                               37
+  MO>C                   PARM                    £G40FU           10            -->
+  MO>C                   PARM                    £G40ME           10            -->
+  MO>C                   PARM                    £G40MS            7            <--
+  MO>C                   PARM                    £G40FI           10            <--
+  MO>C                   PARM                    £G40CM            2            <--
+  MO>C                   PARM                    £G40TP            2            -->  Tipo
+  MO>C                   PARM                    £G40PA           10            -->  Param.
+  MO>C                   PARM                    £G40CD           15            -->  Codice
+  MO>C                   PARM                    £40A                           <--> Sch.Oggetti
+  MO>C                   PARM                    £40B                           <--> Sch.TipPar.
+  MO>C                   PARM                    £G40MV           15            <--> Cod.MDV
+  MO>C                   PARM                    £G40DM           35            <--- Des.MDV
+  MO>C                   PARM                    £G4035            1            <---
+  MO>C                   PARM                    £G4036            1            <---
+  MO>C                   PARM                    £G40DS                         <--> Estensione
+  MO>C                   ELSE
+     C                   EVAL      *IN37=*OFF
+     C                   CALL      £G40PG
+     C                   PARM                    £G40FU           10            -->
+     C                   PARM                    £G40ME           10            -->
+     C                   PARM                    £G40MS            7            <--
+     C                   PARM                    £G40FI           10            <--
+     C                   PARM                    £G40CM            2            <--
+     C                   PARM                    £G40TP            2            -->  Tipo
+     C                   PARM                    £G40PA           10            -->  Param.
+     C                   PARM                    £G40CD           15            -->  Codice
+     C                   PARM                    £40A                           <--> Sch.Oggetti
+     C                   PARM                    £40B                           <--> Sch.TipPar.
+     C                   PARM                    £G40MV           15            <--> Cod.MDV
+     C                   PARM                    £G40DM           35            <--- Des.MDV
+     C                   PARM                    £G4035            1            <---
+     C                   PARM                    £G4036            1            <---
+     C                   PARM                    £G40DS                         <--> Estensione
+  MO>C                   ENDIF
+     C                   ELSE
+  MO>C                   IF        ££B£2J = '1'
+  MO>C                   CALL      £G40PG                               37
+  MO>C                   PARM                    £G40FU           10            -->
+  MO>C                   PARM                    £G40ME           10            -->
+  MO>C                   PARM                    £G40MS            7            <--
+  MO>C                   PARM                    £G40FI           10            <--
+  MO>C                   PARM                    £G40CM            2            <--
+  MO>C                   PARM                    £G40TP            2            -->  Tipo
+  MO>C                   PARM                    £G40PA           10            -->  Param.
+  MO>C                   PARM                    £G40CD           15            -->  Codice
+  MO>C                   PARM                    £40A                           <--> Sch.Oggetti
+  MO>C                   PARM                    £40B                           <--> Sch.TipPar.
+  MO>C                   PARM                    £G40MV           15            <--> Cod.MDV
+  MO>C                   PARM                    £G40DM           35            <--- Des.MDV
+  MO>C                   PARM                    £G4035            1            <---
+  MO>C                   PARM                    £G4036            1            <---
+  MO>C                   PARM                    £G40DS                         <--> Estensione
+  MO>C                   PARM                    £40AE                          <--> Estensione
+  MO>C                   ELSE
+     C                   EVAL      *IN37=*OFF
+     C                   CALL      £G40PG
+     C                   PARM                    £G40FU           10            -->
+     C                   PARM                    £G40ME           10            -->
+     C                   PARM                    £G40MS            7            <--
+     C                   PARM                    £G40FI           10            <--
+     C                   PARM                    £G40CM            2            <--
+     C                   PARM                    £G40TP            2            -->  Tipo
+     C                   PARM                    £G40PA           10            -->  Param.
+     C                   PARM                    £G40CD           15            -->  Codice
+     C                   PARM                    £40A                           <--> Sch.Oggetti
+     C                   PARM                    £40B                           <--> Sch.TipPar.
+     C                   PARM                    £G40MV           15            <--> Cod.MDV
+     C                   PARM                    £G40DM           35            <--- Des.MDV
+     C                   PARM                    £G4035            1            <---
+     C                   PARM                    £G4036            1            <---
+     C                   PARM                    £G40DS                         <--> Estensione
+     C                   PARM                    £40AE                          <--> Estensione
+  MO>C                   ENDIF
+     C                   ENDIF
+      *
+  MO>C   37              DO
+  MO>C                   CALL      'B£GGP0  '
+  MO>C                   PARM      'B£G40G'      £GGPNP           10
+  MO>C                   PARM      *BLANKS       £GGPTP           10
+  MO>C                   PARM      *BLANKS       £GGPPA          100
+  MO>C                   ENDDO
+      *
+     C     £G4035        COMP      *ON                                    35
+     C     £G4036        COMP      *ON                                    36
+      *
+     C                   CLEAR                   £G40LC            1
+     C                   CLEAR                   £G40PG           10
+      *
+     C                   ENDSR
+      *----------------------------------------------------------------

--- a/rpgJavaInterpreter-core/src/test/resources/QILEGEN/£G40E.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/QILEGEN/£G40E.rpgle
@@ -1,0 +1,82 @@
+      *====================================================================
+      * smeup V6R1.021DV
+      * Nome sorgente       : £G40E
+      * Sorgente di origine : SMEDEV/QILEGEN(£G40E)
+      * Esportato il        : 20240409 121041
+      *====================================================================
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 14/02/10  V2R3    BS Aggiunta variabile £40ANM
+     V* 15/02/10  V2R3    BS Aggiunto Keyword VARYING alla variabile £40AE
+     V* 15/02/10  V2R3    BS Aggiunta definizione DS £G40L0DS/L1DS/L2DS
+     V* 21/02/10  V2R3    BS Rilascio in DEV modifiche del 15/02/10
+     V* 21/02/10  V2R3    BS Aggiunto Campo Schema e £40TDS
+     V* 28/02/10  V2R3    BS Aumentata Lunghezza Campo N° Elementi
+     V* 24/08/10  V3R1    BS Aggiunto Campo £40F_MSR
+     V* 31/08/10  V3R1    BS Aggiunti Campi Oggetto Secondario
+     V* 06/09/10  V3R1    BS Allungata DS da 100 a 500 caratteri
+     V* 14/09/15  V4R1    BS Aggiunto campo utente
+     V* 09/10/18  V5R1    BS Aggiunta indicazione I/O su variabili DS
+     V* 01/11/18  V5R1    BS Aggiunto campo annullata
+     V* 16/08/19  001067 BMA Tolte schiere con definizione errata overlay
+     V* 16/08/19  V5R1    BS Check-out 001067 in SMEDEV
+     D*----------------------------------------------------------------
+     D* Schiere x passaggio dati a £G40
+     D*
+     D* Codici oggetto
+     D £40A            S             15    DIM(300)
+     D £40B            S             12    DIM(300)
+     D*
+     D £G40DS          DS           500
+     D  £G40PZ                        1                                         O Lista Dinamica
+     D  £G40EX                        1                                         O Lista Estesa
+     D  £G40FM                        1                                         O Formato Ext
+     D  £G40AE                        1                                         I Utilizzo £40AE
+     D  £G40FL                        1                                         I Applica Filtro JO
+     D  £G40NS                        1                                         I Disabilita SQL
+     D  £G40NE                        9S 0                                      O N° Elementi
+     D  £G40SC                       15                                         O Schema
+     D  £G40FO                       15                                         O Fonte
+     D  £G40T2                        2                                         I Tipo Oggetto Sec.
+     D  £G40P2                       10                                         I Parametro Ogg.Sec.
+     D  £G40C2                       15                                         I Cod.Ogg.Sec.
+     D  £G40UT                       10                                         O Utente
+     D  £G40AN                        1                                         O Annullata
+      *
+     D £40AE           S          30000    VARYING
+      *
+     D £40KNM          S              5S 0 INZ(%ELEM(£40KK))
+     D £40DNM          S              5S 0 INZ(%ELEM(£40D))
+     D £40ANM          S              5S 0 INZ(%ELEM(£40A))
+      *
+      * DS in sui riversare l'output della funzione LISOG
+     D £40KDS          DS         30000    INZ
+     D £40KK                         15    DIM(2000)
+      * DS in sui riversare l'output della funzione LISOD
+     D £40DDS          DS         30000    INZ
+     D £40D                          50    DIM(600)
+     D  £40DK                        15    OVERLAY(£40D:1)
+     D  £40DD                        35    OVERLAY(£40D:*NEXT)
+      * DS in sui riversare l'output della funzione TST
+     D £40TDS          DS                  INZ
+     D  £40TIN                         Z
+     D  £40TFI                         Z
+     D  £40TMI                        7  0
+     D  £40TNE                       11  0
+      * DS in sui riversare l'output della funzione FON
+     D £40FDS          DS                  INZ
+     D  £40FDE                 1     30                                         Descrizione
+     D  £40FRE                31     80                                         Tipo Record
+     D  £40FNT                81     85  0                                      N° Oggetti Gestiti
+     D  £40F_MSO              86     86                                         Gestione OG_SCA
+     D  £40F_MWL              87     87                                         Gestione WHR_LI
+     D  £40F_MWC              88     88                                         Gestione WHR_CO
+     D  £40FLU                89     90                                         Livello Utente
+     D  £40F_MSR              91     91                                         Gestione RE_SCA
+     D  £40FNS                92     92                                         NO SQL
+      *
+     D  £40FTO              1096   7095    DIM(500)                             Oggetti Gestiti
+     D**£40FTP              1096   2095    DIM(500)                             . Tipi Oggetto
+     D**£40FPA              2096   7095    DIM(500)                             . Parametri Oggetto

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU025014.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU025014.rpgle
@@ -1,0 +1,48 @@
+      *====================================================================
+      * smeup V6R1.021DV
+      * Nome sorgente       : MU025014
+      * Sorgente di origine : QTEMP/SRC(MU025014)
+      * Esportato il        : 20240409 121030
+      *====================================================================
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 08/04/24  MUTEST  BERNI Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * DEFINE di varibili definite INLINE in/COPY non di definizione (es: £G40)
+     V* ==============================================================
+      /COPY QILEGEN,MULANG_D_D
+      /COPY QILEGEN,£TABB£1DS
+      /COPY QILEGEN,£G40E
+      /COPY QILEGEN,£PDS
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU025014'
+     C                   EVAL      £DBG_Sez = 'A50'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A50
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico DEFINE
+      *---------------------------------------------------------------------
+     C     SEZ_A50       BEGSR
+    OA* A£.CDOP(DEFINE  )
+     D* DEFINE variabili definite INLINE in /COPY
+     C                   EVAL      £DBG_Pas='P14'
+     C     *LIKE         DEFINE    £G40LC        A50_A14
+     C     *LIKE         DEFINE    £G40PG        A50_B14
+     C                   EVAL      A50_A14='A'
+     C                   EVAL      A50_B14='ABCDEFGHIJ'
+     C                   EVAL      £DBG_Str= 'A50_A14('+A50_A14+')'
+     C                                     +' A50_B14('+A50_B14+')'
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C
+      /COPY QILEGEN,£G40


### PR DESCRIPTION
## Description
This branch fixes two problem:
-  the nonexistent `Z` RPG type. In addition, the `ERROR06` test was fixed by considering that type is now avilable, changing to one that doesn't exist;
- the resolution of an inline Data Definition that must still be executed. In RPG is possible to use the `*LIKE` from a subroutine to a data definition of another subroutine.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
