### PR TITLE
Handle IF DEFINED compiler directives with special parameters as unsupported

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
@@ -25,13 +25,13 @@ val DIRECTIVES_KEYWORDS = listOf(
 val EOF_DIRECTIVE_KEYWORD = "      /EOF"
 
 // Search patterns for identifying compiler directive rows.
-val IF_DEFINED_PATTERN = Regex(""".{6}/IF\sDEFINED\(([\w£$§*,]+)\)$""", RegexOption.IGNORE_CASE)
-val IF_NOT_DEFINED_PATTERN = Regex(""".{6}/IF\sNOT\sDEFINED\(([\w£$§,]+)\)$""", RegexOption.IGNORE_CASE)
-val DEFINE_PATTERN = Regex(""".{6}/DEFINE\s+([^\s]+)""", RegexOption.IGNORE_CASE)
-val UNDEFINE_PATTERN = Regex(""".{6}/UNDEFINE\s+([^\s]+)""", RegexOption.IGNORE_CASE)
-val ELSE_PATTERN = Regex(""".{6}/ELSE""", RegexOption.IGNORE_CASE)
-val ENDIF_PATTERN = Regex(""".{6}/ENDIF""", RegexOption.IGNORE_CASE)
-val EOF_PATTERN = Regex(""".{6}/EOF""", RegexOption.IGNORE_CASE)
+val IF_DEFINED_PATTERN = Regex(""".{6}/IF\sDEFINED\(([\w£$§*,]+)\)\s*$""", RegexOption.IGNORE_CASE)
+val IF_NOT_DEFINED_PATTERN = Regex(""".{6}/IF\sNOT\sDEFINED\(([\w£$§,]+)\)\s*$""", RegexOption.IGNORE_CASE)
+val DEFINE_PATTERN = Regex(""".{6}/DEFINE\s+([^\s]+)\s*$""", RegexOption.IGNORE_CASE)
+val UNDEFINE_PATTERN = Regex(""".{6}/UNDEFINE\s+([^\s]+)\s*$""", RegexOption.IGNORE_CASE)
+val ELSE_PATTERN = Regex(""".{6}/ELSE\s*$""", RegexOption.IGNORE_CASE)
+val ENDIF_PATTERN = Regex(""".{6}/ENDIF\s*$""", RegexOption.IGNORE_CASE)
+val EOF_PATTERN = Regex(""".{6}/EOF\s*$""", RegexOption.IGNORE_CASE)
 
 /**
  * Resolve the EOF directive: after this directive, all rows are ignored until the end of the file

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
@@ -105,7 +105,11 @@ internal fun String.resolveCompilerDirectives(): String {
                     val matchResult = IF_DEFINED_PATTERN.matchEntire(row)
                     val code = matchResult?.groups?.get(1)?.value
                     if (code != null) {
-                        useRow = isDefined(definitions, code)
+                        if (code.startsWith("*V")) {
+                            throw CompilerDirectivesException("IF_DEFINED directive with unsupported $code parameter found at line " + (index + 1))
+                        } else {
+                            useRow = isDefined(definitions, code)
+                        }
                         ifLevel++
                     } else {
                         throw CompilerDirectivesException("IF_DEFINED directive without code value at line " + (index + 1))
@@ -118,15 +122,7 @@ internal fun String.resolveCompilerDirectives(): String {
                     val matchResult = IF_NOT_DEFINED_PATTERN.matchEntire(row)
                     val code = matchResult?.groups?.get(1)?.value
                     if (code != null) {
-                        if (code.startsWith("*V")) {
-                            /*
-                            Manage case with OS400 version as always true because jariko RPG version
-                            is always the last one for definition
-                             */
-                            useRow = true
-                        } else {
-                            useRow = !isDefined(definitions, code)
-                        }
+                        useRow = !isDefined(definitions, code)
                         ifLevel++
                     } else {
                         throw CompilerDirectivesException("IF_NOT_DEFINED directive without code value at line " + (index + 1))

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
@@ -25,13 +25,13 @@ val DIRECTIVES_KEYWORDS = listOf(
 val EOF_DIRECTIVE_KEYWORD = "      /EOF"
 
 // Search patterns for identifying compiler directive rows.
-val IF_DEFINED_PATTERN = Regex(""".{6}/IF\sDEFINED\(([\w£$§*,]+)\)\s*$""", RegexOption.IGNORE_CASE)
-val IF_NOT_DEFINED_PATTERN = Regex(""".{6}/IF\sNOT\sDEFINED\(([\w£$§,]+)\)\s*$""", RegexOption.IGNORE_CASE)
-val DEFINE_PATTERN = Regex(""".{6}/DEFINE\s+([^\s]+)\s*$""", RegexOption.IGNORE_CASE)
-val UNDEFINE_PATTERN = Regex(""".{6}/UNDEFINE\s+([^\s]+)\s*$""", RegexOption.IGNORE_CASE)
-val ELSE_PATTERN = Regex(""".{6}/ELSE\s*$""", RegexOption.IGNORE_CASE)
-val ENDIF_PATTERN = Regex(""".{6}/ENDIF\s*$""", RegexOption.IGNORE_CASE)
-val EOF_PATTERN = Regex(""".{6}/EOF\s*$""", RegexOption.IGNORE_CASE)
+val IF_DEFINED_PATTERN = Regex(""".{6}/IF\sDEFINED\(([\w£$§*,]+)\)$""", RegexOption.IGNORE_CASE)
+val IF_NOT_DEFINED_PATTERN = Regex(""".{6}/IF\sNOT\sDEFINED\(([\w£$§,]+)\)$""", RegexOption.IGNORE_CASE)
+val DEFINE_PATTERN = Regex(""".{6}/DEFINE\s+([^\s]+)""", RegexOption.IGNORE_CASE)
+val UNDEFINE_PATTERN = Regex(""".{6}/UNDEFINE\s+([^\s]+)""", RegexOption.IGNORE_CASE)
+val ELSE_PATTERN = Regex(""".{6}/ELSE""", RegexOption.IGNORE_CASE)
+val ENDIF_PATTERN = Regex(""".{6}/ENDIF""", RegexOption.IGNORE_CASE)
+val EOF_PATTERN = Regex(""".{6}/EOF""", RegexOption.IGNORE_CASE)
 
 /**
  * Resolve the EOF directive: after this directive, all rows are ignored until the end of the file

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/compilerDirectives/CompilerDirectivesTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/compilerDirectives/CompilerDirectivesTest.kt
@@ -25,4 +25,11 @@ class CompilerDirectivesTest : AbstractTest() {
             "compilerDirectives/ERROR03".outputOf()
         }.printStackTrace()
     }
+
+    @Test
+    fun executeError04() {
+        assertFails {
+            "compilerDirectives/ERROR04".outputOf()
+        }.printStackTrace()
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/compilerDirectives/ERROR04.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/compilerDirectives/ERROR04.rpgle
@@ -1,0 +1,4 @@
+      * Test with usupported IF condition (OS400 version)
+      /IF DEFINED(*V5R1M0)
+      /ENDIF
+

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
@@ -103,14 +103,6 @@
      C     £DBG_Str      DSPLY
       /ENDIF
       /ENDIF
-      * Test with condition on OS400 version
-      /IF DEFINED(*V5R1M0)
-     C                   EVAL      £DBG_Str='OK'
-     C     £DBG_Str      DSPLY
-      /ELSE
-     C                   EVAL      £DBG_Str='ERROR'
-     C     £DBG_Str      DSPLY
-      /ENDIF
      C                   ENDSR
       *---------------------------------------------------------------------
       */COPY QILEGEN,MULANG_D_C

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
@@ -82,9 +82,6 @@
      C                   EVAL      £DBG_Str='OK'
      C     £DBG_Str      DSPLY
       * Test with 3 nested IF
-      * The next row has some trailing while spaces.
-      * This test the new regex rules that ignore the
-      * white chars at the end of line.
       /UNDEFINE DEFINE_1
       /UNDEFINE DEFINE_2
       /DEFINE DEFINE_3

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
@@ -103,6 +103,7 @@
      C     £DBG_Str      DSPLY
       /ENDIF
       /ENDIF
+      *
      C                   ENDSR
       *---------------------------------------------------------------------
       */COPY QILEGEN,MULANG_D_C

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
@@ -103,7 +103,14 @@
      C     £DBG_Str      DSPLY
       /ENDIF
       /ENDIF
-      *
+      * Test with condition on OS400 version
+      /IF DEFINED(*V5R1M0)
+     C                   EVAL      £DBG_Str='OK'
+     C     £DBG_Str      DSPLY
+      /ELSE
+     C                   EVAL      £DBG_Str='ERROR'
+     C     £DBG_Str      DSPLY
+      /ENDIF
      C                   ENDSR
       *---------------------------------------------------------------------
       */COPY QILEGEN,MULANG_D_C

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU701006.rpgle
@@ -82,6 +82,9 @@
      C                   EVAL      £DBG_Str='OK'
      C     £DBG_Str      DSPLY
       * Test with 3 nested IF
+      * The next row has some trailing while spaces.
+      * This test the new regex rules that ignore the
+      * white chars at the end of line.
       /UNDEFINE DEFINE_1
       /UNDEFINE DEFINE_2
       /DEFINE DEFINE_3


### PR DESCRIPTION
## Description

Handle IF DEFINED compiler directives with special parameters as unsupported, throwing a CompilerDirectiveException.

Related to the 'Unexpected ENDIF directive' error, observed in all programs that include £CRI as a /COPY, as well as in other instances.

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
