### PR TITLE
bugfix/infinite loop regression during DS field resolution

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -233,11 +233,11 @@ open class BaseCompileTimeInterpreter(
         statements
             .forEach { it ->
                 when {
-                    it.dcl_ds() != null -> {
-                        val type = it.dcl_ds().toAst(conf = conf, knownDataDefinitions = knownDataDefinitions).fields
-                            .firstOrNull { it.name.equals(declName, ignoreCase = true) }?.type
-                        if (type != null) return type
-                    }
+//                    it.dcl_ds() != null -> {
+//                        val type = it.dcl_ds().toAst(conf = conf, knownDataDefinitions = knownDataDefinitions).fields
+//                            .firstOrNull { it.name.equals(declName, ignoreCase = true) }?.type
+//                        if (type != null) return type
+//                    }
                     it.dspec() != null -> {
                         val name = it.dspec().ds_name()?.text ?: it.dspec().dspecConstant().ds_name()?.text
                         if (declName.equals(name, ignoreCase = true)) {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT40ArrayAndDSTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT40ArrayAndDSTest.kt
@@ -1,6 +1,7 @@
 package com.smeup.rpgparser.smeup
 
 import org.junit.Test
+import kotlin.test.Ignore
 import kotlin.test.assertEquals
 
 open class MULANGT40ArrayAndDSTest : MULANGTTest() {
@@ -27,6 +28,7 @@ open class MULANGT40ArrayAndDSTest : MULANGTTest() {
      * Field of DS with LIKE to field of next DS.
      */
     @Test
+    @Ignore(value = "reverted pull #500")
     fun executeMU401012() {
         val expected = listOf("HELLOTHERE")
         assertEquals(expected, "smeup/MU401012".outputOf(configuration = smeupConfig))


### PR DESCRIPTION
This pull reverts changes in #500
This issue currently is not yet reproducible.

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
