### PR TITLE
Feature/ls24003047/pointer variables

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
@@ -95,5 +95,6 @@ interface Evaluator {
     fun eval(expression: ParmsExpr): Value
     fun eval(expression: OpenExpr): Value
     fun eval(expression: SizeExpr): Value
+    fun eval(expression: NullValExpr): Value
     fun eval(expression: MockExpression): Value
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -823,6 +823,8 @@ class ExpressionEvaluation(
         }
     }
 
+    override fun eval(expression: NullValExpr): Value = proxyLogging(expression) { NullValue }
+
     override fun eval(expression: MockExpression): Value {
         MainExecutionContext.getConfiguration().jarikoCallback.onMockExpression(expression)
         return NullValue

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
@@ -218,17 +218,24 @@ data class NumberType(val entireDigits: Int, val decimalDigits: Int, val rpgType
     constructor(entireDigits: Int, decimalDigits: Int, rpgType: RpgType) : this(entireDigits, decimalDigits, rpgType.rpgType)
 
     init {
-        if (rpgType == RpgType.INTEGER.rpgType || rpgType == RpgType.UNSIGNED.rpgType) {
-            require(entireDigits <= 20) { "Integer or Unsigned integer can have only length up to 20. Value specified: $this" }
-            require(decimalDigits == 0)
+        if (rpgType == RpgType.INTEGER.rpgType || rpgType == RpgType.UNSIGNED.rpgType || rpgType == RpgType.POINTER.rpgType) {
+            require(entireDigits <= MAX_INTEGER_DIGITS) {
+                "Integer or Unsigned integer can have only length up to 20. Value specified: $this"
+            }
+            require(decimalDigits == INTEGER_DECIMAL_DIGITS)
         }
+    }
+
+    companion object {
+        const val MAX_INTEGER_DIGITS = 20
+        const val INTEGER_DECIMAL_DIGITS = 0
     }
 
     override val size: Int
         get() {
             return when (rpgType) {
                 RpgType.PACKED.rpgType -> ceil((numberOfDigits + 1).toDouble() / 2.toFloat()).toInt()
-                RpgType.INTEGER.rpgType, RpgType.UNSIGNED.rpgType -> {
+                RpgType.INTEGER.rpgType, RpgType.UNSIGNED.rpgType, RpgType.POINTER.rpgType -> {
                     when (entireDigits) {
                         in 1..3 -> 1
                         in 4..5 -> 2
@@ -249,7 +256,7 @@ data class NumberType(val entireDigits: Int, val decimalDigits: Int, val rpgType
         }
 
     val integer: Boolean
-        get() = decimalDigits == 0
+        get() = decimalDigits == INTEGER_DECIMAL_DIGITS
     val decimal: Boolean
         get() = !integer
     val numberOfDigits: Int

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
@@ -148,6 +148,11 @@ data class JulFormatExpr(override val position: Position? = null) : FigurativeCo
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
 
+@Serializable
+data class NullValExpr(override val position: Position? = null) : FigurativeConstantRef(position) {
+    override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
+}
+
 // /
 // / Comparisons
 // /

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/serialization.kt
@@ -165,6 +165,7 @@ private val modules = SerializersModule {
         subclass(MinusExpr::class)
         subclass(MultExpr::class)
         subclass(NotExpr::class)
+        subclass(NullValExpr::class)
         subclass(NumberOfElementsExpr::class)
         subclass(OnRefExpr::class)
         subclass(OffRefExpr::class)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -37,7 +37,8 @@ enum class RpgType(val rpgType: String) {
     INTEGER("I"),
     UNSIGNED("U"),
     BINARY("B"),
-    UNLIMITED_STRING("0")
+    UNLIMITED_STRING("0"),
+    POINTER("*")
 }
 
 /**
@@ -445,6 +446,9 @@ internal fun RpgParser.DspecContext.toAst(
             }
             RpgType.UNLIMITED_STRING.rpgType -> {
                 UnlimitedStringType
+            }
+            RpgType.POINTER.rpgType -> {
+                NumberType(NumberType.MAX_INTEGER_DIGITS, NumberType.INTEGER_DECIMAL_DIGITS, RpgType.POINTER.rpgType)
             }
             else -> todo("Unknown type: <${this.DATA_TYPE().text}>", conf)
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -158,6 +158,7 @@ internal fun RpgParser.IdentifierContext.toAst(conf: ToAstConfiguration = ToAstC
         "*OFF" -> OffRefExpr(toPosition(conf.considerPosition))
         "*ISO" -> IsoFormatExpr(toPosition(conf.considerPosition))
         "*JUL" -> JulFormatExpr(toPosition(conf.considerPosition))
+        "*NULL" -> NullValExpr(toPosition(conf.considerPosition))
         else -> variableExpression(conf)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -342,4 +342,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00218".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Reassign value to pointer variable
+     * @see #LS24003047
+     */
+    @Test
+    fun executeMUDRNRAPU00219() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00219".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
@@ -40,8 +40,8 @@ open class MULANGT50FileAccess1Test : MULANGTTest() {
      * @see #LS24002987
      */
     @Test
-    fun executeMUDRNRAPU00219() {
+    fun executeMUDRNRAPU00220() {
         val expected = listOf("ok")
-        assertEquals(expected, "smeup/MUDRNRAPU00219".outputOf(configuration = smeupConfig))
+        assertEquals(expected, "smeup/MUDRNRAPU00220".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00219.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00219.rpgle
@@ -1,0 +1,5 @@
+     D £DBG_Str        S             2
+     D SRIG_PTR        S               *   Inz(*Null)
+     C                   EVAL      SRIG_PTR = *NULL
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00220.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00220.rpgle
@@ -1,0 +1,7 @@
+     D £DBG_Str        S             2
+     D STR132          S            132
+     FPRT132    O    F  132        PRINTER OFLIND(*INOG) USROPN
+     OPRT132    E            RIGA        1
+     O                       STR132
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add support for pointer variable declarations. This is needed to further expand the work done in #549 in order to avoid data reference errors thrown by `EVAL` statements based on `%alloc`, `%realloc` and `%addr`.

Changes also include support for `*NULL` often used to initialize pointer variables with `INZ(*Null)`.

Related to:
- #549
- LS24003047

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
