### PR TITLE
Bugfix/ls24002821/api with comment

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -1893,7 +1893,8 @@ dir_api: (DIR_API
             (((library=copyText DIR_Slash)? file=copyText)? member=copyText)
             | (DIR_Slash? (copyText DIR_Slash)+ copyText)
            )
-          );
+          )
+          DIR_OtherText*;
 dir_include: (DIR_INCLUDE 
 		   (
 			(((library=copyText DIR_Slash)? file=copyText)? member=copyText)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -240,4 +240,17 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
             assertEquals(expected, "smeup/MUDRNRAPU00202".outputOf(configuration = smeupConfig))
         }
     }
+
+    /**
+     * Comments after API directive
+     * @see #LS24002821
+     */
+    @Test
+    fun executeMUDRNRAPU00205() {
+        val expected = listOf("HELLO THERE")
+        assertEquals(
+            expected = expected,
+            "smeup/MUDRNRAPU00205".outputOf(configuration = smeupConfig)
+        )
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00205.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00205.rpgle
@@ -1,0 +1,36 @@
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 28/05/24  MUTEST  APU001 Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * Testare la sostituzione su Jariko di /COPY con /API,
+    O *  avente un commento.
+    O * NB: Su AS400 per compilarli sostituire l'istruzione /API con /COPY.
+     V* ==============================================================
+      * --------------------------------------------------------------
+      /API QILEGEN,MULANG_D_D                  Definizioni
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU711005'
+     C                   EVAL      £DBG_Sez = 'A10'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A10
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* Test atomico /COPY con commento
+      *---------------------------------------------------------------------
+     C     SEZ_A10       BEGSR
+    OA* A£.CDOP(/API)
+     C                   EVAL      £DBG_Pas='P05'
+     C                   EVAL      £DBG_Str='HELLO THERE'
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C                   SR


### PR DESCRIPTION
## Description

Add grammar rule to allow for comments after API directives

Related to:
- LS24002821

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
