### PR TITLE
Bugfix/ls24003532/immutable index arrayaccess

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
@@ -333,7 +333,7 @@ data class QualifiedAccessExpr(val container: Expression, val field: ReferenceBy
 }
 
 @Serializable
-data class ArrayAccessExpr(val array: Expression, val index: Expression, override val position: Position? = null) :
+data class ArrayAccessExpr(var array: Expression, var index: Expression, override val position: Position? = null) :
     AssignableExpression(position) {
     override fun render(): String {
         return "${this.array.render()}(${index.render()}))"

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -528,4 +528,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("0")
         assertEquals(expected, "smeup/MUDRNRAPU00241".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Access to an array detected as a function call by parser in ArrayAccessExpr
+     * @see #LS24003380
+     */
+    @Test
+    fun executeMUDRNRAPU00243() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00243".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00243.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00243.rpgle
@@ -1,0 +1,11 @@
+     D £DBG_Str        S             2
+     D £C6JDSO         DS           512
+     D  £C6JO_TO                      2  0 DIM(10)
+     D $X              S              5  0
+     D §§IMPO          S              6  0
+     D T$AG_I          S             21  6 DIM(15)
+     C                   EVAL      $X=2
+     C                   IF        £C6JO_TO($X)=0
+     C                   ENDIF
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Make `ArrayAccessExpr` fields mutable in order to accomodate `FunctionCallExpr` rewriting.

Related to:
- #559
- #574 
- #568

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
