### PR TITLE
Feature/ls24002651/Implements DOUxx

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -58,6 +58,7 @@ private val modules = SerializersModule {
         subclass(DivStmt::class)
         subclass(DoStmt::class)
         subclass(DouStmt::class)
+        subclass(DOUxxStmt::class)
         subclass(DowStmt::class)
         subclass(DOWxxStmt::class)
         subclass(EvalStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
@@ -56,6 +56,7 @@ internal fun BlockContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
         this.csDOWxx() != null -> this.csDOWxx().toAst(blockContext = this, conf = conf)
         this.forstatement() != null -> this.forstatement().toAst(conf)
         this.begindou() != null -> this.begindou().toAst(blockContext = this, conf = conf)
+        this.csDOUxx() != null -> this.csDOUxx().toAst(blockContext = this, conf = conf)
         this.monitorstatement() != null -> this.monitorstatement().let {
             it.beginmonitor().csMONITOR().cspec_fixed_standard_parts().validate(
                 stmt = it.toAst(conf = conf),
@@ -89,6 +90,42 @@ internal fun RpgParser.CsDOWxxContext.toAst(blockContext: BlockContext, conf: To
     val factor2Ast = factor2.toAstIfSymbolicConstant() ?: factor2.content.toAst(conf)
 
     return DOWxxStmt(
+        comparisonOperator = comparison,
+        factor1 = this.factor1.content.toAst(conf = conf),
+        factor2 = factor2Ast,
+        position = toPosition(conf.considerPosition),
+        body = blockContext.statement().map { it.toAst(conf) }
+    )
+}
+
+/**
+ * In accord to official documentation, the condition of DOUxx is for to quit from block,
+ *  instead for execute it like the new programming languages.
+ * @see https://www.ibm.com/docs/en/i/7.5?topic=codes-douxx-do-until
+ */
+internal fun RpgParser.CsDOUxxContext.toAst(blockContext: BlockContext, conf: ToAstConfiguration = ToAstConfiguration()): DOUxxStmt {
+    val comparison = when {
+        this.csDOUEQ() != null -> ComparisonOperator.NE
+        this.csDOUNE() != null -> ComparisonOperator.EQ
+        this.csDOUGT() != null -> ComparisonOperator.LE
+        this.csDOUGE() != null -> ComparisonOperator.LT
+        this.csDOULT() != null -> ComparisonOperator.GE
+        this.csDOULE() != null -> ComparisonOperator.GT
+        else -> todo(conf = conf)
+    }
+    val factor2 = when {
+        this.csDOUEQ() != null -> this.csDOUEQ().cspec_fixed_standard_parts().factor2
+        this.csDOUNE() != null -> this.csDOUNE().cspec_fixed_standard_parts().factor2
+        this.csDOUGT() != null -> this.csDOUGT().cspec_fixed_standard_parts().factor2
+        this.csDOUGE() != null -> this.csDOUGE().cspec_fixed_standard_parts().factor2
+        this.csDOULT() != null -> this.csDOULT().cspec_fixed_standard_parts().factor2
+        this.csDOULE() != null -> this.csDOULE().cspec_fixed_standard_parts().factor2
+        else -> todo(conf = conf)
+    }
+
+    val factor2Ast = factor2.toAstIfSymbolicConstant() ?: factor2.content.toAst(conf)
+
+    return DOUxxStmt(
         comparisonOperator = comparison,
         factor1 = this.factor1.content.toAst(conf = conf),
         factor2 = factor2Ast,

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
@@ -84,7 +84,7 @@ open class MULANGT12LoopFlowGotoTest : MULANGTTest() {
      */
     @Test
     fun executeMU120905() {
-        val expected = listOf("A09_N1: 11")
+        val expected = listOf("A09_N2: 11")
         assertEquals(expected, "smeup/MU120905".outputOf())
     }
 
@@ -93,7 +93,7 @@ open class MULANGT12LoopFlowGotoTest : MULANGTTest() {
      */
     @Test
     fun executeMU120906() {
-        val expected = listOf("A09_N1: 10")
+        val expected = listOf("A09_N2: 10")
         assertEquals(expected, "smeup/MU120906".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT12LoopFlowGotoTest.kt
@@ -42,4 +42,58 @@ open class MULANGT12LoopFlowGotoTest : MULANGTTest() {
         val expected = listOf("OK")
         assertEquals(expected, "smeup/MU120214".outputOf())
     }
+
+    /**
+     * DOUEQ
+     */
+    @Test
+    fun executeMU120901() {
+        val expected = listOf("A09_N2: 1")
+        assertEquals(expected, "smeup/MU120901".outputOf())
+    }
+
+    /**
+     * DOUNE
+     */
+    @Test
+    fun executeMU120902() {
+        val expected = listOf("A09_N2: 1")
+        assertEquals(expected, "smeup/MU120902".outputOf())
+    }
+
+    /**
+     * DOUGT
+     */
+    @Test
+    fun executeMU120903() {
+        val expected = listOf("A09_N1: 11")
+        assertEquals(expected, "smeup/MU120903".outputOf())
+    }
+
+    /**
+     * DOUGE
+     */
+    @Test
+    fun executeMU120904() {
+        val expected = listOf("A09_N1: 10")
+        assertEquals(expected, "smeup/MU120904".outputOf())
+    }
+
+    /**
+     * DOULT
+     */
+    @Test
+    fun executeMU120905() {
+        val expected = listOf("A09_N1: 11")
+        assertEquals(expected, "smeup/MU120905".outputOf())
+    }
+
+    /**
+     * DOULE
+     */
+    @Test
+    fun executeMU120906() {
+        val expected = listOf("A09_N1: 10")
+        assertEquals(expected, "smeup/MU120906".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU120901.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU120901.rpgle
@@ -1,0 +1,41 @@
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 14/05/24  MUTEST  APU001 Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * L'obiettivo di questo test è quello di verificare
+    O *  il funzionamento del DOUxx, in particolare del DOUEQ.
+     V* ==============================================================
+     DA09_N1           S              3I 0    INZ(1)
+     DA09_N2           S              3I 0    INZ(0)
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU120901'
+     C                   EVAL      £DBG_Sez = 'A09'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A09
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico DOUEQ
+      *---------------------------------------------------------------------
+     C     SEZ_A09       BEGSR
+    OA* A£.COOP(DOUEQ)
+     C                   EVAL      £DBG_Pas='P01'
+      *
+     C     A09_N1        DOUEQ     A09_N2
+     C                   ADD       1             A09_N2
+     C                   EVAL      £DBG_Str='A09_N2: ' + %CHAR(A09_N2)
+     C                   ENDDO
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU120902.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU120902.rpgle
@@ -1,0 +1,41 @@
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 15/05/24  MUTEST  APU001 Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * L'obiettivo di questo test è quello di verificare
+    O *  il funzionamento del DOUxx, in particolare del DOUNE.
+     V* ==============================================================
+     DA09_N1           S              3I 0    INZ(2)
+     DA09_N2           S              3I 0    INZ(0)
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU120902'
+     C                   EVAL      £DBG_Sez = 'A09'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A09
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico DOUNE
+      *---------------------------------------------------------------------
+     C     SEZ_A09       BEGSR
+    OA* A£.COOP(DOUNE)
+     C                   EVAL      £DBG_Pas='P02'
+      *
+     C     A09_N1        DOUNE     A09_N2
+     C                   ADD       1             A09_N2
+     C                   EVAL      £DBG_Str='A09_N2: ' + %CHAR(A09_N2)
+     C                   ENDDO
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU120903.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU120903.rpgle
@@ -1,0 +1,41 @@
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 15/05/24  MUTEST  APU001 Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * L'obiettivo di questo test è quello di verificare
+    O *  il funzionamento del DOUxx, in particolare del DOUGT.
+     V* ==============================================================
+     DA09_N1           S              3I 0    INZ(0)
+     DA09_N2           S              3I 0    INZ(10)
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU120903'
+     C                   EVAL      £DBG_Sez = 'A09'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A09
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico DOUGT
+      *---------------------------------------------------------------------
+     C     SEZ_A09       BEGSR
+    OA* A£.COOP(DOUGT)
+     C                   EVAL      £DBG_Pas='P03'
+      *
+     C     A09_N1        DOUGT     A09_N2
+     C                   ADD       1             A09_N1
+     C                   EVAL      £DBG_Str='A09_N1: ' + %CHAR(A09_N1)
+     C                   ENDDO
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU120904.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU120904.rpgle
@@ -1,0 +1,41 @@
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 15/05/24  MUTEST  APU001 Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * L'obiettivo di questo test è quello di verificare
+    O *  il funzionamento del DOUxx, in particolare del DOUGE.
+     V* ==============================================================
+     DA09_N1           S              3I 0    INZ(0)
+     DA09_N2           S              3I 0    INZ(10)
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU120904'
+     C                   EVAL      £DBG_Sez = 'A09'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A09
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico DOUGE
+      *---------------------------------------------------------------------
+     C     SEZ_A09       BEGSR
+    OA* A£.COOP(DOUGE)
+     C                   EVAL      £DBG_Pas='P04'
+      *
+     C     A09_N1        DOUGE     A09_N2
+     C                   ADD       1             A09_N1
+     C                   EVAL      £DBG_Str='A09_N1: ' + %CHAR(A09_N1)
+     C                   ENDDO
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU120905.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU120905.rpgle
@@ -1,0 +1,41 @@
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 15/05/24  MUTEST  APU001 Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * L'obiettivo di questo test è quello di verificare
+    O *  il funzionamento del DOUxx, in particolare del DOULT.
+     V* ==============================================================
+     DA09_N1           S              3I 0    INZ(10)
+     DA09_N2           S              3I 0    INZ(0)
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU120905'
+     C                   EVAL      £DBG_Sez = 'A09'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A09
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico DOULT
+      *---------------------------------------------------------------------
+     C     SEZ_A09       BEGSR
+    OA* A£.COOP(DOULT)
+     C                   EVAL      £DBG_Pas='P05'
+      *
+     C     A09_N1        DOULT     A09_N2
+     C                   ADD       1             A09_N2
+     C                   EVAL      £DBG_Str='A09_N2: ' + %CHAR(A09_N2)
+     C                   ENDDO
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU120906.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU120906.rpgle
@@ -1,0 +1,41 @@
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 15/05/24  MUTEST  APU001 Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * L'obiettivo di questo test è quello di verificare
+    O *  il funzionamento del DOUxx, in particolare del DOULE.
+     V* ==============================================================
+     DA09_N1           S              3I 0    INZ(10)
+     DA09_N2           S              3I 0    INZ(0)
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU120906'
+     C                   EVAL      £DBG_Sez = 'A09'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A09
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico DOULE
+      *---------------------------------------------------------------------
+     C     SEZ_A09       BEGSR
+    OA* A£.COOP(DOULE)
+     C                   EVAL      £DBG_Pas='P06'
+      *
+     C     A09_N1        DOULE     A09_N2
+     C                   ADD       1             A09_N2
+     C                   EVAL      £DBG_Str='A09_N2: ' + %CHAR(A09_N2)
+     C                   ENDDO
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C


### PR DESCRIPTION
## Description
This PR implements the `DOUxx` operator, where `xx` could be a compare operation like `GT`, `LT`, `EQ`, `NE`, `GE`, and `LE`. For each of them there is one atomic test.

In accord to [official documentation](https://www.ibm.com/docs/en/i/7.5?topic=codes-douxx-do-until), the condition of DOUxx is for to quit from block, instead for executing it like the new programming languages.

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
