### PR TITLE
Bugfix/ls24003137/caller group default

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
@@ -54,7 +54,7 @@ fun CompilationUnit.activationGroupType(): ActivationGroupType? {
     }
 }
 
-fun ActivationGroupType.assignedName(current: RpgProgram, caller: RpgProgram?): String {
+fun ActivationGroupType.assignedName(caller: RpgProgram?): String {
     return when (this) {
         is CallerActivationGroup -> {
             require(caller != null) { "caller is mandatory" }
@@ -62,7 +62,6 @@ fun ActivationGroupType.assignedName(current: RpgProgram, caller: RpgProgram?): 
         }
         is NewActivationGroup -> UUID.randomUUID().toString()
         is NamedActivationGroup -> groupName
-        else -> error("$this ActivationGroupType is not yet handled")
     }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -139,7 +139,7 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
                         }
                     }
                 activationGroupType.let {
-                    activationGroup = ActivationGroup(it, it.assignedName(this, caller))
+                    activationGroup = ActivationGroup(it, it.assignedName(caller))
                 }
             }
             MainExecutionContext.getProgramStack().push(this)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/ActivationGroupTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/ActivationGroupTest.kt
@@ -37,6 +37,30 @@ open class ActivationGroupTest : AbstractTest() {
     }
 
     /**
+     * Assigned activation group name should be the default from configuration
+     * */
+    @Test
+    fun testUnspecifiedCaller() {
+        val pgm = "     H ACTGRP(*CALLER)\n" +
+                "     C                   SETON                                          RT"
+
+        val conf = Configuration(
+            jarikoCallback = JarikoCallback(
+                getActivationGroup = {
+                        _: String, associatedActivationGroup: ActivationGroup? ->
+                    println("associatedActivationGroupName: ${associatedActivationGroup?.assignedName}")
+                    assertEquals(Configuration().defaultActivationGroupName, associatedActivationGroup?.assignedName)
+                    assertEquals(DEFAULT_ACTIVATION_GROUP_NAME, associatedActivationGroup?.assignedName)
+                    null
+                }
+            )
+        )
+        conf.adaptForTestCase(this)
+        val commandLineProgram = getProgram(pgm)
+        commandLineProgram.singleCall(emptyList(), conf)
+    }
+
+    /**
      * Assigned activation group name should be from declaration
      * */
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -352,4 +352,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00219".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Caller activation group with no actual caller
+     * @see #LS24003137
+     */
+    @Test
+    fun executeMUDRNRAPU00221() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00221".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00221.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00221.rpgle
@@ -1,0 +1,5 @@
+     D £DBG_Str        S             2
+     H DECEDIT(*JOBRUN) DATEDIT(*DMY/) DFTACTGRP(*NO) ACTGRP(*CALLER)
+     H OPTION(*NODEBUGIO:*SRCSTMT:*NOUNREF) CCSID(*CHAR : *JOBRUN) DEBUG(*INPUT)
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add sane default for `ACTGRP(*CALLER)` when no actual caller is present.

Related to:
- LS24003137

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
