### PR TITLE
Bugfix/ls24003456/comptime like api

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -200,6 +200,19 @@ open class BaseCompileTimeInterpreter(
                         val size = it.block().findType(declName, conf)?.size
                         if (size != null) return size
                     }
+                    it.directive() != null -> {
+                        // API Directives
+                        if (it.directive().dir_api() != null) {
+                            val apiDirective = it.directive().dir_api()
+                            val apiId = apiDirective.toApiId(conf)
+                            val api = MainExecutionContext.getSystemInterface()?.findApi(apiId)
+                            api?.let {
+                                it.compilationUnit.dataDefinitions.firstOrNull { def ->
+                                    def.name.equals(declName, ignoreCase = true)
+                                }
+                            }?.let { return it.type.size }
+                        }
+                    }
                 }
             }
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -482,4 +482,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00235".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Dspec with LIKE on a field defined in an API
+     * @see TODO
+     */
+    @Test
+    fun executeMUDRNRAPU00238() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00238".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -485,7 +485,7 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
 
     /**
      * Dspec with LIKE on a field defined in an API
-     * @see TODO
+     * @see #LS24003456
      */
     @Test
     fun executeMUDRNRAPU00238() {

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00238.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00238.rpgle
@@ -1,0 +1,7 @@
+     D £DBG_Str        S             2
+
+     D OlCod           S                   LIKE(£DECCD) INZ(*HIVAL)
+      /API QILEGEN,£DEC
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add support for comptime resolution of variables referencing symbols in API directives.

Related to:
- LS24003456

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
