### PR TITLE
Bugfix/ls24003329/comptime like on like

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -172,7 +172,15 @@ open class BaseCompileTimeInterpreter(
                     it.dspec() != null -> {
                         val name = it.dspec().ds_name()?.text ?: it.dspec().dspecConstant().ds_name()?.text
                         if (declName.equals(name, ignoreCase = true)) {
-                            return it.dspec().TO_POSITION().text.asInt()
+                            /**
+                             * If this is a D-Spec based on a LIKE, recursively find and return its size
+                             * else-wise return explicit size
+                             */
+                            val likeSize = it.dspec().keyword().firstOrNull { it.keyword_like() != null }?.let {
+                                val target = it.keyword_like()!!.name.text.trim()
+                                findSize(statements, target, conf, innerBlock)
+                            }
+                            return likeSize ?: it.dspec().TO_POSITION().text.asInt()
                         }
                     }
                     it.cspec_fixed() != null -> {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -432,4 +432,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00230".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Comptime LIKE referencing another D-Spec with LIKE
+     * @see #LS24003329
+     */
+    @Test
+    fun executeMUDRNRAPU00233() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00233".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00233.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00233.rpgle
@@ -1,0 +1,10 @@
+     D £DBG_Str        S             2
+
+     D F$LIB           S                   LIKE(U$LIB )
+     D U$LIB           S                   LIKE($IR1LB)
+     C     £INIZI        BEGSR
+     C                   CLEAR                   $Ir1LB           10
+     C                   ENDSR
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add recursive comptime resolution for D-specs.

Related to:
- LS24003329

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
