### PR TITLE
Feature/improve error event

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -18,12 +18,15 @@ package com.smeup.rpgparser.execution
 
 import com.smeup.dbnative.DBNativeAccessConfig
 import com.smeup.rpgparser.interpreter.*
+import com.smeup.rpgparser.parsing.ast.Api
+import com.smeup.rpgparser.parsing.ast.ApiId
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.smeup.rpgparser.parsing.ast.MockStatement
 import com.smeup.rpgparser.parsing.facade.CopyBlocks
 import com.smeup.rpgparser.parsing.facade.CopyId
 import com.smeup.rpgparser.parsing.facade.SourceReference
 import com.smeup.rpgparser.parsing.parsetreetoast.ToAstConfiguration
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import java.io.File
 
 const val DEFAULT_ACTIVATION_GROUP_NAME: String = "*DFTACTGRP"
@@ -124,6 +127,8 @@ data class Options(
  * @param channelLoggingEnabled If specified, it allows to enable programmatically the channel logging.
  * For instance, you can enable all channels by using [consoleVerboseConfiguration] but you can decide, through
  * the implementation of this callback, which channel you want to log.
+ * @param onMockStatement If specified, it allows customizing the behavior of the mock statements.
+ * @param onApiInclusion If specified, it allows overriding the default mechanism of API validation.
  * */
 data class JarikoCallback(
     var getActivationGroup: (programName: String, associatedActivationGroup: ActivationGroup?) -> ActivationGroup? = { _: String, _: ActivationGroup? ->
@@ -168,7 +173,16 @@ data class JarikoCallback(
      * This is called for those statements mocked.
      * @param mockStatement "Statement" where is get its name for the `println`.
      */
-    var onMockStatement: ((mockStatement: MockStatement) -> Unit) = { System.err.println("Executing mock: ${it.javaClass.simpleName}") }
+    var onMockStatement: ((mockStatement: MockStatement) -> Unit) = { System.err.println("Executing mock: ${it.javaClass.simpleName}") },
+    /**
+     * This is called before the Api is included in the main program.
+     * Default implementation resolves and validates the compilationUnit related the API.
+     * @param apiId The id of the API
+     * @param api The API to include
+     * */
+    var onApiInclusion: ((apiId: ApiId, api: Api) -> Unit) = { _, api ->
+        api.compilationUnit.resolveAndValidate()
+    }
 )
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/api.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/api.kt
@@ -1,7 +1,6 @@
 package com.smeup.rpgparser.parsing.ast
 
 import com.smeup.rpgparser.parsing.facade.RpgParserFacade
-import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Position
 import kotlinx.serialization.Serializable
@@ -72,10 +71,6 @@ data class ApiDescriptor(
  * @see Api.loadApi
  * */
 data class Api(val compilationUnit: CompilationUnit) {
-
-    init {
-        compilationUnit.resolveAndValidate()
-    }
 
     companion object {
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/api.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/api.kt
@@ -1,6 +1,7 @@
 package com.smeup.rpgparser.parsing.ast
 
 import com.smeup.rpgparser.parsing.facade.RpgParserFacade
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Position
 import kotlinx.serialization.Serializable
@@ -71,6 +72,10 @@ data class ApiDescriptor(
  * @see Api.loadApi
  * */
 data class Api(val compilationUnit: CompilationUnit) {
+
+    init {
+        compilationUnit.resolveAndValidate()
+    }
 
     companion object {
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/api.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/api.kt
@@ -52,7 +52,9 @@ private fun CompilationUnit.includeApi(apiId: ApiId): CompilationUnit {
     return apiId.runNode {
         val parentPgmName = MainExecutionContext.getExecutionProgramName()
         MainExecutionContext.setExecutionProgramName(apiId.toString())
-        val api = MainExecutionContext.getSystemInterface()!!.findApi(apiId).validate()
+        val api = MainExecutionContext.getSystemInterface()!!.findApi(apiId).apply {
+            MainExecutionContext.getConfiguration().jarikoCallback.onApiInclusion(apiId, this)
+        }.validate()
         this.copy(
             fileDefinitions = this.fileDefinitions.include(api.compilationUnit.fileDefinitions),
             dataDefinitions = this.dataDefinitions.include(api.compilationUnit.dataDefinitions),

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/api.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/api.kt
@@ -50,6 +50,7 @@ internal fun List<RpgParser.StatementContext>.toApiDescriptors(conf: ToAstConfig
 
 private fun CompilationUnit.includeApi(apiId: ApiId): CompilationUnit {
     return apiId.runNode {
+        val parentPgmName = MainExecutionContext.getExecutionProgramName()
         MainExecutionContext.setExecutionProgramName(apiId.toString())
         val api = MainExecutionContext.getSystemInterface()!!.findApi(apiId).validate()
         this.copy(
@@ -63,7 +64,9 @@ private fun CompilationUnit.includeApi(apiId: ApiId): CompilationUnit {
                 this.apiDescriptors?.plus(it)
             } ?: this.apiDescriptors,
             procedures = this.procedures.let { it ?: listOf() }.includeProceduresWithoutDuplicates(api.compilationUnit.procedures.let { it ?: listOf() })
-        )
+        ).apply {
+            MainExecutionContext.setExecutionProgramName(parentPgmName)
+        }
     }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -167,11 +167,9 @@ private fun CompilationUnit.resolve() {
 
     this.specificProcess(ExecuteSubroutine::class.java) { esr ->
         if (!esr.subroutine.resolved) {
-            esr.runNode {
-                kotlin.runCatching {
-                    require(esr.subroutine.tryToResolve(this.subroutines, caseInsensitive = true)) {
-                        "Subroutine call not resolved: ${esr.subroutine.name}"
-                    }
+            kotlin.runCatching {
+                esr.require(esr.subroutine.tryToResolve(this.subroutines, caseInsensitive = true)) {
+                    "Subroutine call not resolved: ${esr.subroutine.name}"
                 }
             }
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/SmeupInterpreterTest.kt
@@ -25,6 +25,7 @@ open class SmeupInterpreterTest : AbstractTest() {
         smeupConfig.reloadConfig = ReloadConfig(
             nativeAccessConfig = DBNativeAccessConfig(emptyList()),
             metadataProducer = { dbFile: String -> reloadConfig.getMetadata(dbFile = dbFile) })
+        smeupConfig.options.debuggingInformation = true
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -484,6 +484,26 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR20SourceLineTest() {
+        executeSourceLineTest("ERROR20")
+    }
+
+    @Test
+    fun executeERROR21CallBackTest() {
+        executePgmCallBackTest("ERROR21", SourceReferenceType.Program, "ERROR21", listOf(9, 10))
+    }
+
+    @Test
+    fun executeERROR21SourceLineTest() {
+        executeSourceLineTest("ERROR21")
+    }
+
+    @Test
+    fun executeERROR20CallBackTest() {
+        executePgmCallBackTest("ERROR20", SourceReferenceType.Program, "ERROR20", listOf(7, 8))
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -462,6 +462,16 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR18CallBackTest() {
+        executePgmCallBackTest("ERROR18", SourceReferenceType.Program, "ERROR18", listOf(10))
+    }
+
+    @Test
+    fun executeERROR18SourceLineTest() {
+        executeSourceLineTest("ERROR18")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -452,6 +452,16 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR17CallBackTest() {
+        executePgmCallBackTest("ERROR17", SourceReferenceType.Program, "ERROR17", listOf(12))
+    }
+
+    @Test
+    fun executeERROR17SourceLineTest() {
+        executeSourceLineTest("ERROR17")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -472,6 +472,18 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR19CallBackTest() {
+        // In this case the error occurs inside APIERR1
+        executePgmCallBackTest("APIERR1", SourceReferenceType.Program, "APIERR1", listOf(7, 7, 7))
+    }
+
+    @Test
+    fun executeERROR19SourceLineTest() {
+        // In this case the error occurs inside APIERR1
+        executeSourceLineTest("APIERR1")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {
@@ -604,7 +616,9 @@ class JarikoCallbackTest : AbstractTest() {
         val errorEvents = mutableListOf<ErrorEvent>()
         val configuration = Configuration().apply {
             jarikoCallback.beforeParsing = { it ->
-                lines = StringReader(it).readLines()
+                if (MainExecutionContext.getParsingProgramStack().peek().name == pgm) {
+                    lines = StringReader(it).readLines()
+                }
                 it
             }
             jarikoCallback.onError = { errorEvents.add(it) }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
@@ -27,22 +27,24 @@ open class MULANGT70CompilationDirectiveTest : MULANGTTest() {
     /**
      * Data definition under dependencies.
      * @see #265
-     * Currently this test fails because MU711003 include an /API (QILEGEN,£PRZ) not formally valid.
      */
     @Test
     fun executeMU711003() {
         val expected = listOf("A71_01(0) A71_02(3) A71_03(F)")
-        assertEquals(expected, "smeup/MU711003".outputOf(configuration = smeupConfig))
+        // Since QILEGEN,£PRZ is not formally correct API I override the API resolution.
+        val myConfig = smeupConfig.copy().apply { jarikoCallback.onApiInclusion = { _, _ -> } }
+        assertEquals(expected, "smeup/MU711003".outputOf(configuration = myConfig))
     }
 
     /**
      * Data definition under dependencies.
      * @see #265
-     * Currently this test fails because MU711003 include an /API (QILEGEN,£C5PES) not formally valid.
      */
     @Test
     fun executeMU711004() {
         val expected = listOf("A71_01(0) A71_02(3) A71_03(F)")
-        assertEquals(expected, "smeup/MU711004".outputOf(configuration = smeupConfig))
+        // Since QILEGEN,£C5PES is not formally correct API I override the API resolution.
+        val myConfig = smeupConfig.copy().apply { jarikoCallback.onApiInclusion = { _, _ -> } }
+        assertEquals(expected, "smeup/MU711004".outputOf(configuration = myConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
@@ -27,6 +27,7 @@ open class MULANGT70CompilationDirectiveTest : MULANGTTest() {
     /**
      * Data definition under dependencies.
      * @see #265
+     * Currently this test fails because MU711003 include an /API (QILEGEN,£PRZ) not formally valid.
      */
     @Test
     fun executeMU711003() {
@@ -37,6 +38,7 @@ open class MULANGT70CompilationDirectiveTest : MULANGTTest() {
     /**
      * Data definition under dependencies.
      * @see #265
+     * Currently this test fails because MU711003 include an /API (QILEGEN,£C5PES) not formally valid.
      */
     @Test
     fun executeMU711004() {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGTTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGTTest.kt
@@ -29,5 +29,6 @@ abstract class MULANGTTest : AbstractTest() {
         smeupConfig.reloadConfig = ReloadConfig(
             nativeAccessConfig = DBNativeAccessConfig(emptyList()),
             metadataProducer = { dbFile: String -> reloadConfig.getMetadata(dbFile = dbFile) })
+        smeupConfig.options.debuggingInformation = true
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/testing_utils.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/testing_utils.kt
@@ -663,6 +663,7 @@ fun compileAllMutes(dirs: List<String>, format: Format = Format.BIN, metadataPat
                         ?: error("resource $dbFile.json not found in $metadataPaths")
                 }
             )
+            options = Options(debuggingInformation = true)
         }
 
         val compiled = compile(

--- a/rpgJavaInterpreter-core/src/test/resources/APIERR1.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/APIERR1.rpgle
@@ -1,0 +1,10 @@
+      * This API contains an intentionally mistake
+      * It tries to add X to Y return the Z but
+      * none of them is defined
+      *--------------------------------------------------------------*
+     C     SUM           BEGSR
+      *
+     C                   EVAL      Z = X + Y
+      *
+     C                   ENDSR
+      *--------------------------------------------------------------*

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR17.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR17.rpgle
@@ -1,0 +1,14 @@
+     V* ==============================================================
+     D* 02/05/24
+     D* Purpose: Test the right behavior in terms of error position
+     D* when an error occurs after a not included copy because included earlier
+     V* ==============================================================
+
+     D* In QILEGEN,£PDS we have "IF NOT DEFINE" directive that prevents the inclusion of the same copy
+       /COPY QILEGEN,£PDS
+       /COPY QILEGEN,£PDS
+
+      * Display MSG that not exists
+     C     MSG           DSPLY
+
+     

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR18.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR18.rpgle
@@ -1,0 +1,12 @@
+     V* ==============================================================
+     D* 02/05/24
+     D* Purpose: Test the right behavior in terms of error position
+     D* when an error occurs after an included API
+     V* ==============================================================
+
+      /API APIMATH
+
+      * Display MSG that not exists
+     C     MSG          DSPLY
+
+     

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR19.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR19.rpgle
@@ -1,10 +1,10 @@
      V* ==============================================================
      D* 02/05/24
      D* Purpose: Test the right behavior in terms of error position
-     D* when an error occurs after an included API
+     D* when an error occurs inside an included API
      V* ==============================================================
 
-      /API APIMATH
+      /API APIERR1
 
       * Display MSG that not exists
      C     MSG           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR20.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR20.rpgle
@@ -1,0 +1,8 @@
+     V* ==============================================================
+     D* Subroutine £MYSUB not resolved test
+     D* Jariko must fire two error events:
+     D*  - data reference not resolved £MYVAR at line 7
+     D*  - subroutine call not resolved £MYSUB at line 8
+     V* ==============================================================
+     C                   MOVEL(P)  'D1'          £MYVAR1
+     C                   EXSR      £MYSUB

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR21.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR21.rpgle
@@ -1,0 +1,11 @@
+     V* ==============================================================
+     D* Subroutine £MYSUB not resolved test when EXSR is inside
+     D* another subroutine
+     D* Jariko must fire two error events:
+     D*  - data reference not resolved £MYVAR at line 9
+     D*  - subroutine call not resolved £MYSUB at line 10
+     V* ==============================================================
+     C     SUB           BEGSR
+     C                   MOVEL(P)  'D1'          £MYVAR1
+     C                   EXSR      £MYSUB
+     C                   ENDSR


### PR DESCRIPTION
## Description

**Syntax and resolution errors in /API**
Before being included in a program, now the API are resolved and validated similar to a program.
To override this new constraint, you can pass a no-op function to the `JarikoCallback.onApiInclusion` callback.

**Error in subroutine call resolution**
The error event that was triggered was completely wrong, as it always reported the first line of the program as the line number and fragment.


## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
