### PR TITLE
bufix/"data_not_resolved" errors shadowed by "missing resolution" errors

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/errors.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/errors.kt
@@ -166,6 +166,12 @@ internal fun ParserRuleContext.require(value: Boolean, lazyMessage: () -> String
 }
 
 internal fun checkAstCreationErrors(phase: AstHandlingPhase) {
+    // If the parsing program stack is greater than 1, it means: I am parsing an API.
+    // The errors inside API must never be blocking else I run the risk
+    // to skip all errors related to the main program occurring after the API inclusions
+    if (MainExecutionContext.getParsingProgramStack().size > 1) {
+        return
+    }
     if (getAstCreationErrors().isNotEmpty()) {
         if (MainExecutionContext.getConfiguration().options?.toAstConfiguration?.afterPhaseErrorContinue?.invoke(phase) != true) {
             throw getAstCreationErrors()[0]

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -504,6 +504,16 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR22CallBackTest() {
+        executePgmCallBackTest("ERROR22", SourceReferenceType.Program, "ERROR22", listOf(10, 11))
+    }
+
+    @Test
+    fun executeERROR22SourceLineTest() {
+        executeSourceLineTest("ERROR22")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR22.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR22.rpgle
@@ -1,0 +1,13 @@
+     V* ==============================================================
+     D* 09/05/24
+     D* Purpose: Must fire the following errors
+     D* line 10 - MSG not resolved
+     D* line 11 - DUMMY not implemented
+     V* ==============================================================
+
+      /API APIMATH
+
+     C     MSG           DSPLY
+     C                   DUMMY
+
+     


### PR DESCRIPTION
## Description

The "data reference not resolved errors" were shadowed by "missing resolution errors" in programs containing /API directive.


## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
