### PR TITLE
Avoid logging reconfiguration

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -159,7 +159,7 @@ data class JarikoCallback(
         // If SystemInterface is not in the main execution context or in the SystemInterface there is no
         // logging configuration, the error event must be shown as before, else we run the risk to miss very helpful information
         MainExecutionContext.getSystemInterface()?.apply {
-            if (getAllLogHandlers().isErrorChannelConfigured()) {
+            if (MainExecutionContext.isErrorChannelConfigured) {
                 MainExecutionContext.log(LazyLogEntry.produceError(errorEvent))
             } else {
                 System.err.println(errorEvent)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
@@ -176,6 +176,11 @@ object MainExecutionContext {
     }
 
     /**
+     * Get all the log handlers
+     */
+    val logHandlers get(): List<InterpreterLogHandler> = context.get()?.logHandlers ?: emptyList()
+
+    /**
      * Checks if logging is enabled
      */
     val isLoggingEnabled get() = context.get()?.isLoggingEnabled ?: false
@@ -199,6 +204,11 @@ object MainExecutionContext {
      * @return true if context is already created
      * */
     fun isCreated() = context.get() != null
+
+    /**
+     * @return true if error log channel is configured
+     * */
+    val isErrorChannelConfigured get() = context.get()?.logHandlers?.isErrorChannelConfigured() ?: false
 }
 
 data class Context(
@@ -216,7 +226,7 @@ data class Context(
         DBFileFactory(it.nativeAccessConfig)
     }
 ) {
-    private val logHandlers: MutableList<InterpreterLogHandler> by lazy {
+    val logHandlers: MutableList<InterpreterLogHandler> by lazy {
         systemInterface.getAllLogHandlers()
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/runner.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/runner.kt
@@ -157,12 +157,12 @@ fun getProgram(
             systemInterface.rpgSystem.addProgramFinders(programFinders)
             programFinders.forEach {
                 val logSource = { LogSourceData.UNKNOWN }
-                systemInterface.getAllLogHandlers().renderLog(LazyLogEntry.produceResolution(logSource, it.toString()))
+                MainExecutionContext.logHandlers.renderLog(LazyLogEntry.produceResolution(logSource, it.toString()))
             }
         } else {
             // for compatibility with other system interfaces using singleton instance
             RpgSystem.SINGLETON_RPG_SYSTEM?.addProgramFinders(programFinders)
-            RpgSystem.SINGLETON_RPG_SYSTEM?.log(systemInterface.getAllLogHandlers())
+            RpgSystem.SINGLETON_RPG_SYSTEM?.log(MainExecutionContext.logHandlers)
         }
         CommandLineProgram(nameOrSource, systemInterface)
     }


### PR DESCRIPTION
## Description

Avoid to call `getAllLogHandlers` method of `SystemInterface` when possible as it tries, under the hood, to perform a logging reconfiguration. Improved `testPerformance` from 9m to 8m on my local machine.

Related to: #495, #508, #510 

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
