### PR TITLE
Bugfix/ls24003689/data reference by using api directive

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -317,6 +317,21 @@ open class BaseCompileTimeInterpreter(
                             val type = it.block().findType(declName, conf)
                             if (type != null) return type
                         }
+                        it.directive() != null -> {
+                            // API Directives
+                            if (it.directive().dir_api() != null) {
+                                val apiDirective = it.directive().dir_api()
+                                val apiId = apiDirective.toApiId(conf)
+                                val type = apiId.loadAndUse { api ->
+                                    api.let {
+                                        it.compilationUnit.dataDefinitions.firstOrNull { def ->
+                                            def.name.equals(declName, ignoreCase = true)
+                                        }
+                                    }?.type
+                                }
+                                if (type != null) return type
+                            }
+                        }
                     }
                 }
             }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT70CompilationDirectiveTest.kt
@@ -57,4 +57,14 @@ open class MULANGT70CompilationDirectiveTest : MULANGTTest() {
         val expected = listOf("HELLO THERE")
         assertEquals(expected, "smeup/MU711006".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Data Definition with LIKE of another variable imported with API directive
+     * @see #LS24003689
+     */
+    @Test
+    fun executeMUDRNRAPU00103() {
+        val expected = listOf("HELLO THERE")
+        assertEquals(expected, "smeup/MUDRNRAPU00103".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00103.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00103.rpgle
@@ -1,0 +1,6 @@
+     D FOO             S                   LIKE(£DECCD)
+
+      /API QILEGEN,£DEC
+
+     C                   EVAL      FOO = 'HELLO THERE'
+     C     FOO           DSPLY


### PR DESCRIPTION
## Description
This work resolves utilization of `LIKE` to a variable imported by `API` directive.

Related to LS24003689

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
