### PR TITLE
Bugfix/ls24002758/xlate pattern with semicolon

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -141,7 +141,7 @@ fun String.toIntLiteral(position: Position?): IntLiteral {
 }
 
 internal fun RpgParser.IdentifierContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Expression {
-    if (this.text.toUpperCase().startsWith("*ALL")) {
+    if (this.text.uppercase().startsWith("*ALL")) {
         return AllExpr(this.all().literal().toAst(conf), toPosition(conf.considerPosition))
     }
 
@@ -149,7 +149,7 @@ internal fun RpgParser.IdentifierContext.toAst(conf: ToAstConfiguration = ToAstC
         return FunctionCall(ReferenceByName(this.text), listOf(), toPosition(conf.considerPosition))
     }
 
-    return when (this.text.toUpperCase()) {
+    return when (this.text.uppercase()) {
         "*BLANK", "*BLANKS" -> BlanksRefExpr(toPosition(conf.considerPosition))
         "*ZERO", "*ZEROS" -> ZeroExpr(toPosition(conf.considerPosition))
         "*HIVAL" -> HiValExpr(toPosition(conf.considerPosition))

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1396,20 +1396,19 @@ internal fun CsCHECKContext.toAst(conf: ToAstConfiguration): Statement {
 }
 
 private fun FactorContext.toDoubleExpression(conf: ToAstConfiguration, index: Int): Expression =
-    if (this.text.contains(":")) this.text.toDoubleExpression(toPosition(conf.considerPosition), index, conf) else this.content.toAst(conf)
+    if (this.text.contains(":")) this.text.toDoubleExpression(toPosition(conf.considerPosition), index) else this.content.toAst(conf)
 
-private fun String.toDoubleExpression(position: Position?, index: Int, conf: ToAstConfiguration): Expression {
-    val baseStringTokens = this.split(":")
-    val startPosition = 0
+private fun String.toDoubleExpression(position: Position?, index: Int): Expression {
+    val quoteAwareSplitPattern = Regex(""":(?=([^']*'[^']*')*[^']*$)""")
+    val baseStringTokens = this.split(quoteAwareSplitPattern)
     var reference = baseStringTokens[index]
-    val ret: Expression
 
     val regexp = Regex("'(.*?)'")
-    if (reference.matches(regexp)) {
+    val ret = if (reference.matches(regexp)) {
         reference = reference.replace("'", "")
-        ret = StringLiteral(reference, position)
+        StringLiteral(reference, position)
     } else {
-        ret = DataRefExpr(ReferenceByName(reference), position)
+        DataRefExpr(ReferenceByName(reference), position)
     }
     return ret
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/SymbolTableStoragingTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/SymbolTableStoragingTest.kt
@@ -113,7 +113,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
         commandLineProgram.singleCall(emptyList(), configuration)
         // verify if serialization is ok
         // get variables for memorysliceid
-        val variables = memoryStorage.storage[MemorySliceId("MyAct".toUpperCase(), programName = myProgram)]
+        val variables = memoryStorage.storage[MemorySliceId("MyAct".uppercase(), programName = myProgram)]
         require(variables != null)
         assertEquals(
             expected = varValue,
@@ -143,7 +143,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
      C                   SETON                                          RT
      """
         val commandLineProgram = getProgram(nameOrSource = myProgram)
-        val memorySliceId = MemorySliceId("MyAct".toUpperCase(), programName = myProgram)
+        val memorySliceId = MemorySliceId("MyAct".uppercase(), programName = myProgram)
         val memoryStorage = MemoryStorage()
         memoryStorage.storage[memorySliceId] = mutableMapOf("Y" to StringValue(value = varValue, varying = true))
         val configuration = Configuration(memorySliceStorage = memoryStorage)
@@ -173,7 +173,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
         val memoryStorage = MemoryStorage()
         val configuration = Configuration(memorySliceStorage = memoryStorage)
         commandLineProgram.singleCall(emptyList(), configuration)
-        val variables = memoryStorage.storage[MemorySliceId("MyAct".toUpperCase(), programName = myProgram)]
+        val variables = memoryStorage.storage[MemorySliceId("MyAct".uppercase(), programName = myProgram)]
         assertEquals(
             expected = null,
             actual = variables,
@@ -202,7 +202,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
         val configuration = Configuration(memorySliceStorage = memoryStorage)
         // First call, instatiate and initialize X variable to value 1
         commandLineProgram.singleCall(emptyList(), configuration)
-        var variables = memoryStorage.storage[MemorySliceId("MyAct".toUpperCase(), programName = myProgram)]
+        var variables = memoryStorage.storage[MemorySliceId("MyAct".uppercase(), programName = myProgram)]
         require(variables != null)
         assertEquals(
             expected = varValue.trim(),
@@ -211,7 +211,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
 
         // Second program execution, X variable must exist with value 1, than it will increase to value 2.
         commandLineProgram.singleCall(emptyList(), configuration)
-        variables = memoryStorage.storage[MemorySliceId("MyAct".toUpperCase(), programName = myProgram)]
+        variables = memoryStorage.storage[MemorySliceId("MyAct".uppercase(), programName = myProgram)]
         require(variables != null)
         assertEquals(
             expected = varValue.trim() + varValue.trim(),
@@ -236,12 +236,12 @@ open class SymbolTableStoragingTest : AbstractTest() {
      C                   SETON                                          RT
      """
         val commandLineProgram = getProgram(nameOrSource = myProgram)
-        val memorySliceId = MemorySliceId("MyAct".toUpperCase(), programName = myProgram)
+        val memorySliceId = MemorySliceId("MyAct".uppercase(), programName = myProgram)
         val memoryStorage = MemoryStorage()
         memoryStorage.storage[memorySliceId] = mutableMapOf("Z" to StringValue(value = varValue, varying = true))
         val configuration = Configuration(memorySliceStorage = memoryStorage)
         commandLineProgram.singleCall(emptyList(), configuration)
-        val variables = memoryStorage.storage[MemorySliceId("MyAct".toUpperCase(), programName = myProgram)]
+        val variables = memoryStorage.storage[MemorySliceId("MyAct".uppercase(), programName = myProgram)]
         require(variables != null)
         assertEquals(
             expected = varValue,
@@ -284,7 +284,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
 
         // First call to program A, instatiate and initialize Z variable to value ending with 'A' character.
         commandLineProgramA.singleCall(emptyList(), configuration)
-        var variables = memoryStorage.storage[MemorySliceId("MyActA".toUpperCase(), programName = myProgramA)]
+        var variables = memoryStorage.storage[MemorySliceId("MyActA".uppercase(), programName = myProgramA)]
         require(variables != null)
         assertEquals(
             expected = "${varValue}A",
@@ -293,7 +293,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
 
         // First call to program B, instatiate and initialize Z variable to value ending with 'B' character.
         commandLineProgramB.singleCall(emptyList(), configuration)
-        variables = memoryStorage.storage[MemorySliceId("MyActB".toUpperCase(), programName = myProgramB)]
+        variables = memoryStorage.storage[MemorySliceId("MyActB".uppercase(), programName = myProgramB)]
         require(variables != null)
         assertEquals(
             expected = "${varValue}B",
@@ -301,7 +301,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
         )
 
         // Z variable on MyActA must have previous value ending with 'A' character.
-        variables = memoryStorage.storage[MemorySliceId("MyActA".toUpperCase(), programName = myProgramA)]
+        variables = memoryStorage.storage[MemorySliceId("MyActA".uppercase(), programName = myProgramA)]
         require(variables != null)
         assertEquals(
             expected = "${varValue}A",
@@ -344,7 +344,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
 
         // First call to program A, instatiate and initialize Z variable to value ending with 'A' character.
         commandLineProgramA.singleCall(emptyList(), configuration)
-        var variables = memoryStorage.storage[MemorySliceId("MyActSAME".toUpperCase(), programName = myProgramA)]
+        var variables = memoryStorage.storage[MemorySliceId("MyActSAME".uppercase(), programName = myProgramA)]
         require(variables != null)
         assertEquals(
             expected = "${varValue}A",
@@ -353,7 +353,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
 
         // First call to program B, instatiate and initialize Z variable to value ending with 'B' character.
         commandLineProgramB.singleCall(emptyList(), configuration)
-        variables = memoryStorage.storage[MemorySliceId("MyActSAME".toUpperCase(), programName = myProgramB)]
+        variables = memoryStorage.storage[MemorySliceId("MyActSAME".uppercase(), programName = myProgramB)]
         require(variables != null)
         assertEquals(
             expected = "${varValue}B",
@@ -361,7 +361,7 @@ open class SymbolTableStoragingTest : AbstractTest() {
         )
 
         // Variable 'Z myProgramA scoped' have not changed his initial values, no interference between two programs
-        variables = memoryStorage.storage[MemorySliceId("MyActSAME".toUpperCase(), programName = myProgramA)]
+        variables = memoryStorage.storage[MemorySliceId("MyActSAME".uppercase(), programName = myProgramA)]
         require(variables != null)
         assertEquals(
             expected = "${varValue}A",

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -199,19 +199,15 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     }
 
     /**
-     * Data definition not resolved for a specification that uses `LIKE` to a field from file. In addition,
-     *  there is a DS with an `%ELEM()` built-in function to that field.
-     * @see #LS24002645
+     * Data definition not resolved for patterns containing the ':' in XLate factor 1
+     * @see #LS24002758
      */
     @Test
     fun executeMUDRNRAPU00201() {
-        MULANGTLDbMock().use {
-            com.smeup.rpgparser.db.utilities.execute(listOf(it.createTable(), it.populateTable()))
-            val expected = listOf("ok")
-            assertEquals(
-                expected = expected,
-                "smeup/MUDRNRAPU00201".outputOf(configuration = smeupConfig)
-            )
-        }
+        val expected = listOf("ok")
+        assertEquals(
+            expected = expected,
+            "smeup/MUDRNRAPU00201".outputOf(configuration = smeupConfig)
+        )
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -197,4 +197,21 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
             )
         }
     }
+
+    /**
+     * Data definition not resolved for a specification that uses `LIKE` to a field from file. In addition,
+     *  there is a DS with an `%ELEM()` built-in function to that field.
+     * @see #LS24002645
+     */
+    @Test
+    fun executeMUDRNRAPU00201() {
+        MULANGTLDbMock().use {
+            com.smeup.rpgparser.db.utilities.execute(listOf(it.createTable(), it.populateTable()))
+            val expected = listOf("ok")
+            assertEquals(
+                expected = expected,
+                "smeup/MUDRNRAPU00201".outputOf(configuration = smeupConfig)
+            )
+        }
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00201.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00201.rpgle
@@ -1,0 +1,10 @@
+     D £G90DS          DS           512
+     D  £G90TG                       20                                         Tag
+     D £G90SO          S          30000    VARYING
+     D £DBG_Str        S             2
+
+     C     ':':'.'       XLATE     £G90TG        £G90TG
+     C     ':':'.'       XLATE     £G90SO        £G90SO
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Update the split pattern in toDoubleExpression in order to make it aware of `:` characters when inside of a string.

> Note: some deprecated `toUpperCase()` calls also got updated to `uppercase()` calls to clear some very verbose warnings.

Related to:
- LS24002758

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
