### PR TITLE
Bugfix/nw23001440/bif elem into occurs

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -159,7 +159,7 @@ keyword_likerec : KEYWORD_LIKEREC OPEN_PAREN intrecname=simpleExpression
 	(COLON (SPLAT_ALL | SPLAT_INPUT | SPLAT_OUTPUT | SPLAT_KEY))?
 	CLOSE_PAREN; 
 keyword_noopt : KEYWORD_NOOPT;
-keyword_occurs : KEYWORD_OCCURS OPEN_PAREN (numeric_constant=number | function | identifier) CLOSE_PAREN;
+keyword_occurs : KEYWORD_OCCURS OPEN_PAREN ((numeric_constant=number | function | identifier)|(expr=expression)) CLOSE_PAREN;
 keyword_opdesc : KEYWORD_OPDESC;
 keyword_options : KEYWORD_OPTIONS OPEN_PAREN identifier (COLON identifier)* CLOSE_PAREN; 
 keyword_overlay : KEYWORD_OVERLAY OPEN_PAREN name=simpleExpression (COLON (SPLAT_NEXT | pos=simpleExpression))? CLOSE_PAREN; 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -482,7 +482,7 @@ internal fun RpgParser.Dcl_dsContext.type(
     val explicitSize = this.TO_POSITION().text.trim().let { if (it.isBlank()) null else it.toInt() }
     val keywords = this.keyword()
     val dim: Expression? = keywords.asSequence().mapNotNull { it.keyword_dim()?.simpleExpression()?.toAst(conf) }.firstOrNull()
-    val occurs: Int? = keywords.asSequence().mapNotNull { it.keyword_occurs()?.numeric_constant?.children?.get(0)?.text?.toInt() }.firstOrNull()
+    val occurs: Int? = keywords.asSequence().mapNotNull { it.keyword_occurs()?.evaluate(conf) }.firstOrNull()
     val nElements = if (dim != null) conf.compileTimeInterpreter.evaluate(this.rContext(), dim).asInt().value.toInt() else null
     val fieldTypes: List<FieldType> = fieldsList.fields.map { it.toFieldType() }
     val calculatedElementSize = fieldsList.fields.map {
@@ -511,6 +511,23 @@ internal fun RpgParser.Dcl_dsContext.type(
         baseType
     } else {
         ArrayType(baseType, nElements)
+    }
+}
+
+/**
+ * Evaluates the OCCURS keyword between a number or an expression to evaluate at runtime.
+ */
+internal fun RpgParser.Keyword_occursContext.evaluate(conf: ToAstConfiguration = ToAstConfiguration()): Int? {
+    return when {
+        this.numeric_constant != null -> numeric_constant?.getChild(0)?.text?.toInt()
+        this.expr != null -> {
+            val injectableCompileTimeInterpreter = InjectableCompileTimeInterpreter(
+                KnownDataDefinition.getInstance().values.toList(),
+                conf.compileTimeInterpreter
+            )
+            injectableCompileTimeInterpreter.evaluate(rContext(), this.expr.toAst(conf)).asInt().value.toInt()
+        }
+        else -> null
     }
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -148,4 +148,13 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("A50_A14(A) A50_B14(ABCDEFGHIJ)")
         assertEquals(expected, "smeup/MU025014".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * OCCURS with an expressions
+     */
+    @Test
+    fun executeMU401011() {
+        val expected = listOf("HELLOTHERE")
+        assertEquals(expected, "smeup/MU401011".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -148,13 +148,4 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("A50_A14(A) A50_B14(ABCDEFGHIJ)")
         assertEquals(expected, "smeup/MU025014".outputOf(configuration = smeupConfig))
     }
-
-    /**
-     * OCCURS with an expressions
-     */
-    @Test
-    fun executeMU401011() {
-        val expected = listOf("HELLOTHERE")
-        assertEquals(expected, "smeup/MU401011".outputOf(configuration = smeupConfig))
-    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT40ArrayAndDSTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT40ArrayAndDSTest.kt
@@ -13,4 +13,13 @@ open class MULANGT40ArrayAndDSTest : MULANGTTest() {
         val expected = listOf("Contenuto Pre-RESET: AAA - Contenuto Post-RESET:")
         assertEquals(expected, "smeup/T40_A10_P10".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * OCCURS with an expressions
+     */
+    @Test
+    fun executeMU401011() {
+        val expected = listOf("HELLOTHERE")
+        assertEquals(expected, "smeup/MU401011".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU401011.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU401011.rpgle
@@ -1,0 +1,44 @@
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 19/04/24  MUTEST  APU001 Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * L'obiettivo di questo test è l'utilizzo di OCCURS dove, tra le sue
+    O *  parentesi, abbiamo una espressione da valutare.
+     V* ==============================================================
+     D* Sezione delle variabili.
+     D D40_AR1         S             10I 0 DIM(10)
+     D D40_DS1         DS                  OCCURS(%ELEM(D40_AR1))
+     D  D40_DS1_I1                   10I 0
+     D  D40_DS1_I2                   10I 0
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      /COPY QILEGEN,£TABB£1DS
+      /COPY QILEGEN,£PDS
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU401011'
+     C                   EVAL      £DBG_Sez = 'A40'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A40
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico OCCURS ed espressione al suo interno
+      *---------------------------------------------------------------------
+     C     SEZ_A40       BEGSR
+    OA* A£.TPDA(OCCURS)
+     D* Commento
+     C                   EVAL      £DBG_Pas='P11'
+      *
+     C                   EVAL      £DBG_Str= 'HELLOTHERE'
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C


### PR DESCRIPTION
## Description
An `OCCURS` might have an expression to evaluate. So, I applied a fix into `RpgParser` by adding a case where the argument is an expression, in addition to `numeric_constant`. Then, I re-built the logic of evaluation in `data_definitions` by considering both numeric and expression.

## Checklist:
- [ ] There are tests regarding this feature
- [ ] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [ ] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
