### PR TITLE
Bugfix/ls24003149/immutable for endvalue

### DIFF
--- a/kolasu/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
+++ b/kolasu/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt
@@ -148,6 +148,13 @@ fun Node.transformChildren(operation: (Node) -> Node, inPlace: Boolean = false):
                         if (p is KMutableProperty<*>) {
                             p.setter.call(this, newValue)
                         } else {
+                            /**
+                             * The following exception is raised when the property we are trying to replace is immutable.
+                             * This usually happens when it is declared as `val` or it is a getter without a setter.
+                             * If for some reason you are sure the property must be replaced please check that it is
+                             * declared as `var` field or add a setter to it in the corresponding superclass of Node
+                             * that defines the target property.
+                             */
                             throw ImmutablePropertyException(p, v)
                         }
                     } else {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1881,7 +1881,7 @@ data class CabStmt(
 @Serializable
 data class ForStmt(
     var init: Expression,
-    val endValue: Expression,
+    var endValue: Expression,
     val byValue: Expression,
     val downward: Boolean = false,
     override val body: List<Statement>,

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -362,4 +362,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00221".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Access to an array detected as a function call by parser
+     * @see #
+     */
+    @Test
+    fun executeMUDRNRAPU00224() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00224".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00224.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00224.rpgle
@@ -1,0 +1,11 @@
+     D £DBG_Str        S             2
+     D                 DS
+     D SMET                         100    DIM(60)
+     D  SMET_NUM                     07  0 OVERLAY(SMET:*NEXT)
+     D $B              S             06  0
+     D $GRU_A          S             02  0
+     C                   EVAL      $GRU_A=2
+     C                   FOR       $B=1 TO SMET_NUM($GRU_A)
+     C                   ENDFOR
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Change immutable field `endValue` in `ForStmt` to mutable in order to allow for `ArrayAccessExpr` replacing erroneous `FunctionCall`s during resolution.

Related to:
- LS24003149

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
