### PR TITLE
Feature/ls24003656/error data reference when is used api directive

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -205,13 +205,14 @@ open class BaseCompileTimeInterpreter(
                         if (it.directive().dir_api() != null) {
                             val apiDirective = it.directive().dir_api()
                             val apiId = apiDirective.toApiId(conf)
-                            return apiId.loadAndUse { api ->
+                            val size = apiId.loadAndUse { api ->
                                 api.let {
                                     it.compilationUnit.dataDefinitions.firstOrNull { def ->
                                         def.name.equals(declName, ignoreCase = true)
                                     }
-                                }?.let { it.type.size }
+                                }?.type?.size
                             }
+                            if (size != null) return size
                         }
                     }
                 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -1,7 +1,6 @@
 package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.db.utilities.DBServer
-import com.smeup.rpgparser.execution.Configuration
 import com.smeup.rpgparser.smeup.dbmock.MULANGTLDbMock
 import org.junit.Test
 import kotlin.test.AfterTest

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -1,6 +1,7 @@
 package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.db.utilities.DBServer
+import com.smeup.rpgparser.execution.Configuration
 import com.smeup.rpgparser.smeup.dbmock.MULANGTLDbMock
 import org.junit.Test
 import kotlin.test.AfterTest
@@ -206,6 +207,16 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
                 "smeup/MUDRNRAPU00101".outputOf(configuration = smeupConfig)
             )
         }
+    }
+
+    /**
+     * Resolves problem od Data Reference with LIKE when in the RPG source is used an API directive.
+     * @see LS24003656
+     */
+    @Test
+    fun executeMUDRNRAPU00102() {
+        val expected = listOf("HELLO THERE")
+        assertEquals(expected, "smeup/MUDRNRAPU00102".outputOf(configuration = smeupConfig))
     }
 
     /**

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00102.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00102.rpgle
@@ -1,0 +1,23 @@
+     D $FOO            S                   LIKE(£FOO)
+     D STR             S             15    INZ('HELLO THERE')
+
+     C                   EXSR      SUB01
+
+     C     *INZSR        BEGSR
+     C                   EXSR      £INIZI
+     C                   ENDSR
+
+
+     C     £INIZI        BEGSR
+     C     *ENTRY        PLIST
+     C     $FOO          PARM                    £FOO             10
+     C                   ENDSR
+
+
+     C     SUB01         BEGSR
+     C                   IF        $FOO <> 'BAR'
+     C     STR           DSPLY
+     C                   ENDIF
+     C                   ENDSR
+
+      /API QILEGEN,£OAV


### PR DESCRIPTION
## Description
This works is made in pair with @dom-apuliasoft. Resolves a problem of Data Reference when the RPG program has the `API` directive.

Related to LS24003656

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
