### PR TITLE
Example: display file from CLI

### DIFF
--- a/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
+++ b/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
@@ -18,8 +18,8 @@ import java.io.File
 
 // UI control functions
 
-class UnknownVariable(name: String) : Exception("Variable name $name")
-class WrongInputSyntax : Exception("Input syntax is `VAR1=VALUE;VAR2=23`")
+class UnknownVariable(name: String) : Exception("`$name`")
+class WrongInputSyntax : Exception("Should be: `VAR1=VALUE;VAR2=23`")
 
 private fun parseInput(input: String): Map<String, String> {
     try {
@@ -58,7 +58,7 @@ private fun askInputFor(fields: List<DSPFField>): Map<String, Value> {
     val updatedVariables = parseInput(line)
 
     updatedVariables.keys.forEach { variable ->
-        fields.find { field -> field.name == variable } ?: throw WrongInputSyntax()
+        fields.find { field -> field.name == variable } ?: throw UnknownVariable(variable)
     }
 
     fields.filter { it.type == DSPFFieldType.INPUT && updatedVariables[it.name] != null}.forEach {

--- a/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
+++ b/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
@@ -5,7 +5,6 @@ import com.smeup.dspfparser.linesclassifier.DSPFFieldType
 import com.smeup.rpgparser.execution.Configuration
 import com.smeup.rpgparser.execution.DspfConfig
 import com.smeup.rpgparser.execution.JarikoCallback
-import com.smeup.rpgparser.execution.Options
 import com.smeup.rpgparser.execution.SimpleDspfConfig
 import com.smeup.rpgparser.execution.getProgram
 import com.smeup.rpgparser.interpreter.DecimalValue
@@ -31,12 +30,19 @@ private fun parseInput(input: String): Map<String, String> {
     return variablesAndValues
 }
 
-private fun printOutputFields(fields: List<DSPFField>) {
-    print("OUTPUT fields:\t")
+private fun printFields(fields: List<DSPFField>) {
+    println()
+    print("OUTPUT fields:\n")
     fields.filter { it.type == DSPFFieldType.OUTPUT }.forEach {
-        print("${it.name} = ${(it.value as Value).asString().value}")
+        println("\t|${it.name}=${(it.value as Value).asString().value}|")
     }
-    print("\t")
+    println()
+    print("INPUT fields:\n")
+    fields.filter { it.type == DSPFFieldType.INPUT }.forEach {
+        println("\t|${it.name}=${(it.value as Value).asString().value}|")
+    }
+    println()
+    println("Insert input: ")
 }
 
 private fun askInputFor(fields: List<DSPFField>): Map<String, Value> {
@@ -57,7 +63,7 @@ private fun askInputFor(fields: List<DSPFField>): Map<String, Value> {
 }
 
 private fun onExfmt(fields: List<DSPFField>, runtimeInterpreterSnapshot: RuntimeInterpreterSnapshot): OnExfmtResponse? {
-    printOutputFields(fields)
+    printFields(fields)
     while (true) {
         try {
             val variablesAndValues = askInputFor(fields)
@@ -93,7 +99,7 @@ private fun createConfig(): Configuration {
 }
 
 fun main() {
-    val programSource = "ADD01.rpgle"
+    val programSource = "TRIM01.rpgle"
     val programFinders = listOf(DirRpgProgramFinder(File({ }.javaClass.getResource("/rpg")!!.path)),)
     val program = getProgram(nameOrSource = programSource, programFinders = programFinders)
 

--- a/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
+++ b/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
@@ -71,10 +71,6 @@ private fun onExfmt(fields: List<DSPFField>, runtimeInterpreterSnapshot: Runtime
 
 // Jariko call setup functions
 
-private fun createOptions(): Options {
-    return Options(callProgramHandler = createCallProgramHandler())
-}
-
 private fun createDspfConfig(): DspfConfig {
     val simpleDspfConfig = SimpleDspfConfig({ }.javaClass.getResource("/metadata")!!.path)
     return DspfConfig(
@@ -91,15 +87,15 @@ private fun createJarikoCallback(): JarikoCallback {
 
 private fun createConfig(): Configuration {
     return Configuration(
-        options = createOptions(),
         dspfConfig = createDspfConfig(),
         jarikoCallback = createJarikoCallback()
     )
 }
 
 fun main() {
+    val programSource = "ADD01.rpgle"
     val programFinders = listOf(DirRpgProgramFinder(File({ }.javaClass.getResource("/rpg")!!.path)),)
-    val program = getProgram(nameOrSource = "ADD01.rpgle", programFinders = programFinders)
+    val program = getProgram(nameOrSource = programSource, programFinders = programFinders)
 
     program.singleCall(emptyList(), configuration = createConfig())
 }

--- a/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
+++ b/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
@@ -18,16 +18,23 @@ import java.io.File
 
 // UI control functions
 
+class UnknownVariable(name: String) : Exception("Variable name $name")
+class WrongInputSyntax : Exception("Input syntax is `VAR1=VALUE;VAR2=23`")
+
 private fun parseInput(input: String): Map<String, String> {
-    val assignments = input.split(';')
-    val variablesAndValues = mutableMapOf<String, String>()
+    try {
+        val assignments = input.split(';')
+        val variablesAndValues = mutableMapOf<String, String>()
 
-    assignments.forEach {
-        val tokens = it.split('=')
-        variablesAndValues[tokens[0]] = tokens[1]
+        assignments.forEach {
+            val tokens = it.split('=')
+            variablesAndValues[tokens[0]] = tokens[1]
+        }
+
+        return variablesAndValues
+    } catch (e: Exception) {
+        throw WrongInputSyntax()
     }
-
-    return variablesAndValues
 }
 
 private fun printFields(fields: List<DSPFField>) {
@@ -50,7 +57,11 @@ private fun askInputFor(fields: List<DSPFField>): Map<String, Value> {
     val line = readln()
     val updatedVariables = parseInput(line)
 
-    fields.filter { it.type == DSPFFieldType.INPUT && updatedVariables[it.name] != null }.forEach {
+    updatedVariables.keys.forEach { variable ->
+        fields.find { field -> field.name == variable } ?: throw WrongInputSyntax()
+    }
+
+    fields.filter { it.type == DSPFFieldType.INPUT && updatedVariables[it.name] != null}.forEach {
         if (it.isNumeric && it.precision!! == 0)
             variablesAndValues[it.name] = IntValue(updatedVariables[it.name]!!.toLong())
         if (it.isNumeric && it.precision!! > 0)
@@ -99,7 +110,7 @@ private fun createConfig(): Configuration {
 }
 
 fun main() {
-    val programSource = "TRIM01.rpgle"
+    val programSource = "ADD01.rpgle"
     val programFinders = listOf(DirRpgProgramFinder(File({ }.javaClass.getResource("/rpg")!!.path)),)
     val program = getProgram(nameOrSource = programSource, programFinders = programFinders)
 

--- a/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
+++ b/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
@@ -1,0 +1,105 @@
+package com.jariko.samples
+
+import com.smeup.dspfparser.linesclassifier.DSPFField
+import com.smeup.dspfparser.linesclassifier.DSPFFieldType
+import com.smeup.rpgparser.execution.Configuration
+import com.smeup.rpgparser.execution.DspfConfig
+import com.smeup.rpgparser.execution.JarikoCallback
+import com.smeup.rpgparser.execution.Options
+import com.smeup.rpgparser.execution.SimpleDspfConfig
+import com.smeup.rpgparser.execution.getProgram
+import com.smeup.rpgparser.interpreter.DecimalValue
+import com.smeup.rpgparser.interpreter.IntValue
+import com.smeup.rpgparser.interpreter.OnExfmtResponse
+import com.smeup.rpgparser.interpreter.RuntimeInterpreterSnapshot
+import com.smeup.rpgparser.interpreter.StringValue
+import com.smeup.rpgparser.interpreter.Value
+import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
+import java.io.File
+
+// UI control functions
+
+private fun parseInput(input: String): Map<String, String> {
+    val assignments = input.split(';')
+    val variablesAndValues = mutableMapOf<String, String>()
+
+    assignments.forEach {
+        val tokens = it.split('=')
+        variablesAndValues[tokens[0]] = tokens[1]
+    }
+
+    return variablesAndValues
+}
+
+private fun printOutputFields(fields: List<DSPFField>) {
+    print("OUTPUT fields:\t")
+    fields.filter { it.type == DSPFFieldType.OUTPUT }.forEach {
+        print("${it.name} = ${(it.value as Value).asString().value}")
+    }
+    print("\t")
+}
+
+private fun askInputFor(fields: List<DSPFField>): Map<String, Value> {
+    val variablesAndValues = mutableMapOf<String, Value>()
+    val line = readln()
+    val updatedVariables = parseInput(line)
+
+    fields.filter { it.type == DSPFFieldType.INPUT && updatedVariables[it.name] != null }.forEach {
+        if (it.isNumeric && it.precision!! == 0)
+            variablesAndValues[it.name] = IntValue(updatedVariables[it.name]!!.toLong())
+        if (it.isNumeric && it.precision!! > 0)
+            variablesAndValues[it.name] = DecimalValue(updatedVariables[it.name]!!.toBigDecimal())
+        else if (!it.isNumeric)
+            variablesAndValues[it.name] = StringValue(updatedVariables[it.name]!!)
+    }
+
+    return variablesAndValues
+}
+
+private fun onExfmt(fields: List<DSPFField>, runtimeInterpreterSnapshot: RuntimeInterpreterSnapshot): OnExfmtResponse? {
+    printOutputFields(fields)
+    while (true) {
+        try {
+            val variablesAndValues = askInputFor(fields)
+            return OnExfmtResponse(runtimeInterpreterSnapshot, variablesAndValues)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            continue
+        }
+    }
+}
+
+// Jariko call setup functions
+
+private fun createOptions(): Options {
+    return Options(callProgramHandler = createCallProgramHandler())
+}
+
+private fun createDspfConfig(): DspfConfig {
+    val simpleDspfConfig = SimpleDspfConfig({ }.javaClass.getResource("/metadata")!!.path)
+    return DspfConfig(
+        metadataProducer = simpleDspfConfig::getMetadata,
+        dspfProducer = simpleDspfConfig::dspfProducer
+    )
+}
+
+private fun createJarikoCallback(): JarikoCallback {
+    val jarikoCallback = JarikoCallback()
+    jarikoCallback.onExfmt = ::onExfmt
+    return jarikoCallback
+}
+
+private fun createConfig(): Configuration {
+    return Configuration(
+        options = createOptions(),
+        dspfConfig = createDspfConfig(),
+        jarikoCallback = createJarikoCallback()
+    )
+}
+
+fun main() {
+    val programFinders = listOf(DirRpgProgramFinder(File({ }.javaClass.getResource("/rpg")!!.path)),)
+    val program = getProgram(nameOrSource = "ADD01.rpgle", programFinders = programFinders)
+
+    program.singleCall(emptyList(), configuration = createConfig())
+}

--- a/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
+++ b/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
@@ -61,7 +61,7 @@ private fun askInputFor(fields: List<DSPFField>): Map<String, Value> {
         fields.find { field -> field.name == variable } ?: throw UnknownVariable(variable)
     }
 
-    fields.filter { it.type == DSPFFieldType.INPUT && updatedVariables[it.name] != null}.forEach {
+    fields.filter { it.type == DSPFFieldType.INPUT && updatedVariables[it.name] != null }.forEach {
         if (it.isNumeric && it.precision!! == 0)
             variablesAndValues[it.name] = IntValue(updatedVariables[it.name]!!.toLong())
         if (it.isNumeric && it.precision!! > 0)

--- a/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
+++ b/examples/src/main/kotlin/com/jariko/samples/DisplayFileFromCLI.kt
@@ -111,7 +111,7 @@ private fun createConfig(): Configuration {
 
 fun main() {
     val programSource = "ADD01.rpgle"
-    val programFinders = listOf(DirRpgProgramFinder(File({ }.javaClass.getResource("/rpg")!!.path)),)
+    val programFinders = listOf(DirRpgProgramFinder(File({ }.javaClass.getResource("/rpg")!!.path)))
     val program = getProgram(nameOrSource = programSource, programFinders = programFinders)
 
     program.singleCall(emptyList(), configuration = createConfig())

--- a/examples/src/main/resources/metadata/ADD01V.dspf
+++ b/examples/src/main/resources/metadata/ADD01V.dspf
@@ -1,4 +1,4 @@
-                R CALC01
+                R FMT01
                   A              2  2I  0  0
                   B              2  2I  0  0
                   RESULT         2  2O  0  0

--- a/examples/src/main/resources/metadata/ADD01V.dspf
+++ b/examples/src/main/resources/metadata/ADD01V.dspf
@@ -1,0 +1,5 @@
+                R CALC01
+                  A              2  2I  0  0
+                  B              2  2I  0  0
+                  RESULT         2  2O  0  0
+                  PGMCTL         1  0I  0  0

--- a/examples/src/main/resources/metadata/TRIM01V.dspf
+++ b/examples/src/main/resources/metadata/TRIM01V.dspf
@@ -1,0 +1,4 @@
+                R FMT01
+                  STR           10   I  0  0
+                  TRM           10   O  0  0
+                  PGMCTL         1  0I  0  0

--- a/examples/src/main/resources/rpg/ADD01.rpgle
+++ b/examples/src/main/resources/rpg/ADD01.rpgle
@@ -1,0 +1,5 @@
+     FADD01V    CF   E             WORKSTN USROPN
+     C     PGMCTL        DOWEQ      0
+     C                   EXFMT      CALC01
+     C                   EVAL       RESULT=A+B      
+     C                   ENDDO

--- a/examples/src/main/resources/rpg/ADD01.rpgle
+++ b/examples/src/main/resources/rpg/ADD01.rpgle
@@ -1,5 +1,5 @@
      FADD01V    CF   E             WORKSTN USROPN
      C     PGMCTL        DOWEQ      0
-     C                   EXFMT      CALC01
+     C                   EXFMT      FMT01
      C                   EVAL       RESULT=A+B      
      C                   ENDDO

--- a/examples/src/main/resources/rpg/TRIM01.rpgle
+++ b/examples/src/main/resources/rpg/TRIM01.rpgle
@@ -1,0 +1,5 @@
+     FTRIM01V   CF   E             WORKSTN USROPN
+     C     PGMCTL        DOWEQ      0
+     C                   EXFMT      FMT01
+     C                   EVAL       TRM=%TRIM(STR)
+     C                   ENDDO

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/SimpleDspfConfig.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/SimpleDspfConfig.kt
@@ -8,13 +8,13 @@ import kotlinx.serialization.Serializable
 import java.io.File
 
 /**
- * Helper class used to load dspf configuration from a display file
+ * Helper class used to load dspf configuration from a display file.
  * @param displayFilePath path where display file is located
  * */
 @Serializable
-internal data class SimpleDspfConfig(var displayFilePath: String? = null) {
+data class SimpleDspfConfig(var displayFilePath: String? = null) {
 
-    internal fun dspfProducer(displayFile: String): DSPF {
+    fun dspfProducer(displayFile: String): DSPF {
         val videoFile = File(displayFilePath, "$displayFile.dspf")
         require(videoFile.exists()) { "$videoFile doesn't exist" }
 
@@ -23,7 +23,7 @@ internal data class SimpleDspfConfig(var displayFilePath: String? = null) {
         }
     }
 
-    internal fun getMetadata(displayFile: String): FileMetadata {
+    fun getMetadata(displayFile: String): FileMetadata {
         val videoFile = File(displayFilePath, "$displayFile.dspf")
         require(videoFile.exists()) { "$videoFile doesn't exist" }
 


### PR DESCRIPTION
## Description

Example about using EXFMT callback to simulate IBM i display files in Jariko. The `main()` function of the example file sets up a Jariko call to a certain program (chosen with a variable, to keep it simple) with the correct configuration for display file handling. It also sets up the `onExfmt(fields: List<DSPFField>, runtimeInterpreterSnapshot: RuntimeInterpreterSnapshot): OnExfmtResponse?` callback to manage CLI interaction. Two ad-hoc example files were added: `ADD01` and `TRIM01` (with their display files).

### `ADD01`

Uses the display file format `FMT01` to ask user input for variables `A`, `B` and `PGMCTL` and write computation `A+B` to `RESULT` while `PGMCTL==0`. 

### `TRIM01`

Uses the display file format `FMT01` to ask user input for variables `STR` and `PGMCTL` and write computation `%TRIM(STR)` to `TRM` while `PGMCTL==0`. 

User input syntax is `VAR1=VALUE;VAR2=123`. A change in value is considered only for INPUT values. If `OUT` is an OUTPUT variable, prompting `OUT=123` will simply have no effect; fields whose value is to be changed are filtered to INPUT only.
Before user input is asked, previous values of INPUT and OUTPUT variables is wrote to screen. When ENTER is pressed `readln()` ends an error is displayed if input was not accepted and system requires user to re-prompt it, or will return control back to Jariko if input is accepted; calling `readln()` is blocking and will cause program to wait for user input (just like in RPG display file scenario).

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
