### PR TITLE
Bugfix/ls24003296/like case insensitive

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -182,7 +182,7 @@ open class BaseCompileTimeInterpreter(
                     it.dcl_ds() != null -> {
                         val name = it.dcl_ds().name
                         val fields = fileDefinitions?.let { defs -> it.dcl_ds().getExtnameFields(defs, conf) } ?: emptyList()
-                        if (name == declName) {
+                        if (name.equals(declName, ignoreCase = true)) {
                             return it.dcl_ds().elementSizeOf(knownDataDefinitions, fields)
                         }
                     }
@@ -313,7 +313,7 @@ open class BaseCompileTimeInterpreter(
             }
             is StatementThatCanDefineData -> {
                 val dataDefinition = ast.dataDefinition()
-                dataDefinition.firstOrNull { it.name == declName }?.type
+                dataDefinition.firstOrNull { it.name.equals(declName, ignoreCase = true) }?.type
             }
             else -> null
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -422,4 +422,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("9991\uFFFF\uFFFF99999")
         assertEquals(expected, "smeup/MUDRNRAPU00227".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * LIKE on a PList with case in-sensitive lookup
+     * @see #LS24003296
+     */
+    @Test
+    fun executeMUDRNRAPU00230() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00230".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00230.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00230.rpgle
@@ -1,0 +1,13 @@
+     D £DBG_Str        S             2
+
+     D $OavFU          S                   Like(£OavFU)
+     D $OavME          S                   Like(£OavME)
+     D §OavFU          S                   Like(£OavFU)
+     D §OavME          S                   Like(£OavME)
+
+     C     *ENTRY        PLIST
+     C                   PARM                    £OAVFU           10            Funzione
+     C                   PARM                    £OAVME           10            Metodo
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Tweak some checks causing `DataReference` errors to be case insensitive as intended.

Related to:
- LS24003296

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
