### PR TITLE
Bugfix/ls24003380/subst immutable length

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -425,7 +425,7 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: SubstExpr): Value = proxyLogging(expression) {
-        val length = if (expression.length != null) expression.length.evalWith(this).asInt().value.toInt() else 0
+        val length = expression.length?.evalWith(this)?.asInt()?.value?.toInt() ?: 0
         val start = expression.start.evalWith(this).asInt().value.toInt() - 1
         val originalString = expression.string.evalWith(this).asString().value
         return@proxyLogging if (length == 0) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -885,7 +885,7 @@ open class InternalInterpreter(
             }
             is SubstExpr -> {
                 val oldValue = eval(target.string).asString().value
-                val length = if (target.length != null) eval(target.length).asInt().value.toInt() else null
+                val length = target.length?.let { eval(it).asInt().value.toInt() }
                 val start = eval(target.start).asInt().value.toInt() - 1
 
                 val newValue = if (length == null) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -198,7 +198,7 @@ data class SubstExpr(
     override val loggableEntityName: String
         get() = "%SUBST"
     override fun render(): String {
-        val len = length?.let { ": ${length!!.render()}" } ?: ""
+        val len = length?.let { ": ${it.render()}" } ?: ""
         return "%SUBST(${this.string.render()} : ${start.render()} $len)"
     }
     override fun size(): Int {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -192,13 +192,13 @@ data class SubstExpr(
     var string: Expression,
     // i don't know but fix: Error com.strumenta.kolasu.model.ImmutablePropertyException: Cannot mutate property 'start' of node FunctionCall(
     var start: Expression,
-    val length: Expression? = null,
+    var length: Expression? = null,
     override val position: Position? = null
 ) : AssignableExpression(position) {
     override val loggableEntityName: String
         get() = "%SUBST"
     override fun render(): String {
-        val len = if (length != null) ": ${length.render()}" else ""
+        val len = length?.let { ": ${length!!.render()}" } ?: ""
         return "%SUBST(${this.string.render()} : ${start.render()} $len)"
     }
     override fun size(): Int {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -502,4 +502,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00238".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Access to an array detected as a function call by parser in SubstExpr
+     * @see #LS24003380
+     */
+    @Test
+    fun executeMUDRNRAPU00239() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00239".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00239.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00239.rpgle
@@ -1,0 +1,24 @@
+     D £DBG_Str        S             2
+     D $X              S              5  0
+
+     D OGG$N           C                   106
+     D OGG_IP          S             12  0 DIM(OGG$N)
+     D OGG_E           S              2  0 DIM(OGG$N)
+     D OGG_L           S              2  0 DIM(OGG$N)
+
+     D£K04DI           DS          2000    INZ
+     D £K04I_OG                      52                                         Classe
+
+     D£K04DO           DS          3000    INZ
+     D £K04O_IP                       1                                         Modalità Input Panel
+
+     D OK04O_IP        S                   LIKE(£K04O_IP)
+      *
+     C                   EVAL      $X=2
+     C                   IF        %SUBST(£K04I_OG:1:OGG_L($X))=
+     C                             %SUBST(OGG_IP($X):1:OGG_L($X))
+     C                   EVAL      OK04O_IP=OGG_E($X)
+     C                   ENDIF
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Make `length` field of `SubstExpr` mutable in order to allow for expression rewriting at runtime.

Related to:
- #559 
- #568 
- #571 

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
