### PR TITLE
Bugfix/ the compile function hides "data reference not resolved" errors in case of "an operation not implemented" errors

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -639,6 +639,20 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR35CallBackTest() {
+        executePgmCallBackTest(
+            pgm = "ERROR35",
+            sourceReferenceType = SourceReferenceType.Program,
+            sourceId = "ERROR35",
+            lines = listOf(9, 10))
+    }
+
+    @Test
+    fun executeERROR35CSourceLineTest() {
+        executeSourceLineTest(pgm = "ERROR35")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
@@ -322,4 +322,36 @@ class MiscTest {
             System.err.println("Stderr restored")
         }
     }
+
+    /**
+     * When compile error occurs, the error event must be the same of what is expected
+     * when the errors occur during the interpretation of the program
+     * */
+    @Test
+    fun onCompileErrorEventMustBeTheSame() {
+        val expectedLines = listOf(10, 11)
+        val dir = File("src/test/resources")
+        File(dir, "ERROR35.rpgle").inputStream().use { src ->
+            var errorLines = mutableListOf<Int>()
+            val configuration = Configuration().apply {
+                jarikoCallback.onError = { errorEvent ->
+                    errorEvent?.sourceReference?.relativeLine?.let {
+                        errorLines.add(it)
+                    }
+                }
+            }
+            kotlin.runCatching {
+                compile(
+                    src = src,
+                    out = ByteArrayOutputStream(),
+                    format = Format.BIN,
+                    programFinders = listOf(),
+                    configuration = configuration
+                )
+            }.onSuccess {
+                fail("ERROR35 cannot be compiled")
+            }
+            assertEquals(expected = expectedLines, actual = errorLines)
+        }
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/utils/MiscTest.kt
@@ -329,7 +329,7 @@ class MiscTest {
      * */
     @Test
     fun onCompileErrorEventMustBeTheSame() {
-        val expectedLines = listOf(10, 11)
+        val expectedLines = listOf(9, 10)
         val dir = File("src/test/resources")
         File(dir, "ERROR35.rpgle").inputStream().use { src ->
             var errorLines = mutableListOf<Int>()
@@ -343,7 +343,7 @@ class MiscTest {
             kotlin.runCatching {
                 compile(
                     src = src,
-                    out = ByteArrayOutputStream(),
+                    out = null,
                     format = Format.BIN,
                     programFinders = listOf(),
                     configuration = configuration
@@ -351,7 +351,7 @@ class MiscTest {
             }.onSuccess {
                 fail("ERROR35 cannot be compiled")
             }
-            assertEquals(expected = expectedLines, actual = errorLines)
+            assertEquals(expected = expectedLines.sorted(), actual = errorLines.sorted())
         }
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR35.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR35.rpgle
@@ -4,7 +4,7 @@
      D* "missing sympol implementation" and "data reference not resolved"
      D* errors
      D* Expected errors at line:
-     D* 10 and 11
+     D* 9 and 10
      V* ==============================================================
      C     MSG           DSPLY
      C                   ABCDE

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR35.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR35.rpgle
@@ -1,0 +1,10 @@
+     V* ==============================================================
+     D* 01/08/24  nn.mm lanmam
+     D* Purpose: SyntaxChecking with compile must show bot
+     D* "missing sympol implementation" and "data reference not resolved"
+     D* errors
+     D* Expected errors at line:
+     D* 10 and 11
+     V* ==============================================================
+     C     MSG           DSPLY
+     C                   ABCDE


### PR DESCRIPTION
## Description
Since the `compile` function was designed to serialize the `CompilationUnit`, if there is at least one error before serialization, the function must throw an error. However, due to technical reasons, we must serialize the `CompilationUnit` before calling `CompilationUnit.resolveAndValidate`, which means we might miss information about unresolved data reference errors.

To address this issue, the `compile` function has been refactored. If the `out` parameter is passed as `null`, it indicates that the method is being used solely for syntax checking. In this case, all errors, including unresolved data references, will be reported before the function throws the final error.

## Checklist:
- [X] There are tests for this feature.
- [X] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [X] The code passes all tests (run `./gradlew check`).
- [ ] There is specific documentation in the `docs` directory.