### PR TITLE
Bugfix/nw23001440/like referencing PARM inline definition

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -270,9 +270,17 @@ open class BaseCompileTimeInterpreter(
     private fun Cspec_fixedContext.findType(declName: String, conf: ToAstConfiguration): Type? {
         val ast = this.toAst(conf)
         if (ast is StatementThatCanDefineData) {
+            /**
+             * If ast does not have a parent we consider it to be part of a CU
+             * to accomodate resolution in CU scoping (see PListStmt)
+             */
+            if (ast.parent == null) {
+                ast.parent = CompilationUnit.empty()
+            }
+
             val dataDefinition = ast.dataDefinition()
             dataDefinition.forEach {
-                if (it.name.asValue().value == declName) {
+                if (it.name == declName) {
                     return it.type
                 }
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -270,14 +270,6 @@ open class BaseCompileTimeInterpreter(
     private fun Cspec_fixedContext.findType(declName: String, conf: ToAstConfiguration): Type? {
         val ast = this.toAst(conf)
         if (ast is StatementThatCanDefineData) {
-            /**
-             * If ast does not have a parent we consider it to be part of a CU
-             * to accomodate resolution in CU scoping (see PListStmt)
-             */
-            if (ast.parent == null) {
-                ast.parent = CompilationUnit.empty()
-            }
-
             val dataDefinition = ast.dataDefinition()
             dataDefinition.forEach {
                 if (it.name == declName) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1031,12 +1031,14 @@ data class PlistStmt(
 
     override fun dataDefinition(): List<InStatementDataDefinition> {
         val allDataDefinitions = params.mapNotNull { it.dataDefinition }
-        // We do not want params in plist to shadow existing data definitions
-        // They are implicit data definitions only when explicit data definitions are not present
+        /**
+         * We do not want params in plist to shadow existing data definitions
+         * They are implicit data definitions only when explicit data definitions are not present
+         * Does not apply when we are not in a CU (for example with CompileTimeInterpreter)
+         */
         val filtered = allDataDefinitions.filter { paramDataDef ->
             val containingCU = this.ancestor(CompilationUnit::class.java)
-                ?: throw IllegalStateException("Not contained in a CU")
-            containingCU.dataDefinitions.none { it.name == paramDataDef.name }
+            containingCU?.dataDefinitions?.none { it.name == paramDataDef.name } ?: true
         }
         return filtered
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -95,8 +95,8 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * Inline definition on KFLD
-     * @see #277
+     * CALL with params defined in line and in D-spec
+     * @see #278
      */
     @Test
     fun executeMU106011() {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -93,4 +93,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("ABCDEFGHIL, 12")
         assertEquals(expected, "smeup/MU105501".outputOf())
     }
+
+    /**
+     * Inline definition on KFLD
+     * @see #277
+     */
+    @Test
+    fun executeMU106011() {
+        val expected = listOf("CALL(mod:inp   )")
+        assertEquals(expected, "smeup/MU106011".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU106011.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU106011.rpgle
@@ -1,0 +1,47 @@
+      *====================================================================
+      * smeup V6R1.021DV
+      * Nome sorgente       : MU106011
+      * Sorgente di origine : QTEMP/SRC(MU106011)
+      * Esportato il        : 20240429 170425
+      *====================================================================
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 29/04/24  MUTEST  GUAGIA Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O *
+     V* ==============================================================
+     D A60_D1          S             10
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      /COPY QILEGEN,£TABB£1DS
+      /COPY QILEGEN,£PDS
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU106011'
+     C                   EVAL      £DBG_Sez = 'A60'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A60
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico LIKEDS
+      *---------------------------------------------------------------------
+     C     SEZ_A60       BEGSR
+    OA* A£.CDOP(CALL;PLIST;PARM)
+     D* CALL con parametri definiti in line e in specifiche D
+     C                   EVAL      £DBG_Pas='P10'
+     C                   EVAL      A60_D1='inp'
+     C                   CALL      'MULANGTD10'
+     C                   PARM                    A60_D1
+     C                   EVAL      £DBG_Str='CALL('+A60_D1+')'
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MULANGTD10.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MULANGTD10.rpgle
@@ -1,0 +1,20 @@
+      *====================================================================
+      * smeup V6R1.021DV
+      * Nome sorgente       : MULANGTD10
+      * Sorgente di origine : QTEMP/SRC(MULANGTD10)
+      * Esportato il        : 20240429 170419
+      *====================================================================
+     V*=====================================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V*=====================================================================
+     V* 29/04/24  V6R1    GUAGIA Creazione
+     V*=====================================================================
+     D VARPARM         S                   LIKE(£VARPARM)
+      *---------------------------------------------------------------------
+     C     *ENTRY        PLIST
+     C                   PARM                    £VARPARM         10
+     C                   EVAL      VARPARM=':'+%TRIM(£VARPARM)
+     C                   EVAL      £VARPARM='mod'+%TRIM(VARPARM)
+      *
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description

Allow D-spec definition using LIKE keyword referencing an inline data definition provided by a PARM in PlistStmt.

Related to:
- MU106011

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
