### PR TITLE
Perf/chain with cache

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -192,7 +192,8 @@ For example if you want to execute all tests trying the feature flag `jariko.fea
 | feature flag                              | description                                                                                       |
 |-------------------------------------------|---------------------------------------------------------------------------------------------------|
 | `jariko.features.UnlimitedStringTypeFlag` | when `on` you ask jariko to force the use of `UnlimitedStringType` for all rpg alphanumeric types |
-                                                                                                        |
+| `jariko.features.ChainCacheFlag`          | when `on` you ask jariko to use cache in the chain operations - default `on`                      |
+
 
 
 ## Creating a jar with all dependencies to run some examples

--- a/docs/development.md
+++ b/docs/development.md
@@ -161,17 +161,19 @@ Creating features factory: com.smeup.rpgparser.interpreter.StandardFeaturesFacto
 ------------------------------------------------------------------------------------
 Feature flags status:
  - jariko.features.UnlimitedStringTypeFlag: off
+ - jariko.features.ChainCacheFlag: on
 ------------------------------------------------------------------------------------
 ```
 
 This it means that jariko is using the default `IFeaturesFactory` implementation (creating features factory...), 
 but more relevant is the following part of the console message where it is displayed a list of available feature
 flags and their status.  
-What you see it means that currently jariko provides one feature flag named:
-`jariko.features.UnlimitedStringTypeFlag` and its status is `off`.
+What you see it means that currently jariko provides two features flag named:
+- `jariko.features.UnlimitedStringTypeFlag` and its status is `off`
+- `jariko.features.ChainCacheFlag` and its status is `on`.
 
 **how to switch on a feature flag at runtime**  
-Before to call jariko it is necessary set the system property like this:
+Before to call jariko as library it is necessary to set the system property like this:
 ```java
 System.setProperty(featureFlagName, "on");
 ```
@@ -180,19 +182,24 @@ and for example if you want to try `jariko.features.UnlimitedStringTypeFlag` you
 System.setProperty("jariko.features.UnlimitedStringTypeFlag", "on");
 ```
 
-**how to switch on a feature flag via cli**  
-For example if you want to execute all tests trying the feature flag `jariko.features.UnlimitedStringTypeFlag`:
+A more fine-grained control is possible by using the provided callback by implementing `featureFlagIsOn` like below:
+```kotlin
+private val turnOnChainCacheFlagConfig = Configuration().apply {
+    jarikoCallback.featureFlagIsOn = { featureFlag: FeatureFlag -> featureFlag == FeatureFlag.ChainCacheFlag }
+}
+val systemInterface = JavaSystemInterface(turnOnChainCacheFlagConfig)
+...
 ```
-./gradlew -Djariko.features.UnlimitedStringTypeFlag=on test
-```
+
+
 
 
 **available feature flags and description**
 
-| feature flag                              | description                                                                                       |
-|-------------------------------------------|---------------------------------------------------------------------------------------------------|
-| `jariko.features.UnlimitedStringTypeFlag` | when `on` you ask jariko to force the use of `UnlimitedStringType` for all rpg alphanumeric types |
-| `jariko.features.ChainCacheFlag`          | when `on` you ask jariko to use cache in the chain operations - default `on`                      |
+| feature flag                              | description                                                                                       | default |
+|-------------------------------------------|---------------------------------------------------------------------------------------------------| ------- |
+| `jariko.features.UnlimitedStringTypeFlag` | when `on` you ask jariko to force the use of `UnlimitedStringType` for all rpg alphanumeric types | `off`   |
+| `jariko.features.ChainCacheFlag`          | when `on` you ask jariko to use cache in the chain operations                                     | `on`    |
 
 
 

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hsqldb:hsqldb:2.5.0'
-    testImplementation 'io.mockk:mockk:1.9'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:5.3.1'
 }
 
 configurations.all() {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -182,7 +182,15 @@ data class JarikoCallback(
      * */
     var onApiInclusion: ((apiId: ApiId, api: Api) -> Unit) = { _, api ->
         api.compilationUnit.resolveAndValidate()
-    }
+    },
+
+    /**
+     * It allows overriding the feature flag check.
+     * @param featureFlag The feature flag
+     * @return true if the feature flag is on, false otherwise - default implementation returns the feature flag default value
+     * @see FeatureFlag.on
+     * */
+    var featureFlagIsOn: ((featureFlag: FeatureFlag) -> Boolean) = { featureFlag -> featureFlag.on }
 )
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -94,67 +94,102 @@ data class Options(
 }
 
 /**
- * Sometimes we have to gain control of Jariko, this is the right place.
- * It was primarily intended for future use.
- * @param getActivationGroup If specified, it overrides the activation group associated to the program.
- * Default null it means by Configuration.
- * Parameter programName is program for which we are getting activation group, associatedActivationGroup is the current
- * activation group associated to the program.
- * @param beforeCopyInclusion It is invoked before than the copy is included in the source, the default implementation
- * will return the copy source itself
- * @param afterCopiesInclusion It is invoked after that all copies has been included in the source.
- * **This callback will be called only if [Options.debuggingInformation] is set to true**.
- * @param beforeParsing It is invoked before the parsing. It is passed the source that will be parsed after all copy inclusion, the default implementation
- * will return source itself
- * @param exitInRT If specified, it overrides the exit mode established in program. Default null (nei seton rt od lr mode)
- * @param onInterpreterCreation It is invoked on Interpreter creation
- * @param onEnterPgm It is invoked on program enter after symboltable initialization.
- * @param onExitPgm It is invoked on program exit. In case of error it is no longer called, then even error parameter is no longer significant
- * @param afterAstCreation It is invoked after ast creation
- * @param onEnterCopy It is invoked on copy enter.
- * **This callback will be called only if [Options.debuggingInformation] is set to true**.
- * @param onExitCopy It is invoked on copy exit.
- * **This callback will be called only if [Options.debuggingInformation] is set to true**.
- * @param onEnterStatement It is invoked before statement execution.
- * **This callback will be called only if [Options.debuggingInformation] is set to true**.
- * See [JarikoCallback.onEnterStatement] for further information
- * @param onEnterFunction It is invoked on function enter after symboltable initialization.
- * @param onExitFunction It is invoked on function exit, only if the function does not throw any error
- * @param onError It is invoked in case of errors. The default implementation writes error event in stderr
- * @param onCallPgmError It is invoked in case of runtime errors accurred inside the program called only if the error indicator
- * at column 73-74 is specified. The default implementation does nothing
- * @param logInfo If specified, it is invoked to log information messages, for all channel enabled
- * @param channelLoggingEnabled If specified, it allows to enable programmatically the channel logging.
- * For instance, you can enable all channels by using [consoleVerboseConfiguration] but you can decide, through
- * the implementation of this callback, which channel you want to log.
- * @param onMockStatement If specified, it allows customizing the behavior of the mock statements.
- * @param onApiInclusion If specified, it allows overriding the default mechanism of API validation.
+ * Through this class, we can customize Jariko behavior.
  * */
 data class JarikoCallback(
+    /**
+     * If specified, it overrides the activation group associated to the program.
+     * Default null it means by Configuration.
+     * Parameter programName is a program for which we are getting activation group, associatedActivationGroup is the current
+     * activation group associated with the program.
+     * */
     var getActivationGroup: (programName: String, associatedActivationGroup: ActivationGroup?) -> ActivationGroup? = { _: String, _: ActivationGroup? ->
             null
     },
-    var beforeCopyInclusion: (copyId: CopyId, source: String?) -> String? = { _, source -> source },
-    var afterCopiesInclusion: (copyBlocks: CopyBlocks) -> Unit = { },
-    var beforeParsing: (source: String) -> String = { source -> source },
-    var exitInRT: (programName: String) -> Boolean? = { null },
-    var onInterpreterCreation: (interpreter: InterpreterCore) -> Unit = { },
-    var onEnterPgm: (programName: String, symbolTable: ISymbolTable) -> Unit = { _: String, _: ISymbolTable -> },
-    var onExitPgm: (programName: String, symbolTable: ISymbolTable, error: Throwable?) -> Unit = { _: String, _: ISymbolTable, _: Throwable? -> },
-    var afterAstCreation: (ast: CompilationUnit) -> Unit = { },
-    var onEnterCopy: (copyId: CopyId) -> Unit = { },
-    var onExitCopy: (copyId: CopyId) -> Unit = { },
+
     /**
-     * absoluteLine is the absolute position of the statement in the post-processed program.
-     * In case of programs with copy, the absolute position usually is different from the position of the statement
+     * It is invoked before than the copy is included in the source, the default implementation
+     * will return the copy source itself
+     */
+    var beforeCopyInclusion: (copyId: CopyId, source: String?) -> String? = { _, source -> source },
+
+    /**
+     * It is invoked after that all copies has been included in the source.
+     * **This callback will be called only if [Options.debuggingInformation] is set to true**.
+     * */
+    var afterCopiesInclusion: (copyBlocks: CopyBlocks) -> Unit = { },
+
+    /**
+     * It is invoked before the parsing.
+     * It is passed the source that will be parsed after all copy inclusions, the default implementation
+     * will return the source itself
+     * */
+    var beforeParsing: (source: String) -> String = { source -> source },
+
+    /**
+     * If specified, it overrides the exit mode established in the program. Default null to preserve default behavior.
+     * */
+    var exitInRT: (programName: String) -> Boolean? = { null },
+
+    /**
+     * It is invoked on Interpreter creation
+     * */
+    var onInterpreterCreation: (interpreter: InterpreterCore) -> Unit = { },
+
+    /**
+     * It is invoked on program entered after symbol table initialization.
+     * */
+    var onEnterPgm: (programName: String, symbolTable: ISymbolTable) -> Unit = { _: String, _: ISymbolTable -> },
+
+    /**
+     * It is invoked on program exit.
+     * In case of error it is no longer called, then even error parameter is no longer significant
+     * */
+    var onExitPgm: (programName: String, symbolTable: ISymbolTable, error: Throwable?) -> Unit = { _: String, _: ISymbolTable, _: Throwable? -> },
+
+    /**
+     * It is invoked after ast creation.
+     * */
+    var afterAstCreation: (ast: CompilationUnit) -> Unit = { },
+
+    /**
+     * It is invoked on copy entered.
+     * **This callback will be called only if [Options.debuggingInformation] is set to true**.
+     * */
+    var onEnterCopy: (copyId: CopyId) -> Unit = { },
+
+    /**
+     * It is invoked on copy exited.
+     * **This callback will be called only if [Options.debuggingInformation] is set to true**.
+     * */
+    var onExitCopy: (copyId: CopyId) -> Unit = { },
+
+    /**
+     * It is invoked before statement execution.
+     * **This callback will be called only if [Options.debuggingInformation] is set to true**.
+     * @see [JarikoCallback.onEnterStatement] for further information
+     * @param absoluteLine is the absolute position of the statement in the post-processed program.
+     * In the case of programs with copy, the absolute position usually is different from the position of the statement
      * inside the source.
-     * The position of the statement inside the source is accessible through sourceReference parameter.
+     * @param sourceReference The position of the statement inside the source is accessible through sourceReference parameter.
      * sourceReference The source type where the statement is
      * */
     var onEnterStatement: (absoluteLine: Int, sourceReference: SourceReference) -> Unit = { _: Int, _: SourceReference -> },
+
+    /**
+     * It is invoked on function entered after symbol table initialization.
+     * */
     var onEnterFunction: (functionName: String, params: List<FunctionValue>, symbolTable: ISymbolTable)
     -> Unit = { _: String, _: List<FunctionValue>, _: ISymbolTable -> },
+
+    /**
+     * It is invoked on function exit, only if the function does not throw any error
+     * */
     var onExitFunction: (functionName: String, returnValue: Value) -> Unit = { _: String, _: Value -> },
+
+    /**
+     * It is invoked in case of errors. The default implementation writes error event in stderr
+     * */
     var onError: (errorEvent: ErrorEvent) -> Unit = { errorEvent ->
         // If SystemInterface is not in the main execution context or in the SystemInterface there is no
         // logging configuration, the error event must be shown as before, else we run the risk to miss very helpful information
@@ -166,16 +201,36 @@ data class JarikoCallback(
             }
         } ?: System.err.println(errorEvent)
     },
+
+    /***
+     * It is invoked in case of runtime errors occurred inside the program called, only if the error indicator
+     * at column 73-74 is specified.
+     * The default implementation does nothing
+     */
     var onCallPgmError: (errorEvent: ErrorEvent) -> Unit = { },
-    var logInfo: ((channel: String, message: String) -> Unit)? = null,
-    var channelLoggingEnabled: ((channel: String) -> Boolean)? = null,
+
     /**
-     * This is called for those statements mocked.
-     * @param mockStatement "Statement" where is get its name for the `println`.
+     * If specified, it is invoked to log information messages, for all enabled channels
+     * */
+    var logInfo: ((channel: String, message: String) -> Unit)? = null,
+
+    /**
+     * If specified, it allows to enable programmatically the channel logging.
+     * For instance, you can enable all channels by using [consoleVerboseConfiguration] but you can decide, through
+     * the implementation of this callback, which channel you want to log.
+     * */
+    var channelLoggingEnabled: ((channel: String) -> Boolean)? = null,
+
+    /**
+     * If specified, it allows customizing the behavior of the mock statements.
+     * Default implementation provides a simple println with the name of the mock statement.
+     * @param mockStatement The mock statement
      */
     var onMockStatement: ((mockStatement: MockStatement) -> Unit) = { System.err.println("Executing mock: ${it.javaClass.simpleName}") },
+
     /**
-     * This is called before the Api is included in the main program.
+     * If specified, it allows overriding the default mechanism of API validation.
+     * It is called before the Api is included in the main program.
      * Default implementation resolves and validates the compilationUnit related the API.
      * @param apiId The id of the API
      * @param api The API to include

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/IFeaturesFactory.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/IFeaturesFactory.kt
@@ -17,6 +17,7 @@
 @file:JvmName("StandardFeaturesFactory")
 package com.smeup.rpgparser.interpreter
 
+import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
 import kotlin.reflect.full.createInstance
 
@@ -127,23 +128,35 @@ class StandardFeaturesFactory : IFeaturesFactory {
     override fun createSymbolTable() = SymbolTable()
 }
 
+/**
+ * Enumeration of feature flags that can be enabled or disabled.
+ *
+ * @property on The default value of the feature flag. Defaults to false if not specified.
+ */
 enum class FeatureFlag(val on: Boolean = false) {
 
     /**
      * If "on" the alphanumeric [RpgType.ZONED] is handled like [RpgType.UNLIMITED_STRING].
-     * Currently, the [RpgType.CHARACTER] is not yet handled because this cause a regression in some tests
+     * Currently, the [RpgType.CHARACTER] is not yet handled because this cause a regression in some tests.
+     * Default off
      */
     UnlimitedStringTypeFlag(on = false),
+    /**
+     * If "on" the chain cache is enabled.
+     * Default on
+     */
     ChainCacheFlag(on = true),
     ;
 
     fun getPropertyName() = "jariko.features.$name"
 
     /**
-     * @return true if the system property [getPropertyName] is set to "1" "on" or "true"
+     * @return true if the system property [getPropertyName] is set to "1" "on" or "true" or
+     * the value returned by JarikoCallback.featureFlagIsOn is true
      * */
     fun isOn(): Boolean {
-        val property = System.getProperty(getPropertyName(), this.on.toString())
+        val isOn = MainExecutionContext.getConfiguration().jarikoCallback.featureFlagIsOn.invoke(this)
+        val property = System.getProperty(getPropertyName(), isOn.toString())
         return property.lowercase().matches(Regex("1|on|true"))
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/IFeaturesFactory.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/IFeaturesFactory.kt
@@ -38,6 +38,13 @@ interface IFeaturesFactory {
             UnlimitedStringType
         } else create.invoke()
     }
+
+    /**
+     * @return true if the chain cache is enabled
+     * */
+    fun isChainCacheEnabled(): Boolean {
+        return FeatureFlag.ChainCacheFlag.isOn()
+    }
 }
 
 object FeaturesFactory {
@@ -120,13 +127,15 @@ class StandardFeaturesFactory : IFeaturesFactory {
     override fun createSymbolTable() = SymbolTable()
 }
 
-enum class FeatureFlag {
+enum class FeatureFlag(val on: Boolean = false) {
 
     /**
      * If "on" the alphanumeric [RpgType.ZONED] is handled like [RpgType.UNLIMITED_STRING].
      * Currently, the [RpgType.CHARACTER] is not yet handled because this cause a regression in some tests
      */
-    UnlimitedStringTypeFlag;
+    UnlimitedStringTypeFlag(on = false),
+    ChainCacheFlag(on = true),
+    ;
 
     fun getPropertyName() = "jariko.features.$name"
 
@@ -134,7 +143,7 @@ enum class FeatureFlag {
      * @return true if the system property [getPropertyName] is set to "1" "on" or "true"
      * */
     fun isOn(): Boolean {
-        val property = System.getProperty(getPropertyName(), "0")
+        val property = System.getProperty(getPropertyName(), this.on.toString())
         return property.lowercase().matches(Regex("1|on|true"))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/EnrichedDBFileTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/EnrichedDBFileTest.kt
@@ -1,0 +1,127 @@
+package com.smeup.rpgparser.interpreter
+
+import com.smeup.dbnative.file.DBFile
+import com.smeup.dbnative.file.Record
+import com.smeup.dbnative.file.Result
+import com.smeup.rpgparser.execution.Configuration
+import com.smeup.rpgparser.execution.MainExecutionContext
+import com.smeup.rpgparser.jvminterop.JavaSystemInterface
+import org.junit.Before
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+
+class EnrichedDBFileTest {
+
+    private lateinit var dbFile: DBFile
+    private lateinit var fileDefinition: FileDefinition
+    private lateinit var jarikoMetadata: FileMetadata
+
+    private val turnOnChainCacheFlagConfig = Configuration().apply {
+        jarikoCallback.featureFlagIsOn = { featureFlag: FeatureFlag -> featureFlag == FeatureFlag.ChainCacheFlag }
+    }
+
+    private val turnOffChainCacheFlagConfig = Configuration().apply {
+        jarikoCallback.featureFlagIsOn =
+            { featureFlag: FeatureFlag -> if (featureFlag == FeatureFlag.ChainCacheFlag) false else featureFlag.on }
+    }
+
+    @Before
+    fun setup() {
+        dbFile = mock()
+        fileDefinition = mock()
+        jarikoMetadata = mock()
+    }
+
+    @Test
+    fun `chain should return result from cache if cache is enabled and key exists`() {
+        val configuration = turnOnChainCacheFlagConfig
+        val systemInterface = JavaSystemInterface(configuration)
+        MainExecutionContext.execute(configuration = configuration, systemInterface = systemInterface) {
+            val enrichedDBFile = EnrichedDBFile(dbFile, fileDefinition, jarikoMetadata)
+            val result = mock<Result>()
+            whenever(dbFile.chain(anyString())).thenReturn(result)
+            enrichedDBFile.chain("testKey1")
+            enrichedDBFile.chain("testKey1")
+            enrichedDBFile.chain("testKey2")
+            verify(dbFile, times(1)).chain("testKey1")
+            verify(dbFile, times(1)).chain("testKey2")
+        }
+    }
+
+    @Test
+    fun `chain should return result from dbFile if cache is not enabled`() {
+        val configuration = turnOffChainCacheFlagConfig
+        val systemInterface = JavaSystemInterface(configuration)
+        MainExecutionContext.execute(configuration = configuration, systemInterface = systemInterface) {
+            val enrichedDBFile = EnrichedDBFile(dbFile, fileDefinition, jarikoMetadata)
+            val result = mock<Result>()
+            whenever(dbFile.chain(anyString())).thenReturn(result)
+            enrichedDBFile.chain("testKey1")
+            enrichedDBFile.chain("testKey1")
+            enrichedDBFile.chain("testKey2")
+            verify(dbFile, times(2)).chain("testKey1")
+            verify(dbFile, times(1)).chain("testKey2")
+        }
+    }
+
+    @Test
+    fun `delete should clear cache and return result from dbFile`() {
+        val configuration = turnOnChainCacheFlagConfig
+        val systemInterface = JavaSystemInterface(configuration)
+        MainExecutionContext.execute(configuration = configuration, systemInterface = systemInterface) {
+            val enrichedDBFile = EnrichedDBFile(dbFile, fileDefinition, jarikoMetadata)
+            val record = mock<Record>()
+            val result = mock<Result>()
+            whenever(dbFile.chain(anyString())).thenReturn(result)
+            whenever(dbFile.delete(record)).thenReturn(result)
+            enrichedDBFile.chain("testKey1")
+            enrichedDBFile.chain("testKey1")
+            verify(dbFile, times(1)).chain("testKey1")
+            enrichedDBFile.delete(record)
+            enrichedDBFile.chain("testKey1")
+            verify(dbFile, times(2)).chain("testKey1")
+        }
+    }
+
+    @Test
+    fun `write should clear cache and return result from dbFile`() {
+        val configuration = turnOnChainCacheFlagConfig
+        val systemInterface = JavaSystemInterface(configuration)
+        MainExecutionContext.execute(configuration = configuration, systemInterface = systemInterface) {
+            val enrichedDBFile = EnrichedDBFile(dbFile, fileDefinition, jarikoMetadata)
+            val record = mock<Record>()
+            val result = mock<Result>()
+            whenever(dbFile.chain(anyString())).thenReturn(result)
+            whenever(dbFile.write(record)).thenReturn(result)
+            enrichedDBFile.chain("testKey1")
+            enrichedDBFile.chain("testKey1")
+            verify(dbFile, times(1)).chain("testKey1")
+            enrichedDBFile.write(record)
+            enrichedDBFile.chain("testKey1")
+            verify(dbFile, times(2)).chain("testKey1")
+        }
+    }
+
+    @Test
+    fun `update should clear cache and return result from dbFile`() {
+        val configuration = turnOnChainCacheFlagConfig
+        val systemInterface = JavaSystemInterface(configuration)
+        MainExecutionContext.execute(configuration = configuration, systemInterface = systemInterface) {
+            val enrichedDBFile = EnrichedDBFile(dbFile, fileDefinition, jarikoMetadata)
+            val record = mock<Record>()
+            val result = mock<Result>()
+            whenever(dbFile.chain(anyString())).thenReturn(result)
+            whenever(dbFile.update(record)).thenReturn(result)
+            enrichedDBFile.chain("testKey1")
+            enrichedDBFile.chain("testKey1")
+            verify(dbFile, times(1)).chain("testKey1")
+            enrichedDBFile.update(record)
+            enrichedDBFile.chain("testKey1")
+            verify(dbFile, times(2)).chain("testKey1")
+        }
+    }
+}

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/PerfLoggingExample.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/PerfLoggingExample.kt
@@ -10,7 +10,7 @@ class PerfLoggingExample : MULANGTTest() {
     @Test
     fun testMUTE10_10() {
         val si = JavaSystemInterface().apply {
-            loggingConfiguration = consoleLoggingConfiguration(LogChannel.PERFORMANCE)
+            loggingConfiguration = consoleLoggingConfiguration(LogChannel.ANALYTICS)
         }
         executePgm(programName = "performance/MUTE10_10", systemInterface = si)
     }
@@ -18,7 +18,7 @@ class PerfLoggingExample : MULANGTTest() {
     @Test
     fun testT10_A60_P02() {
         val si = JavaSystemInterface().apply {
-            loggingConfiguration = consoleLoggingConfiguration(LogChannel.PERFORMANCE, LogChannel.ANALYTICS)
+            loggingConfiguration = consoleLoggingConfiguration(LogChannel.ANALYTICS)
         }
         executePgm(programName = "smeup/T10_A60_P02", systemInterface = si)
     }


### PR DESCRIPTION
## Experimental Cache for Chain Operations

- Implemented in the `EnrichedDBFile` class.
- Operates in-memory.
- Scope is limited to the Program.
- Can be turned off or on through feature flags.
- on by default.

To disable it, you have two alternatives:
```kotlin
// Via system property
System.setProperty("jariko.features.ChainCacheFlag", "off");

// Programmatically
val turnOffChainCacheFlagConfig = Configuration().apply {
    jarikoCallback.featureFlagIsOn = { featureFlag: FeatureFlag ->
        if (featureFlag == FeatureFlag.ChainCacheFlag) false else featureFlag.on
    }
}
```

Let me know if you need any further modifications!

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
