### PR TITLE
Bugfix/Patch for RENAME attribute on file opening 

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -164,7 +164,7 @@ internal fun FileDefinition.toDataDefinitions(): List<DataDefinition> {
     }.onFailure { error ->
         error("Not found metadata for $this", error)
     }.getOrNull() ?: error("Not found metadata for $this")
-    if (internalFormatName == null) internalFormatName = metadata.tableName
+    if (internalFormatName == null) internalFormatName = metadata.recordFormat
     dataDefinitions.addAll(
         metadata.fields.map { dbField ->
             dbField.toDataDefinition(prefix = prefix, position = position).apply {
@@ -181,7 +181,7 @@ internal fun FileDefinition.toDataDefinitions(): List<DataDefinition> {
     // record format possibly for file video is unuseful
     if (fileType == FileType.DB) {
         val recordFormatDefinition = DataDefinition(
-            name = metadata.recordFormat,
+            internalFormatName!!,
             type = RecordFormatType,
             position = position,
             fields = fieldsDefinition

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/OpenCloseTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/OpenCloseTest.kt
@@ -17,6 +17,7 @@
 package com.smeup.rpgparser.db
 
 import com.smeup.rpgparser.AbstractTest
+import com.smeup.rpgparser.db.utilities.createEmployeeMetadata
 import org.junit.Test
 import kotlin.test.assertEquals
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/OpenRenameTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/OpenRenameTest.kt
@@ -18,15 +18,13 @@ package com.smeup.rpgparser.db
 
 import com.smeup.rpgparser.AbstractTest
 import com.smeup.rpgparser.db.utilities.*
-import com.smeup.rpgparser.interpreter.StringValue
 import org.hsqldb.Server
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
-import kotlin.test.Ignore
 import kotlin.test.assertEquals
 
-open class ReadTest : AbstractTest() {
+open class OpenRenameTest : AbstractTest() {
 
     companion object {
 
@@ -46,41 +44,24 @@ open class ReadTest : AbstractTest() {
     }
 
     @Test
-    fun equalWithNoSetllReturnsFalse() {
+    fun testOpenWithoutRename() {
         val outputLines = outputOfDBPgm(
-            "db/EQUALNOSET",
-            listOf(createEmployeeMetadata()),
+            "db/OPEN",
+            listOf(createEmployeeMetadata("EMPLOY0F", "EMPLOYR")),
             emptyList(),
             emptyMap()
         )
-        assertEquals(listOf("EQUAL=0"), outputLines)
+        assertEquals(listOf("OK"), outputLines)
     }
 
     @Test
-    fun doesNotFindNonExistingRecord() {
-        assertEquals(
-            listOf("Not found"),
-            outputOfDBPgm(
-                "db/CHAINREADE",
-                listOf(createEmployeeMetadata()),
-                emptyList(),
-                mapOf("toFind" to StringValue("XXX"))
-            )
+    fun testWithRename() {
+        val outputLines = outputOfDBPgm(
+            "db/OPEN_RENAME",
+            listOf(createEmployeeMetadata("EMPLOY0F", "EMPLOYR")),
+            emptyList(),
+            emptyMap()
         )
-    }
-
-    @Test
-    @Ignore
-    fun findsExistingRecords2() {
-        assertEquals(
-            // TODO is the order of results mandatory?
-            listOf("SALLY KWAN", "DELORES QUINTANA", "HEATHER NICHOLLS", "KIM NATZ"),
-            outputOfDBPgm(
-                "db/CHAINREADE",
-                listOf(createEmployeeMetadata()),
-                emptyList(),
-                mapOf("toFind" to StringValue("C01"))
-            )
-        )
+        assertEquals(listOf("OK"), outputLines)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/StoreTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/StoreTest.kt
@@ -17,6 +17,9 @@
 package com.smeup.rpgparser.db
 
 import com.smeup.rpgparser.AbstractTest
+import com.smeup.rpgparser.db.utilities.createEMPLOYEE
+import com.smeup.rpgparser.db.utilities.createEmployeeMetadata
+import com.smeup.rpgparser.db.utilities.dropEMPLOYEE
 import com.smeup.rpgparser.db.utilities.execute
 import org.hsqldb.Server
 import org.junit.After

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/employeesTestDB.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/db/utilities/employeesTestDB.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.smeup.rpgparser.db
+package com.smeup.rpgparser.db.utilities
 
 import com.smeup.rpgparser.interpreter.DbField
 import com.smeup.rpgparser.interpreter.FileMetadata

--- a/rpgJavaInterpreter-core/src/test/resources/db/OPEN.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/db/OPEN.rpgle
@@ -1,0 +1,8 @@
+     FEMPLOY0F  IF   E           K DISK    USROPN
+     D £DBG_Str        S             10          VARYING
+     C                   EVAL      £DBG_Str='OK'
+     C                   OPEN      EMPLOY0F
+      * Execute clear of file record to test existence
+     C                   CLEAR                   EMPLOYR
+     C                   CLOSE     EMPLOY0F
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/db/OPEN_RENAME.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/db/OPEN_RENAME.rpgle
@@ -1,0 +1,9 @@
+     FEMPLOY0F  IF   E           K DISK    USROPN
+     F                                     RENAME(EMPLOYR:EMPLOYU)
+     D £DBG_Str        S             10          VARYING
+     C                   EVAL      £DBG_Str='OK'
+     C                   OPEN      EMPLOY0F
+      * Execute clear of renamed file record
+     C                   CLEAR                   EMPLOYU
+     C                   CLOSE     EMPLOY0F
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
Patch for RENAME attribute on file opening (including small refactoring for reload tests)

## Description

RENAME attribute on file opening now changes the name of the record format associated with the file, using the alias name.

Related to LS24002738 action

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
