### PR TITLE
Bugfix/ls24002930/define instatement defs

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
@@ -75,6 +75,8 @@ data class CompilationUnit(
 
     private val inStatementsDataDefinitions = mutableListOf<InStatementDataDefinition>()
 
+    fun getInStatementDataDefinitions() = inStatementsDataDefinitions
+
     fun addInStatementDataDefinitions(dataDefinitions: List<InStatementDataDefinition>) {
         inStatementsDataDefinitions.addAll(dataDefinitions)
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1188,7 +1188,10 @@ data class DefineStmt(
         val containingCU = this.ancestor(CompilationUnit::class.java)
             ?: return emptyList()
 
+        // Search standalone 'D spec' or InStatement definition
         val originalDataDefinition = containingCU.dataDefinitions.find { it.name == originalName }
+            ?: containingCU.getInStatementDataDefinitions().find { it.name == originalName }
+
         // If definition was not found as a 'standalone' 'D spec' declaration,
         // maybe it can be found as a sub-field of DS in 'D specs' declarations
         containingCU.dataDefinitions.forEach {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -312,4 +312,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("A40DS1(ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ) DS1_FL1(1)(BCDEFGHIJK) DS1_FL1(2)(LMNOPQRSTU) | A40DS1(A88        LMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ) DS1_FL1(1)(88        ) DS1_FL1(2)(LMNOPQRSTU) | A40DS1(A88        00        VWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ) DS1_FL1(1)(88        ) DS1_FL1(2)(00        )")
         assertEquals(expected, "smeup/MU024014".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * DefineStmt on instatement data definitions
+     * @see #LS24002930
+     */
+    @Test
+    fun executeMUDRNRAPU00213() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00213".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00213.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00213.rpgle
@@ -1,0 +1,34 @@
+     D £DBG_Str        S             2
+     C     £G00          BEGSR
+      *
+     C                   Z-ADD     $1            £G00$1
+     C                   Z-ADD     $2            £G00$2
+     C                   Z-ADD     $3            £G00$3
+
+     C                   Z-ADD     01            £G00A1            2 0
+     C                   Z-ADD     02            £G00A2            2 0
+     C                   Z-ADD     03            £G00A3            2 0
+     C                   Z-ADD     04            £G00D1            2 0
+     C                   Z-ADD     05            £G00D2            2 0
+     C                   Z-ADD     06            £G00D3            2 0
+     C                   Z-ADD     07            £G00E2            2 0
+     C                   Z-ADD     08            £G00E3            2 0
+     C                   Z-ADD     10            £G00R1            2 0
+     C                   Z-ADD     60            £G00R2            2 0
+      *
+     C     0             IFEQ      0
+     C                   Z-ADD     £G00A1        $1                5 0
+     C                   Z-ADD     £G00A2        $2                5 0
+     C                   Z-ADD     £G00A3        $3                5 0
+     C                   ENDIF
+      *
+     C                   Z-ADD     £G00$1        $1
+     C                   Z-ADD     £G00$2        $2
+     C                   Z-ADD     £G00$3        $3
+     C     *LIKE         DEFINE    $1            £G00$1
+     C     *LIKE         DEFINE    $2            £G00$2
+     C     *LIKE         DEFINE    $2            £G00$3
+      *
+     C                   ENDSR
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add support for DEFINE Statement based on instatement data definitions.

Related to:
- LS24002930

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
