### PR TITLE
Feature/ls24002987/printer file mockup

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -137,7 +137,7 @@ data class Prefix(internal val prefix: String, private val numCharsReplaced: Int
 }
 
 enum class FileType(val keyword: String?) {
-    DB(null), VIDEO("C");
+    DB(null), VIDEO("C"), PRINTER("O");
 
     companion object {
         fun getByKeyword(keyword: String): FileType {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -215,6 +215,15 @@ private fun FileDefinition.loadMetadata(): FileMetadata {
                 error("Not found metadata for $this", error)
             }.getOrNull() ?: error("Not found metadata for $this")
         }
+        fileType == FileType.PRINTER -> {
+            FileMetadata(
+                name = this.name,
+                tableName = this.name,
+                recordFormat = this.internalFormatName ?: this.name,
+                fields = emptyList(),
+                accessFields = emptyList()
+            )
+        }
         else -> error("Unhandled file type $fileType")
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
@@ -34,4 +34,14 @@ open class MULANGT50FileAccess1Test : MULANGTTest() {
         val expected = listOf("TSSYST(IBMI) TSLIBR() TSFILE() TATIPO(3) TBPROG(MULANGT12) AAAAAA(A03) BBBBBB(P01) CCCCCC()")
         assertEquals(expected, "smeup/MU500901".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Printer file with O-specs
+     * @see #LS24002987
+     */
+    @Test
+    fun executeMUDRNRAPU00219() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00219".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00219.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00219.rpgle
@@ -1,0 +1,7 @@
+     D £DBG_Str        S             2
+     D STR132          S            132
+     FPRT132    O    F  132        PRINTER OFLIND(*INOG) USROPN
+     OPRT132    E            RIGA        1
+     O                       STR132
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add mock implementation for printer files. The `MUDRNRAPU00219.rpgle` test case also contains some O-Specs referencing it to ensure everything works properly without errors.

Related to:
- LS24002987

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
