### PR TITLE
Bugfix/ls24003436/copy case insensitive

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
@@ -105,7 +105,7 @@ val PATTERN: Pattern = Pattern.compile("" +
 fun String.copyId(): CopyId {
     return when {
         this.contains('/') -> {
-            this.split("/,").let {
+            this.split("/", ",").let {
                 CopyId(it[0].uppercase(Locale.getDefault()), it[1].uppercase(Locale.getDefault()), it[2].uppercase(Locale.getDefault()))
             }
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
@@ -106,12 +106,12 @@ fun String.copyId(): CopyId {
     return when {
         this.contains('/') -> {
             this.split("/,").let {
-                CopyId(it[0], it[1], it[2].uppercase(Locale.getDefault()))
+                CopyId(it[0].uppercase(Locale.getDefault()), it[1].uppercase(Locale.getDefault()), it[2].uppercase(Locale.getDefault()))
             }
         }
         this.contains(",") -> {
             this.split(",").let {
-                CopyId(null, it[0], it[1].uppercase(Locale.getDefault()))
+                CopyId(null, it[0].uppercase(Locale.getDefault()), it[1].uppercase(Locale.getDefault()))
             }
         }
         else -> CopyId(null, null, this)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
@@ -106,12 +106,12 @@ fun String.copyId(): CopyId {
     return when {
         this.contains('/') -> {
             this.split("/,").let {
-                CopyId(it[0], it[1], it[2])
+                CopyId(it[0], it[1], it[2].uppercase(Locale.getDefault()))
             }
         }
         this.contains(",") -> {
             this.split(",").let {
-                CopyId(null, it[0], it[1])
+                CopyId(null, it[0], it[1].uppercase(Locale.getDefault()))
             }
         }
         else -> CopyId(null, null, this)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -33,6 +33,7 @@ import org.junit.Assert
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.StringReader
+import java.util.*
 import kotlin.test.DefaultAsserter.assertTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -112,7 +113,7 @@ class JarikoCallbackTest : AbstractTest() {
                         println("Program - relativeLineNumber: ${sourceReference.relativeLine}, lineNumber: $lineNumber")
                     }
                     val src = when (sourceReference.sourceReferenceType) {
-                        SourceReferenceType.Copy -> copyDefinitions[CopyId(member = sourceReference.sourceId)]
+                        SourceReferenceType.Copy -> copyDefinitions[CopyId(member = sourceReference.sourceId.uppercase(Locale.getDefault()))]
                         SourceReferenceType.Program -> pgm
                     }
                     require(src != null)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
@@ -47,4 +47,14 @@ open class MULANGT70CompilationDirectiveTest : MULANGTTest() {
         val myConfig = smeupConfig.copy().apply { jarikoCallback.onApiInclusion = { _, _ -> } }
         assertEquals(expected, "smeup/MU711004".outputOf(configuration = myConfig))
     }
+
+    /**
+     * COPY where its name has lower alphabetic character.
+     * @see #LS24003436
+     */
+    @Test
+    fun executeMU711006() {
+        val expected = listOf("HELLO THERE")
+        assertEquals(expected, "smeup/MU711006".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/QILEGEN/£K37DS.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/QILEGEN/£K37DS.rpgle
@@ -1,0 +1,68 @@
+      *====================================================================
+      * smeup V6R1.023DV
+      * Nome sorgente       : £K37DS
+      * Sorgente di origine : SMEDEV/QILEGEN(£K37DS)
+      * Esportato il        : 20240617 113438
+      *====================================================================
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 28/05/18         PEDSTE Creazione
+     V* 11/07/18  000065 PEDSTE Aggiunta gestione definizione attributi
+     V* 25/02/19  000491 PEDSTE Aggiunto £K37O_NN Nome Nodo
+     V* 28/02/19  V5R1   CATMAS Check-out 000491 in SMEUP_TST
+     V* 06/09/19  V5R1    CM Rilascio 000065, 000491 in SMEDEV
+     V* 06/03/20  001647  PEDSTE Gestione forzatura "0" per campo numerico con valore 0
+     V* 06/03/20  V5R1   BERNI  Check-out 001647 in SMEUP_TST
+     V* 14/04/20  V5R1   PEDSTE Rilascio 001647 in SMEDEV
+     V* 07/08/20  002052 PEDSTE Gestione json da xls oggettizzati smeup
+     V* 07/08/20  V5R1   AS Check-out 002052 in SMEUP_TST
+     V* ££10916A  V5R1    BERNI **********************
+     V* ££10916A  V5R1    BERNI ************* RILASCIO INTERO SORGENTE DA SMEUP_TST A SMEDEV
+     V* ££10916A  V5R1    BERNI **********************
+     V* 01/07/22  003975  BUSFIO Aggiunta stringa 16Mb in input
+     V* 05/07/22  V6R1   BMA Check-out 003975 in SMEDEV
+     V* ==============================================================
+      *
+      * DS di Input
+      * -----------
+     D£K37DI           DS          2560
+     D £K37I_FU                      10                                         Funzione
+     D £K37I_ME                      10                                         Metodo
+     D £K37I_PF                     256                                         Pathfile IFS
+     D £K37I_PA                    1000                                         Percorso Attributo
+     D £K37I_TI                      10                                         Tipo integrazione
+     D £K37I_XO                       1                                         XLS oggettizzato
+      * Stringa di Output (singola riga)
+      * ------------
+     D£K37I_ST         S               A   VARYING LEN(16773100)                Stringa input
+      *
+      * DS di Output
+      * ------------
+     D£K37DO           DS          1024
+     D £K37O_TA                       1                                         Tipo attributo
+     D £K37O_NU                      63 20                                      Valore numerico
+     D £K37O_MS                       7                                         Msg
+     D £K37O_FI                      10                                         File
+     D £K37O_TX                     198                                         Testo/variabili msg
+     D £K37O_ML                       2                                         Livello messaggio
+     D £K37O_MT                       5                                         Tipo messaggio
+     D £K37O_35                       1N                                        Indicatore 35
+     D* Definizione campo
+     D £K37O_NC                     010                                         Nome campo
+     D £K37O_DC                     100                                         Descrizione
+     D £K37O_OG                     012                                         Oggetto
+     D £K37O_OA                     015                                         Attributo OAV
+     D £K37O_LU                     003                                         Lunghezza
+     D £K37O_DE                     001                                         Decimali
+     D £K37O_VI                     001                                         Visualizzazione O/H
+     D £K37O_RD                     001                                         Risalita Descrizione
+     D £K37O_BC                     001                                         Aggiornamento batch
+     D £K37O_NN                     150                                         Nome Nodo
+     D £K37O_FZ                     001                                         Forzatura valore "0"
+      *
+      * Stringa di Output (valore alfanumerico)
+      * ------------
+     D£K37O_AL         S          32000    VARYING                              Valore alfanumerico
+      *----------------------------------------------------------------*

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MU711006.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MU711006.rpgle
@@ -1,0 +1,42 @@
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 18/08/24  MUTEST  APU001 Creazione
+     V*=====================================================================
+    O *  OBIETTIVO
+    O * Esecuzione di una COPY il cui nome possiede dei caratteri
+    O *  alfabetici in minuscolo.
+     V* ==============================================================
+      * --------------------------------------------------------------
+     D A71_01          S                   LIKE(£K37I_ST)
+      * --------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_D
+      /COPY QILEGEN,£TABB£1DS
+      /COPY QILEGEN,£PDS
+      /COPY QILEGEN,£k37DS
+      *---------------------------------------------------------------------
+    RD* M A I N
+      *---------------------------------------------------------------------
+     C                   EVAL      £DBG_Pgm = 'MU711006'
+     C                   EVAL      £DBG_Sez = 'A71'
+     C                   EVAL      £DBG_Fun = '*INZ'
+     C                   EXSR      £DBG
+     C                   EXSR      SEZ_A71
+     C                   EXSR      £DBG
+     C                   EVAL      £DBG_Fun = '*END'
+     C                   EXSR      £DBG
+     C                   SETON                                        LR
+      *---------------------------------------------------------------------
+    RD* COPY case insensitive
+      *---------------------------------------------------------------------
+     C     SEZ_A71       BEGSR
+    OA* A£.CDOP(/COPY)
+     C                   EVAL      £DBG_Pas='P06'
+      *
+     C                   EVAL      A71_01='HELLO THERE'
+     C                   EVAL      £DBG_Str=%TRIMR(A71_01)
+      *
+     C                   ENDSR
+      *---------------------------------------------------------------------
+      /COPY QILEGEN,MULANG_D_C


### PR DESCRIPTION
## Description
This work resolves an issue for resolving a name for COPY in `ETX4` file system, which is case sensitive.

Related to #LS24003436

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
