### PR TITLE
Bugfix/ls24003380/scan expr source mutation

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -101,7 +101,7 @@ data class LookupLeExpr(
 @Serializable
 data class ScanExpr(
     var value: Expression,
-    val source: Expression,
+    var source: Expression,
     val start: Expression? = null,
     val length: Expression? = null,
     override val position: Position? = null

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -462,4 +462,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00232".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Access to an array detected as a function call by parser in ScanExpr
+     * @see #LS24003380
+     */
+    @Test
+    fun executeMUDRNRAPU00234() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00234".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00234.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00234.rpgle
@@ -1,0 +1,11 @@
+     D £DBG_Str        S             2
+
+     D $A              S              5  0
+     D £43A            S            256    DIM(256)
+     D $CPA            S              5  0
+
+     C                   EVAL      $CPA=1
+     C                   EVAL      $A=%SCAN('(':£43A($CPA))
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Allow source mutation in ScanExpr.


Related to:
- LS24003380
- #559

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
