### PR TITLE
Feature/ls24003545/caller parms

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -815,7 +815,9 @@ class ExpressionEvaluation(
         StringValue(value.toString())
     }
 
-    override fun eval(expression: ParmsExpr): Value = proxyLogging(expression) { IntValue(interpreterStatus.params.toLong()) }
+    override fun eval(expression: ParmsExpr): Value = proxyLogging(expression) {
+        interpreterStatus.callerParams.asValue()
+    }
 
     override fun eval(expression: OpenExpr): Value = proxyLogging(expression) {
         val name = expression.name

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -64,7 +64,8 @@ class InterpreterStatus(
     val symbolTable: ISymbolTable,
     val indicators: HashMap<IndicatorKey, BooleanValue>,
     var returnValue: Value? = null,
-    var params: Int = 0
+    var params: Int = 0,
+    var callerParams: Int = params
 ) {
     var inzsrExecuted = false
     var lastFound = false
@@ -381,12 +382,14 @@ open class InternalInterpreter(
     fun execute(
         compilationUnit: CompilationUnit,
         initialValues: Map<String, Value>,
-        reinitialization: Boolean = true
+        reinitialization: Boolean = true,
+        callerParams: Map<String, Value> = initialValues
     ) {
         kotlin.runCatching {
             configureLogHandlers()
 
             this.status.displayFiles = compilationUnit.displayFiles
+            status.callerParams = callerParams.size
             status.params = initialValues.size
             initialize(compilationUnit, caseInsensitiveMap(initialValues), reinitialization)
             execINZSR(compilationUnit)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -83,6 +83,9 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
     override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
         val expectedKeys = params().asSequence().map { it.name }.toSet()
 
+        // Original params passed from the caller
+        val callerParams = LinkedHashMap(params)
+
         if (expectedKeys.size <= params.size) {
             require(params.keys.toSet() == params().asSequence().map { it.name }.toSet()) {
                 "Expected params: ${params().asSequence().map { it.name }.joinToString(", ")}"
@@ -151,7 +154,7 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
             // set reinitialization to false because symboltable cleaning currently is handled directly
             // in internal interpreter before exit
             // todo i don't know whether parameter reinitialization has still sense
-            interpreter.execute(this.cu, params, false)
+            interpreter.execute(this.cu, params, false, callerParams)
             MainExecutionContext.getConfiguration().jarikoCallback.onExitPgm(name, interpreter.getGlobalSymbolTable(), null)
             params.keys.forEach { params[it] = interpreter[it] }
             changedInitialValues = params().map { interpreter[it.name] }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2429,4 +2429,10 @@ Test 6
         program.singleCall(emptyList())
         assertEquals(systemInterface.consoleOutput, listOf(date, year, month, day))
     }
+
+    @Test
+    fun executeCALL_WITH_VOID_PARMS() {
+        val expected = listOf("ok")
+        assertEquals(expected, "VPARMSCALLER".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2448,7 +2448,7 @@ Test 6
 
     @Test
     fun executeCALL_WITH_VOID_PARMS() {
-        val expected = listOf("ok")
+        val expected = listOf("1")
         assertEquals(expected, "VPARMSCALLER".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLEE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLEE.rpgle
@@ -5,44 +5,11 @@
      D §40AE           S                   LIKE(£40AE)
 
      D £40A            S             15    DIM(300)
-     D £40B            S             12    DIM(300)
-
-     D§G40DS           S                   LIKE(£G40DS)
-
-     D £G40DS          DS           500
-     D  £G40PZ                        1                                         O Lista Dinamica
-     D  £G40EX                        1                                         O Lista Estesa
-     D  £G40FM                        1                                         O Formato Ext
-     D  £G40AE                        1                                         I Utilizzo £40AE
-     D  £G40FL                        1                                         I Applica Filtro JO
-     D  £G40NS                        1                                         I Disabilita SQL
-     D  £G40NE                        9S 0                                      O N° Elementi
-     D  £G40SC                       15                                         O Schema
-     D  £G40FO                       15                                         O Fonte
-     D  £G40T2                        2                                         I Tipo Oggetto Sec.
-     D  £G40P2                       10                                         I Parametro Ogg.Sec.
-     D  £G40C2                       15                                         I Cod.Ogg.Sec.
-     D  £G40UT                       10                                         O Utente
-     D  £G40AN                        1                                         O Annullata
 
      C                   IF        £PDSPR>=16
      C                   EVAL      £40AE=§40AE
      C                   ENDIF
 
      C     *ENTRY        PLIST
-     C                   PARM                    §G40FU           10            -->
-     C                   PARM                    §G40ME           10            -->
-     C                   PARM                    §G40MS            7            <--
-     C                   PARM                    §G40FI           10            <--
-     C                   PARM                    §G40CM            2            <--
-     C                   PARM                    §G40TP            2            -->  Tipo
-     C                   PARM                    §G40PA           10            -->  Param.
-     C                   PARM                    §G40CD           15            -->  Codice
-     C                   PARM                    £40A                           <--> Schiera
-     C                   PARM                    £40B                           <--> Schiera
-     C                   PARM                    §G40MV           15            <--> Cod.MDV
-     C                   PARM                    §G40DM           35            <--- Des.MDV
-     C                   PARM                    §G4035            1            <---
-     C                   PARM                    §G4036            1            <---
-     C                   PARM                    §G40DS
+     C                   PARM                    £40A
      C                   PARM                    §40AE

--- a/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLEE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLEE.rpgle
@@ -1,0 +1,48 @@
+     D                SDS
+     D  £PDSPR           *PARMS
+
+     D £40AE           S          30000    VARYING
+     D §40AE           S                   LIKE(£40AE)
+
+     D £40A            S             15    DIM(300)
+     D £40B            S             12    DIM(300)
+
+     D§G40DS           S                   LIKE(£G40DS)
+
+     D £G40DS          DS           500
+     D  £G40PZ                        1                                         O Lista Dinamica
+     D  £G40EX                        1                                         O Lista Estesa
+     D  £G40FM                        1                                         O Formato Ext
+     D  £G40AE                        1                                         I Utilizzo £40AE
+     D  £G40FL                        1                                         I Applica Filtro JO
+     D  £G40NS                        1                                         I Disabilita SQL
+     D  £G40NE                        9S 0                                      O N° Elementi
+     D  £G40SC                       15                                         O Schema
+     D  £G40FO                       15                                         O Fonte
+     D  £G40T2                        2                                         I Tipo Oggetto Sec.
+     D  £G40P2                       10                                         I Parametro Ogg.Sec.
+     D  £G40C2                       15                                         I Cod.Ogg.Sec.
+     D  £G40UT                       10                                         O Utente
+     D  £G40AN                        1                                         O Annullata
+
+     C                   IF        £PDSPR>=16
+     C                   EVAL      £40AE=§40AE
+     C                   ENDIF
+
+     C     *ENTRY        PLIST
+     C                   PARM                    §G40FU           10            -->
+     C                   PARM                    §G40ME           10            -->
+     C                   PARM                    §G40MS            7            <--
+     C                   PARM                    §G40FI           10            <--
+     C                   PARM                    §G40CM            2            <--
+     C                   PARM                    §G40TP            2            -->  Tipo
+     C                   PARM                    §G40PA           10            -->  Param.
+     C                   PARM                    §G40CD           15            -->  Codice
+     C                   PARM                    £40A                           <--> Schiera
+     C                   PARM                    £40B                           <--> Schiera
+     C                   PARM                    §G40MV           15            <--> Cod.MDV
+     C                   PARM                    §G40DM           35            <--- Des.MDV
+     C                   PARM                    §G4035            1            <---
+     C                   PARM                    §G4036            1            <---
+     C                   PARM                    §G40DS
+     C                   PARM                    §40AE

--- a/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLEE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLEE.rpgle
@@ -1,15 +1,12 @@
+     D P1              S             10
+     D P2              S             10
+
      D                SDS
      D  £PDSPR           *PARMS
 
-     D £40AE           S          30000    VARYING
-     D §40AE           S                   LIKE(£40AE)
-
-     D £40A            S             15    DIM(300)
-
-     C                   IF        £PDSPR>=16
-     C                   EVAL      £40AE=§40AE
-     C                   ENDIF
 
      C     *ENTRY        PLIST
-     C                   PARM                    £40A
-     C                   PARM                    §40AE
+     C                   PARM                    P1
+     C                   PARM                    P2
+
+     C     £PDSPR        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLER.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLER.rpgle
@@ -1,40 +1,9 @@
      D £DBG_Str        S             2
 
      D £40A            S             15    DIM(300)
-     D £40B            S             12    DIM(300)
-
-     D £G40DS          DS           500
-     D  £G40PZ                        1                                         O Lista Dinamica
-     D  £G40EX                        1                                         O Lista Estesa
-     D  £G40FM                        1                                         O Formato Ext
-     D  £G40AE                        1                                         I Utilizzo £40AE
-     D  £G40FL                        1                                         I Applica Filtro JO
-     D  £G40NS                        1                                         I Disabilita SQL
-     D  £G40NE                        9S 0                                      O N° Elementi
-     D  £G40SC                       15                                         O Schema
-     D  £G40FO                       15                                         O Fonte
-     D  £G40T2                        2                                         I Tipo Oggetto Sec.
-     D  £G40P2                       10                                         I Parametro Ogg.Sec.
-     D  £G40C2                       15                                         I Cod.Ogg.Sec.
-     D  £G40UT                       10                                         O Utente
-     D  £G40AN                        1                                         O Annullata
 
      C                   CALL      'VPARMSCALLEE'
-     C                   PARM                    £G40FU           10            -->
-     C                   PARM                    £G40ME           10            -->
-     C                   PARM                    £G40MS            7            <--
-     C                   PARM                    £G40FI           10            <--
-     C                   PARM                    £G40CM            2            <--
-     C                   PARM                    £G40TP            2            -->  Tipo
-     C                   PARM                    £G40PA           10            -->  Param.
-     C                   PARM                    £G40CD           15            -->  Codice
-     C                   PARM                    £40A                           <--> Sch.Oggetti
-     C                   PARM                    £40B                           <--> Sch.TipPar.
-     C                   PARM                    £G40MV           15            <--> Cod.MDV
-     C                   PARM                    £G40DM           35            <--- Des.MDV
-     C                   PARM                    £G4035            1            <---
-     C                   PARM                    £G4036            1            <---
-     C                   PARM                    £G40DS                         <--> Estensione
+     C                   PARM                    £40A
 
      C                   EVAL      £DBG_Str='ok'
      C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLER.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLER.rpgle
@@ -1,0 +1,40 @@
+     D £DBG_Str        S             2
+
+     D £40A            S             15    DIM(300)
+     D £40B            S             12    DIM(300)
+
+     D £G40DS          DS           500
+     D  £G40PZ                        1                                         O Lista Dinamica
+     D  £G40EX                        1                                         O Lista Estesa
+     D  £G40FM                        1                                         O Formato Ext
+     D  £G40AE                        1                                         I Utilizzo £40AE
+     D  £G40FL                        1                                         I Applica Filtro JO
+     D  £G40NS                        1                                         I Disabilita SQL
+     D  £G40NE                        9S 0                                      O N° Elementi
+     D  £G40SC                       15                                         O Schema
+     D  £G40FO                       15                                         O Fonte
+     D  £G40T2                        2                                         I Tipo Oggetto Sec.
+     D  £G40P2                       10                                         I Parametro Ogg.Sec.
+     D  £G40C2                       15                                         I Cod.Ogg.Sec.
+     D  £G40UT                       10                                         O Utente
+     D  £G40AN                        1                                         O Annullata
+
+     C                   CALL      'VPARMSCALLEE'
+     C                   PARM                    £G40FU           10            -->
+     C                   PARM                    £G40ME           10            -->
+     C                   PARM                    £G40MS            7            <--
+     C                   PARM                    £G40FI           10            <--
+     C                   PARM                    £G40CM            2            <--
+     C                   PARM                    £G40TP            2            -->  Tipo
+     C                   PARM                    £G40PA           10            -->  Param.
+     C                   PARM                    £G40CD           15            -->  Codice
+     C                   PARM                    £40A                           <--> Sch.Oggetti
+     C                   PARM                    £40B                           <--> Sch.TipPar.
+     C                   PARM                    £G40MV           15            <--> Cod.MDV
+     C                   PARM                    £G40DM           35            <--- Des.MDV
+     C                   PARM                    £G4035            1            <---
+     C                   PARM                    £G4036            1            <---
+     C                   PARM                    £G40DS                         <--> Estensione
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLER.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/VPARMSCALLER.rpgle
@@ -1,9 +1,7 @@
      D £DBG_Str        S             2
+     D P1              S             10
 
-     D £40A            S             15    DIM(300)
+     C                   EVAL      P1='hello'
 
      C                   CALL      'VPARMSCALLEE'
-     C                   PARM                    £40A
-
-     C                   EVAL      £DBG_Str='ok'
-     C     £DBG_Str      DSPLY
+     C                   PARM                    P1


### PR DESCRIPTION
## Description

Add a field to keep caller params in `InterpreterStatus`. This is immediately needed in order to fix the improper evaluation of `ParmsExpr`.

Related to:
- LS24003545

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
