### PR TITLE
Feature/ls24002974/except mock implementation

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -462,6 +462,7 @@ open class InternalInterpreter(
 
                 if (statement is MockStatement) {
                     MainExecutionContext.getConfiguration().jarikoCallback.onMockStatement
+                    statement.onMock()
                 } else {
                     if (logsEnabled())
                         executeWithLogging(statement)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -65,6 +65,7 @@ private val modules = SerializersModule {
         subclass(DowStmt::class)
         subclass(DOWxxStmt::class)
         subclass(EvalStmt::class)
+        subclass(ExceptStmt::class)
         subclass(ExecuteSubroutine::class)
         subclass(ExfmtStmt::class)
         subclass(FeodStmt::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -107,7 +107,13 @@ abstract class Statement(
 /**
  * For statements with this interface there isn't execution but will be called the callback `onMockStatement`.
  */
-interface MockStatement
+interface MockStatement {
+    /**
+     * Callback method called for this statement on mock execution.
+     * It is the equivalent of the [Statement.execute] method for mock statements.
+     */
+    fun onMock() = Unit
+}
 
 interface CompositeStatement {
     val body: List<Statement>
@@ -2408,6 +2414,19 @@ data class UnlockStmt(
         get() = "UNLOCK"
 
     override fun execute(interpreter: InterpreterCore) {}
+}
+
+@Serializable
+data class ExceptStmt(
+    override val position: Position? = null
+) : Statement(position), MockStatement {
+    override val loggableEntityName: String
+        get() = "EXCEPT"
+
+    override fun execute(interpreter: InterpreterCore) {}
+    override fun onMock() {
+        throw NotImplementedError("EXCEPT statement is not implemented yet")
+    }
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -962,6 +962,9 @@ internal fun Cspec_fixed_standardContext.toAst(conf: ToAstConfiguration = ToAstC
         this.csUNLOCK() != null -> this.csUNLOCK()
             .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
 
+        this.csEXCEPT() != null -> this.csEXCEPT()
+            .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
+
         this.csFEOD() != null -> this.csFEOD()
             .let { it.cspec_fixed_standard_parts().validate(stmt = it.toAst(conf), conf = conf) }
 
@@ -2091,6 +2094,12 @@ internal fun CsREADCContext.toAst(conf: ToAstConfiguration = ToAstConfiguration(
 internal fun CsUNLOCKContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
     val position = toPosition(conf.considerPosition)
     return UnlockStmt(position)
+}
+
+// TODO
+internal fun CsEXCEPTContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Statement {
+    val position = toPosition(conf.considerPosition)
+    return ExceptStmt(position)
 }
 
 internal fun CsTESTNContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): TestnStmt {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -122,4 +122,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("51=1,52=0,53=0")
         assertEquals(expected, "smeup/MU102501".outputOf())
     }
+
+    /**
+     * EXCEPT statement is supported
+     * @see #LS24002974
+     */
+    @Test
+    fun executeMUDRNRAPU00216() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00216".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00216.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00216.rpgle
@@ -1,0 +1,6 @@
+     D £DBG_Str        S             2
+     C                   IF        0
+     C                   EXCEPT    E1RIGA
+     C                   ENDIF
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add mock implementation of `EXCEPT` statement. Differently from the other mock statements, it throw a `RuntimeException`.

Related to:
- LS24002974

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
