### PR TITLE
Bugfix/ls24003177/comptime definestmt

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -285,16 +285,18 @@ open class BaseCompileTimeInterpreter(
     }
 
     private fun Cspec_fixedContext.findType(declName: String, conf: ToAstConfiguration): Type? {
-        val ast = this.toAst(conf)
-        if (ast is StatementThatCanDefineData) {
-            val dataDefinition = ast.dataDefinition()
-            dataDefinition.forEach {
-                if (it.name == declName) {
-                    return it.type
-                }
+        return when (val ast = this.toAst(conf)) {
+            is DefineStmt -> {
+                if (declName != ast.newVarName) return null
+                val type = findType(rContext().statement(), ast.originalName, conf)
+                type
             }
+            is StatementThatCanDefineData -> {
+                val dataDefinition = ast.dataDefinition()
+                dataDefinition.firstOrNull { it.name == declName }?.type
+            }
+            else -> null
         }
-        return null
     }
 
     private fun Parm_fixedContext.findType(conf: ToAstConfiguration): Type? {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -362,4 +362,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00221".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Comptime DEFINE support
+     * @see #LS24003177
+     */
+    @Test
+    fun executeMUDRNRAPU00222() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00222".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00222.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00222.rpgle
@@ -1,0 +1,12 @@
+     D £DBG_Str        S             2
+
+     D CSDS            DS
+     D  $OAVT1                             LIKE(§OAVT1)
+
+     C     *LIKE         DEFINE    £OAVT1        §OAVT1
+
+     C     *ENTRY        PLIST
+     C                   PARM                    £OAVT1            2
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add support for `DefineStmt` in `CompileTimeInterpreter`.

Related to:
- LS24003177

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
