### PR TITLE
Bugfix/nw23001440/268 cannot retrieve copy

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
@@ -53,6 +53,8 @@ internal fun String.includesCopy(
     val sb = StringBuffer()
     var addedLines = 0
     while (matcher.find()) {
+        // Skip CDATA section
+        if (null != matcher.group(3)) continue
         // Skip commented line
         if (null != matcher.group(2)) continue
         val copyId = matcher.group(1).copyId()
@@ -87,8 +89,18 @@ internal fun String.includesCopy(
     return sb.toString()
 }
 
+/**
+ *  Group 1: ID of Copy, like <folder>,<file> (without extension)
+ *  Group 2: Commented line
+ *  Group 3: CDATA section
+ */
 @JvmField
-val PATTERN: Pattern = Pattern.compile(".{6}/(?:COPY|INCLUDE)\\s+((?:\\w|£|\\$|§|,)+)|(.{6}\\*.+)", Pattern.CASE_INSENSITIVE)
+val PATTERN: Pattern = Pattern.compile("" +
+        ".{6}/(?:COPY|INCLUDE)\\s+((?:\\w|£|\\\$|§|,)+)|" +
+        "(.{6}\\*.+)|" +
+        "(\\*\\*(CTDATA)?\\s?[§£#@a-zA-Z0-9_]*[\\n\\S\\s]*)",
+    Pattern.CASE_INSENSITIVE
+)
 
 fun String.copyId(): CopyId {
     return when {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -5,12 +5,12 @@ import kotlin.test.assertEquals
 
 open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     /**
-     * CTDATA
+     * /COPY recognized in CTDATA
      * @see #268
      */
     @Test
     fun executeMU023007() {
-        val expected = listOf("/copy in prima posizione in minuscolo             ;Prova alla fine del testo /COPY                   ;Prova alla fine del testo in minuscolo /copy      ;Prova con /COPY in mezzo al testo                 ;")
+        val expected = listOf("/COPY in prima posizione                          ;/copy in prima posizione in minuscolo             ;Prova alla fine del testo /COPY                   ;Prova alla fine del testo in minuscolo /copy      ;Prova con /COPY in mezzo al testo                 ;Prova con /copy in mezzo al testo in minuscolo")
         assertEquals(expected, "smeup/MU023007".outputOf())
     }
     /**

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -14,6 +14,15 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         assertEquals(expected, "smeup/MU023007".outputOf())
     }
     /**
+     * /COPY recognized in CTDATA
+     * @see #269
+     */
+    @Test
+    fun executeMU023008() {
+        val expected = listOf("Prova /COPY                                       ;Prova /COPY numero                                ;Prova /COPY 12                                    ;      /COPY QILEGEN, AAA")
+        assertEquals(expected, "smeup/MU023008".outputOf())
+    }
+    /**
      * Data reference - DS with 2 arrays defined with overlay
      * @see #247
      */

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -5,6 +5,15 @@ import kotlin.test.assertEquals
 
 open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     /**
+     * CTDATA
+     * @see #268
+     */
+    @Test
+    fun executeMU023007() {
+        val expected = listOf("/copy in prima posizione in minuscolo             ;Prova alla fine del testo /COPY                   ;Prova alla fine del testo in minuscolo /copy      ;Prova con /COPY in mezzo al testo                 ;")
+        assertEquals(expected, "smeup/MU023007".outputOf())
+    }
+    /**
      * Data reference - DS with 2 arrays defined with overlay
      * @see #247
      */

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU023007.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU023007.rpgle
@@ -1,0 +1,55 @@
+      *====================================================================
+      * smeup V6R1.021DV
+      * Nome sorgente       : MU023007
+      * Sorgente di origine : QTEMP/SRC(MU023007)
+      * Esportato il        : 20240415 082653
+      *====================================================================
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 08/04/24  MUTEST  BERNI Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * Questo test vuole verificare che se viene scritta /COPY come testo nelle schiere, non
+      * venga considerato come definizione di una /copy
+     V* ==============================================================
+      * Variabili per definire delle schiere a fine programma
+     DA30_AR7          S             50    DIM(6) CTDATA PERRCD(1)              _TXT
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      /COPY QILEGEN,£TABB£1DS
+      /COPY QILEGEN,£PDS
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU023007'
+     C                   EVAL      £DBG_Sez = 'A30'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A30
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test con stringa /copy in schiera
+      *---------------------------------------------------------------------
+     C     SEZ_A30       BEGSR
+    OA* A£.TPDA(ARRAY  )
+     D* Test su stringa /COPY in array
+     C                   EVAL      £DBG_Pas='P07'
+     C                   EVAL      £DBG_Str=A30_AR7(01)+';'+A30_AR7(02)+';'
+     C                                     +A30_AR7(03)+';'+A30_AR7(04)+';'
+     C                                     +A30_AR7(05)+';'+A30_AR7(06)
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C
+** A30_AR7
+/COPY in prima posizione
+/copy in prima posizione in minuscolo
+Prova alla fine del testo /COPY
+Prova alla fine del testo in minuscolo /copy
+Prova con /COPY in mezzo al testo
+Prova con /copy in mezzo al testo in minuscolo

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU023008.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU023008.rpgle
@@ -1,0 +1,52 @@
+      *====================================================================
+      * smeup V6R1.021DV
+      * Nome sorgente       : MU023008
+      * Sorgente di origine : QTEMP/SRC(MU023008)
+      * Esportato il        : 20240415 082653
+      *====================================================================
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 08/04/24  MUTEST  BERNI Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * Questo test vuole verificare che se viene scritta /COPY nella stessa posizione delle
+      * definzioni non venga considerato come /copy da importare
+     V* ==============================================================
+      * Variabili per definire delle schiere a fine programma
+     DA30_AR8          S             50    DIM(4) CTDATA PERRCD(1)              _TXT
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      /COPY QILEGEN,£TABB£1DS
+      /COPY QILEGEN,£PDS
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU023008'
+     C                   EVAL      £DBG_Sez = 'A30'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A30
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test con stringa /copy in schiera
+      *---------------------------------------------------------------------
+     C     SEZ_A30       BEGSR
+    OA* A£.TPDA(ARRAY  )
+     D* Test su stringa /COPY in array
+     C                   EVAL      £DBG_Pas='P08'
+     C                   EVAL      £DBG_Str=A30_AR8(01)+';'+A30_AR8(02)+';'
+     C                                     +A30_AR8(03)+';'+A30_AR8(04)
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C
+** A30_AR8
+Prova /COPY
+Prova /COPY numero
+Prova /COPY 12
+      /COPY QILEGEN, AAA


### PR DESCRIPTION
## Description
This work fixes the problem where whatever string `/COPY` in `CTDATA` section is considered like a `/COPY` directive, producing a syntax error. The retrieving of source with this directive is a preprocessor task, even before the AST production. In accord to [official documentation](https://www.ibm.com/docs/tr/i/7.5?topic=keywords-ctdata):

> The CTDATA keyword indicates that the array or table is loaded using compile-time data. The data is specified at the end of the program following the ** or **CTDATA(array/table name) specification.

So, every `CTDATA` is always located at the end of program. The problem was resolved in `copy.kt` by fixing the `PATTERN` REGEX while I was testing in [Regex101](https://regex101.com/) the two atomic tests (`MU023007` and `MU023008`). In addition to Group 1 (for Copy ID) and Group 2 (commented line) results, there is a third Group dedicated a `CTDATA` block, to exclude as with for a comment.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
