### PR TITLE
bugfix/restore legacy loading of metadata related to display files. 

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -36,6 +36,9 @@ const val DEFAULT_ACTIVATION_GROUP_NAME: String = "*DFTACTGRP"
  * @param memorySliceStorage Allows to implement a symbol table storaging.
  * If null, symbol table persistence will be skipped
  * @param jarikoCallback Several callback.
+ * @param reloadConfig Reload configuration, it is mandatory for rpgle programs containing RLA operations
+ * @param dspfConfig DSPF parser configuration, if null metadata information related to display files will be loaded
+ * from reloadConfig
  * @param defaultActivationGroupName Default activation group. If not specified it assumes "*DEFACTGRP"
  * */
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
@@ -10,19 +10,25 @@ import kotlin.test.assertEquals
 class VideoInterpeterTest : AbstractTest() {
 
     lateinit var configuration: Configuration
+    lateinit var configurationForRetroCompatibilityTest: Configuration
 
     @BeforeTest
     fun setUp() {
         configuration = Configuration()
         val path = javaClass.getResource("/video/metadata")!!.path
-        val reloadConfig = SimpleReloadConfig(metadataPath = path, connectionConfigs = listOf())
-        configuration.reloadConfig = ReloadConfig(
-            nativeAccessConfig = DBNativeAccessConfig(emptyList()),
-            metadataProducer = { dbFile: String -> reloadConfig.getMetadata(dbFile = dbFile) })
         val dspfConfig = SimpleDspfConfig(displayFilePath = path)
         configuration.dspfConfig = DspfConfig(
             metadataProducer = { displayFile: String -> dspfConfig.getMetadata(displayFile = displayFile) }
         )
+        // If dspfConfig is null metadata must be loaded from reloadConfig, as previously
+        configurationForRetroCompatibilityTest = Configuration(dspfConfig = null)
+            .apply {
+                val reloadConfig = SimpleReloadConfig(metadataPath = path, connectionConfigs = listOf())
+                this.reloadConfig = ReloadConfig(
+                    nativeAccessConfig = DBNativeAccessConfig(emptyList()),
+                    metadataProducer = { dbFile: String -> reloadConfig.getMetadata(dbFile = dbFile) }
+                )
+            }
     }
 
     @Test
@@ -34,7 +40,7 @@ class VideoInterpeterTest : AbstractTest() {
     @Test
     fun executeFILEDEF1() {
         val expected = listOf("W\$PERI:12", "£RASDI:HELLO_WORLD")
-        assertEquals(expected = expected, actual = "video/FILEDEF1".outputOf(configuration = configuration))
+        assertEquals(expected = expected, actual = "video/FILEDEF1".outputOf(configuration = configurationForRetroCompatibilityTest))
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/video/VideoInterpeterTest.kt
@@ -1,9 +1,8 @@
 package com.smeup.rpgparser.video
 
+import com.smeup.dbnative.DBNativeAccessConfig
 import com.smeup.rpgparser.AbstractTest
-import com.smeup.rpgparser.execution.Configuration
-import com.smeup.rpgparser.execution.DspfConfig
-import com.smeup.rpgparser.execution.SimpleDspfConfig
+import com.smeup.rpgparser.execution.*
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,6 +15,10 @@ class VideoInterpeterTest : AbstractTest() {
     fun setUp() {
         configuration = Configuration()
         val path = javaClass.getResource("/video/metadata")!!.path
+        val reloadConfig = SimpleReloadConfig(metadataPath = path, connectionConfigs = listOf())
+        configuration.reloadConfig = ReloadConfig(
+            nativeAccessConfig = DBNativeAccessConfig(emptyList()),
+            metadataProducer = { dbFile: String -> reloadConfig.getMetadata(dbFile = dbFile) })
         val dspfConfig = SimpleDspfConfig(displayFilePath = path)
         configuration.dspfConfig = DspfConfig(
             metadataProducer = { displayFile: String -> dspfConfig.getMetadata(displayFile = displayFile) }
@@ -26,6 +29,12 @@ class VideoInterpeterTest : AbstractTest() {
     fun executeFILEDEF() {
         val expected = listOf("W\$PERI:12", "£RASDI:HELLO_WORLD")
         assertEquals(expected = expected, actual = "video/FILEDEF".outputOf(configuration = configuration))
+    }
+
+    @Test
+    fun executeFILEDEF1() {
+        val expected = listOf("W\$PERI:12", "£RASDI:HELLO_WORLD")
+        assertEquals(expected = expected, actual = "video/FILEDEF1".outputOf(configuration = configuration))
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/resources/video/FILEDEF1.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/video/FILEDEF1.rpgle
@@ -1,0 +1,28 @@
+     V* ==============================================================
+     D* 06/02/24
+     D* Test the file video metadata loading
+     V* ==============================================================
+
+
+     FB£DIR40V  CF   E             WORKSTN USROPN
+     F                                     INFDS(DSSF01)
+
+     D MSG             S             50          VARYING
+
+     D WFUND1          DS
+     D  WSDATA                        8  0
+      * This field definition is assumed by B£DIR40V
+     D  W$PERI
+
+     O          E            RIGA        1
+     O                       W$PERI              11
+     C                   EVAL      W$PERI=12
+     C                   EVAL      MSG='W$PERI:' + %CHAR(W$PERI)
+      * EXPECTED: W$PERI:12
+     C     MSG           DSPLY
+
+      * This field is defined in B£DIR40V
+     C                   EVAL      £RASDI='HELLO_WORLD'
+     C                   EVAL      MSG='£RASDI:' + %CHAR(£RASDI)
+      * EXPECTED: £RASDI=:HELLO_WORLD
+     C     MSG           DSPLY


### PR DESCRIPTION
Fixed a regression related a huge breaking change related the topic: "binding between display file field and `DataDefinition`".
Now if `Configuration.dspfConfig` is `null,` the display file metadata are searched by  `Configuration.reloadConfig`



Related to  #542

## Checklist:
- [X] There are tests regarding this feature
- [X] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [X] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
