### PR TITLE
Bugfix/printer file precedence

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -194,6 +194,15 @@ private fun MutableMap<String, DataDefinition>.addIfNotPresent(dataDefinition: D
 
 private fun FileDefinition.loadMetadata(): FileMetadata {
     return when {
+        fileType == FileType.PRINTER -> {
+            FileMetadata(
+                name = this.name,
+                tableName = this.name,
+                recordFormat = this.internalFormatName ?: this.name,
+                fields = emptyList(),
+                accessFields = emptyList()
+            )
+        }
         (fileType == FileType.DB || MainExecutionContext.getConfiguration().dspfConfig == null) -> {
             val reloadConfig = MainExecutionContext.getConfiguration()
                 .reloadConfig
@@ -214,15 +223,6 @@ private fun FileDefinition.loadMetadata(): FileMetadata {
             }.onFailure { error ->
                 error("Not found metadata for $this", error)
             }.getOrNull() ?: error("Not found metadata for $this")
-        }
-        fileType == FileType.PRINTER -> {
-            FileMetadata(
-                name = this.name,
-                tableName = this.name,
-                recordFormat = this.internalFormatName ?: this.name,
-                fields = emptyList(),
-                accessFields = emptyList()
-            )
         }
         else -> error("Unhandled file type $fileType")
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
@@ -1,9 +1,6 @@
 package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.db.utilities.DBServer
-import com.smeup.rpgparser.execution.DspfConfig
-import com.smeup.rpgparser.execution.MainExecutionContext
-import com.smeup.rpgparser.execution.SimpleDspfConfig
 import org.junit.Test
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
@@ -1,6 +1,9 @@
 package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.db.utilities.DBServer
+import com.smeup.rpgparser.execution.DspfConfig
+import com.smeup.rpgparser.execution.MainExecutionContext
+import com.smeup.rpgparser.execution.SimpleDspfConfig
 import org.junit.Test
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
@@ -43,5 +46,17 @@ open class MULANGT50FileAccess1Test : MULANGTTest() {
     fun executeMUDRNRAPU00220() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00220".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * Printer file with O-specs with no DSPF config
+     * @see #LS24002987
+     */
+    @Test
+    fun executeMUDRNRAPU00220WithoutDSPF() {
+        val expected = listOf("ok")
+        val mockSmeupConfig = smeupConfig.copy()
+        mockSmeupConfig.dspfConfig = null
+        assertEquals(expected, "smeup/MUDRNRAPU00220".outputOf(configuration = mockSmeupConfig))
     }
 }


### PR DESCRIPTION
## Description

Give higher precedence to printer file parsing in `loadMetadata` in order to avoid discrimination when DSPF config is null.

Related to: #551 

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
