### PR TITLE
Bugfix/nw24000624/null position in DataDefinition related to DbField

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/db.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/db.kt
@@ -18,6 +18,7 @@ package com.smeup.rpgparser.interpreter
 
 import com.smeup.dbnative.model.Field
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
+import com.strumenta.kolasu.model.Position
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.decodeFromString
@@ -41,7 +42,12 @@ data class DbField(val fieldName: String, val type: Type) {
     /**
      * Creates a data definition associated to this
      * */
-    fun toDataDefinition(prefix: Prefix?) = DataDefinition(prefix?.applyReplacementRules(fieldName) ?: fieldName, type)
+    fun toDataDefinition(prefix: Prefix?, position: Position?) =
+        DataDefinition(
+            name = prefix?.applyReplacementRules(fieldName) ?: fieldName,
+            type = type,
+            position = position
+        )
 }
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -167,7 +167,7 @@ private fun FileDefinition.toDataDefinitions(): List<DataDefinition> {
     if (internalFormatName == null) internalFormatName = metadata.tableName
     dataDefinitions.addAll(
         metadata.fields.map { dbField ->
-            dbField.toDataDefinition(prefix).apply {
+            dbField.toDataDefinition(prefix = prefix, position = position).apply {
                 createDbFieldDataDefinitionRelation(dbField.fieldName, name)
             }
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -596,19 +596,32 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     private fun createMockReloadConfig(): ReloadConfig {
-        val metadataProducer = { file: String ->
-            FileMetadata(
-                name = file,
-                tableName = file,
-                recordFormat = file,
+
+        val metadata = mapOf(
+            "FILE01" to FileMetadata(
+                name = "FILE01",
+                tableName = "FILE01",
+                recordFormat = "FILE01",
                 fields = listOf(
                     DbField("FIELD1", StringType(10)),
-                    DbField("FIELD2", StringType(10)),
+                    DbField("FIELD1", StringType(10)),
+                    DbField("FIELD3", StringType(10))
+                ),
+                accessFields = listOf("FIELD1")
+            ),
+            "FILE02" to FileMetadata(
+                name = "FILE02",
+                tableName = "FILE02",
+                recordFormat = "FILE02",
+                fields = listOf(
+                    DbField("FIELD1", StringType(100)),
+                    DbField("FIELD1", StringType(10)),
                     DbField("FIELD3", StringType(10))
                 ),
                 accessFields = listOf("FIELD1")
             )
-        }
+        )
+        val metadataProducer = { file: String -> metadata[file]!! }
         return ReloadConfig(DBNativeAccessConfig(connectionsConfig = emptyList()), metadataProducer = metadataProducer)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -442,6 +442,16 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR16CallBackTest() {
+        executePgmCallBackTest("ERROR16", SourceReferenceType.Program, "ERROR16", listOf(12))
+    }
+
+    @Test
+    fun executeERROR16SourceLineTest() {
+        executeSourceLineTest("ERROR16")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -16,6 +16,7 @@
 
 package com.smeup.rpgparser.interpreter
 
+import com.smeup.dbnative.DBNativeAccessConfig
 import com.smeup.rpgparser.AbstractTest
 import com.smeup.rpgparser.execution.*
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
@@ -551,6 +552,7 @@ class JarikoCallbackTest : AbstractTest() {
                     errorEvents.add(errorEvent)
                 }
                 options = Options(debuggingInformation = true)
+                reloadConfig = createMockReloadConfig()
             }
             executePgm(pgm, configuration = configuration)
         }.onSuccess {
@@ -579,6 +581,7 @@ class JarikoCallbackTest : AbstractTest() {
             // I set dumpSourceOnExecutionError because I want test also the sourceLine presence in case
             // of runtime error
             options = Options(debuggingInformation = true, dumpSourceOnExecutionError = true)
+            reloadConfig = createMockReloadConfig()
         }
         kotlin.runCatching {
             executePgm(pgm, configuration = configuration)
@@ -590,5 +593,22 @@ class JarikoCallbackTest : AbstractTest() {
                 Assert.assertEquals(lines[it.absoluteLine!! - 1], it.fragment)
             }
         }
+    }
+
+    private fun createMockReloadConfig(): ReloadConfig {
+        val metadataProducer = { file: String ->
+            FileMetadata(
+                name = file,
+                tableName = file,
+                recordFormat = file,
+                fields = listOf(
+                    DbField("FIELD1", StringType(10)),
+                    DbField("FIELD2", StringType(10)),
+                    DbField("FIELD3", StringType(10))
+                ),
+                accessFields = listOf("FIELD1")
+            )
+        }
+        return ReloadConfig(DBNativeAccessConfig(connectionsConfig = emptyList()), metadataProducer = metadataProducer)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR16.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR16.rpgle
@@ -1,0 +1,15 @@
+     V* ==============================================================
+     D* 02/05/24
+     D* Purpose: In case of files inclusion containing fields defined
+     D* with the same name but different size jariko must throw
+     D* recognizable errors
+     V* ==============================================================
+
+     D* FILE01 and FILE02 meta data are programmatically created in JarikoCallBackTest
+     FFILE01    IF   E           K DISK
+
+     D* Jariko should throw an error related the below line of code
+     FFILE02    IF   E           K DISK
+
+
+     


### PR DESCRIPTION
## Description

The `Incongruous definitions` error thrown by Jariko when it checks if in the `DataDefinition` list there is at least a pair of `DataDefinition` instances with the same name but different types, did not contain the `position` property and then, the notified `ErrorEvent` was missing of `sourceReference` property, needed in the context of massive syntax checking.


## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
