### PR TITLE
Fix performance regression

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -49,7 +49,7 @@ class ExpressionEvaluation(
     private fun evalAsDecimal(expression: Expression): BigDecimal = expression.evalWith(this).asDecimal().value
 
     private inline fun proxyLogging(expression: Expression, action: () -> Value): Value {
-        if (systemInterface.getAllLogHandlers().isEmpty()) return action()
+        if (!MainExecutionContext.isLoggingEnabled) return action()
 
         val programName = MainExecutionContext.getExecutionProgramName()
 


### PR DESCRIPTION
## Description

Fix performance regression caused by improper check in ExpressionEvaluation introduced in #510.

Related to: #510, #495

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
