### PR TITLE
Bugfix/nw23001440/mock biton bitoff

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -41,6 +41,8 @@ private val modules = SerializersModule {
     }
     polymorphic(Statement::class) {
         subclass(AddStmt::class)
+        subclass(BitOnStmt::class)
+        subclass(BitOffStmt::class)
         subclass(CabStmt::class)
         subclass(CallStmt::class)
         subclass(CallPStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -2124,3 +2124,21 @@ data class FeodStmt(
 ) : Statement(position), MockStatement {
     override fun execute(interpreter: InterpreterCore) { }
 }
+
+@Serializable
+data class BitOnStmt(
+    override val position: Position? = null,
+    @Derived val dataDefinition: InStatementDataDefinition? = null
+) : Statement(position), StatementThatCanDefineData, MockStatement {
+    override fun execute(interpreter: InterpreterCore) { }
+    override fun dataDefinition(): List<InStatementDataDefinition> = dataDefinition?.let { listOf(it) } ?: emptyList()
+}
+
+@Serializable
+data class BitOffStmt(
+    override val position: Position? = null,
+    @Derived val dataDefinition: InStatementDataDefinition? = null
+) : Statement(position), StatementThatCanDefineData, MockStatement {
+    override fun execute(interpreter: InterpreterCore) { }
+    override fun dataDefinition(): List<InStatementDataDefinition> = dataDefinition?.let { listOf(it) } ?: emptyList()
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -921,6 +921,12 @@ internal fun Cspec_fixed_standardContext.toAst(conf: ToAstConfiguration = ToAstC
         this.csFEOD() != null -> this.csFEOD()
             .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
 
+        this.csBITON() != null -> this.csBITON()
+            .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
+
+        this.csBITOFF() != null -> this.csBITOFF()
+            .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
+
         else -> todo(conf = conf)
     }
 }
@@ -2002,6 +2008,24 @@ internal fun CsUNLOCKContext.toAst(conf: ToAstConfiguration = ToAstConfiguration
 internal fun CsFEODContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
     return FeodStmt(position)
+}
+
+// TODO
+internal fun CsBITONContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+    val position = toPosition(conf.considerPosition)
+    return BitOnStmt(
+        dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(this.cspec_fixed_standard_parts().result.text, position, conf),
+        position = position
+    )
+}
+
+// TODO
+internal fun CsBITOFFContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+    val position = toPosition(conf.considerPosition)
+    return BitOffStmt(
+        dataDefinition = this.cspec_fixed_standard_parts().toDataDefinition(this.cspec_fixed_standard_parts().result.text, position, conf),
+        position = position
+    )
 }
 
 /**

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2377,4 +2377,16 @@ Test 6
         val expected = listOf("OK")
         assertEquals(expected, "LIKEWITHCOPY2".outputOf())
     }
+
+    @Test
+    fun executeBITON_INLINEDATA() {
+        val expected = listOf("1000")
+        assertEquals(expected, "BITON_INLINEDATA".outputOf())
+    }
+
+    @Test
+    fun executeBITOFF_INLINEDATA() {
+        val expected = listOf("1000")
+        assertEquals(expected, "BITOFF_INLINEDATA".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
@@ -1,7 +1,6 @@
 package com.smeup.rpgparser.smeup
 
 import org.junit.Test
-import kotlin.test.Ignore
 import kotlin.test.assertEquals
 
 open class MULANGT70CompilationDirectiveTest : MULANGTTest() {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
@@ -30,7 +30,6 @@ open class MULANGT70CompilationDirectiveTest : MULANGTTest() {
      * @see #265
      */
     @Test
-    @Ignore
     fun executeMU711003() {
         val expected = listOf("A71_01(0) A71_02(3) A71_03(F)")
         assertEquals(expected, "smeup/MU711003".outputOf(configuration = smeupConfig))
@@ -41,7 +40,6 @@ open class MULANGT70CompilationDirectiveTest : MULANGTTest() {
      * @see #265
      */
     @Test
-    @Ignore
     fun executeMU711004() {
         val expected = listOf("A71_01(0) A71_02(3) A71_03(F)")
         assertEquals(expected, "smeup/MU711004".outputOf(configuration = smeupConfig))

--- a/rpgJavaInterpreter-core/src/test/resources/BITOFF_INLINEDATA.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/BITOFF_INLINEDATA.rpgle
@@ -1,0 +1,3 @@
+     C                   BITOFF    '0'           IL_VAR            4
+     C                   EVAL      IL_VAR='1000'
+     C     IL_VAR        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/BITON_INLINEDATA.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/BITON_INLINEDATA.rpgle
@@ -1,0 +1,3 @@
+     C                   BITON     '1'           IL_VAR            4
+     C                   EVAL      IL_VAR='1000'
+     C     IL_VAR        DSPLY


### PR DESCRIPTION
## Description
This work implements a mocked version, with `InStatementDataDefinition`, of `BITON` and `BITOFF` operators.
In addition:
- are restored the `MU711003` and `MU711004` tests;
- are implemented dedicated tests with `InStatementDataDefinition`.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
