### PR TITLE
Bugfix/ls24003755/ds to string when ds is greater than string

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -967,7 +967,7 @@ data class DataStructValue(var value: String, private val optionalExternalLen: I
             // Check if the size of the value matches the expected size within the DS
             // TO REVIEW
             is DataStructureType -> true
-            is StringType -> expectedType.size >= this.value.length
+            is StringType -> true
             else -> false
         }
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -635,20 +635,29 @@ data class ConcreteArrayValue(val elements: MutableList<Value>, override val ele
         require(value.assignableTo(elementType)) {
             "Cannot assign ${value::class.qualifiedName} to ${elementType::class.qualifiedName}"
         }
-        if (elementType is StringType && !elementType.varying) {
-            val v = when (value) {
-                is AbstractStringValue -> {
-                    (value as StringValue).copy()
+        when (elementType) {
+            is StringType -> {
+                val v = when (value) {
+                    is AbstractStringValue -> {
+                        (value as StringValue).copy()
+                    }
+                    is DataStructValue -> {
+                        value.asString().copy()
+                    }
+                    else -> TODO("Not yet implemented")
                 }
-                is DataStructValue -> {
-                    value.asString().copy()
+
+                /*
+                 * Setting the value based of varying flag and length of target.
+                 */
+                if (!elementType.varying && v.length() < elementType.length) {
+                    v.pad(elementType.length)
+                } else if (v.length() > elementType.length) {
+                    v.setSubstring(0, elementType.length)
                 }
-                else -> TODO("Not yet implemented")
+                elements[index - 1] = v
             }
-            v.pad(elementType.length)
-            elements[index - 1] = v
-        } else {
-            elements[index - 1] = value
+            else -> elements[index - 1] = value
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -143,13 +143,12 @@ data class StringValue(var value: String, var varying: Boolean = false) : Abstra
 
     override fun asTimeStamp(): TimeStampValue = TimeStampValue.of(value)
 
-    fun setSubstring(startOffset: Int, endOffset: Int, substringValue: StringValue) {
+    fun setSubstring(startOffset: Int, endOffset: Int) {
         require(startOffset >= 0)
         require(startOffset <= value.length)
         require(endOffset >= startOffset)
         require(endOffset <= value.length) { "Asked startOffset=$startOffset, endOffset=$endOffset on string of length ${value.length}" }
-        substringValue.pad(endOffset - startOffset)
-        value = value.substring(0, startOffset) + substringValue.value + value.substring(endOffset)
+        value = value.substring(startOffset, endOffset)
     }
 
     fun getSubstring(startOffset: Int, endOffset: Int): StringValue {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -633,9 +633,6 @@ data class ConcreteArrayValue(val elements: MutableList<Value>, override val ele
     override fun setElement(index: Int, value: Value) {
         require(index >= 1)
         require(index <= arrayLength())
-        if (!value.assignableTo(elementType)) {
-            println("boom")
-        }
         require(value.assignableTo(elementType)) {
             "Cannot assign ${value::class.qualifiedName} to ${elementType::class.qualifiedName}"
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -65,6 +65,16 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
     }
 
     /**
+     *Assigns content of DS to a String not VARYING in EVAL where, size of DS is greater than String
+     * @see #LS24003755
+     */
+    @Test
+    fun executeMUDRNRAPU00107() {
+        val expected = listOf("Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aeean commodo ligula eget dolor. Aenean ma")
+        assertEquals(expected, "smeup/MUDRNRAPU00107".outputOf())
+    }
+
+    /**
      * %DIFF with several DurationCodes
      * @see #LS24003282
      */

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -55,6 +55,16 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
     }
 
     /**
+     *Assigns content of DS to a String not VARYING in EVAL where, size of DS is greater than String
+     * @see #LS24003755
+     */
+    @Test
+    fun executeMUDRNRAPU00106() {
+        val expected = listOf("Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aeean commodo ligula eget dolor. Aenean ma")
+        assertEquals(expected, "smeup/MUDRNRAPU00106".outputOf())
+    }
+
+    /**
      * %DIFF with several DurationCodes
      * @see #LS24003282
      */

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -45,7 +45,7 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
     }
 
     /**
-     *Assigns content of DS to a String  VARYING in EVAL
+     *Assigns content of DS to a String VARYING in EVAL
      * @see #LS24003679
      */
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -60,7 +60,7 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00106() {
-        val expected = listOf("Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aeean commodo ligula eget dolor. Aenean ma")
+        val expected = listOf("Lorem ipsum dolor sit amet, consectetuer adipiscin")
         assertEquals(expected, "smeup/MUDRNRAPU00106".outputOf())
     }
 
@@ -70,7 +70,7 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00107() {
-        val expected = listOf("Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aeean commodo ligula eget dolor. Aenean ma")
+        val expected = listOf("Lorem ipsum dolor sit amet, consectetuer adipiscin")
         assertEquals(expected, "smeup/MUDRNRAPU00107".outputOf())
     }
 

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00106.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00106.rpgle
@@ -1,3 +1,22 @@
+     V* ==============================================================
+     V* 08/08/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment the content of DS to an element of array that is
+    O *  String type (not varying) with size smaller than DS.
+    O * After declaration of variable there is the assignment of
+    O *  specific substring of "Lorem ipsum" to every field of DS.
+    O * Then, there is the assignment of DS content to an element
+    O *  of array. In AS400 there is a truncate of content for adapting
+    O *  to destination, smaller than DS.
+    O * The implementation is like the original source, by changing
+    O *  only the name of variables and by adding the assignment
+    O *  of substring to undestand about the behavior.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was
+    O *  `Cannot assign DataStructValue to StringType`.
+     V* ==============================================================
      D A40_A100        S            100    DIM(300)
      D A40_DS          DS
      D  A40_DS_F1                    10

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00106.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00106.rpgle
@@ -1,0 +1,55 @@
+     D A40_A100        S            100    DIM(300)
+     D A40_DS          DS
+     D  A40_DS_F1                    10
+     D  A40_DS_F2                    29
+     D  A40_DS_F3                    21
+     D  A40_DS_F4                    01
+     D  A40_DS_F5                    04
+     D  A40_DS_F6                    01
+     D  A40_DS_F7                    01
+     D  A40_DS_F8                    10
+     D  A40_DS_F9                    16
+     D  A40_DS_F10                   02
+     D  A40_DS_F11                   05
+     D  A40_DS_F12                  100
+     D  A40_DS_F13                  300
+     D A40_A5          S              5  0
+
+     D OUTPUT          S            100
+
+     C                   EVAL      A40_DS_F1='Lorem ipsu'
+     C                   EVAL      A40_DS_F2='m dolor sit amet, consectetue'
+     C                   EVAL      A40_DS_F3='r adipiscing elit. Ae'
+     C                   EVAL      A40_DS_F4='e'
+     C                   EVAL      A40_DS_F5='an c'
+     C                   EVAL      A40_DS_F6='o'
+     C                   EVAL      A40_DS_F7='m'
+     C                   EVAL      A40_DS_F8='modo ligul'
+     C                   EVAL      A40_DS_F9='a eget dolor. Ae'
+     C                   EVAL      A40_DS_F10='ne'
+     C                   EVAL      A40_DS_F11='an ma'
+     C                   EVAL      A40_DS_F12='ssa. Cum sociis natoque penatib'
+     c                                            + 'us et magnis dis '
+     C                                            + 'partu rient montes, nasce'
+     C                                            + 'tur ridiculus mus.'
+     C                                            + ' Donec qua'
+     C                   EVAL      A40_DS_F13='m felis, ultricies nec, pellen'
+     C                                            + 'tesque eu, pretium'
+     C                                            + ' quis, sem. Nulla conse'
+     C                                            + 'quat massa quis '
+     C                                            + 'enim. Donec pede justo, '
+     C                                            + 'fringilla vel, '
+     C                                            + 'aliquet nec, vulputate'
+     C                                            + ' eget, arcu. '
+     C                                            + 'In enim justo, rhoncus '
+     C                                            + 'ut, imperdiet a, '
+     C                                            + 'venenatis vitae, justo. '
+     C                                            + 'Nullam dictum '
+     C                                            + 'felis eu pede mollis '
+     C                                            + 'pretium. Integer '
+     C                                            + 'tincidunt. Cras dapibus'
+
+     C                   EVAL      A40_A5=1
+     C                   EVAL      A40_A100(A40_A5)=A40_DS
+     C                   EVAL      OUTPUT=A40_A100(A40_A5)
+     C     OUTPUT        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00106.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00106.rpgle
@@ -1,5 +1,7 @@
      V* ==============================================================
      V* 08/08/2024 APU001 Creation
+     V* 20/08/2024 APU001 Simplification by removing several
+     V*                   fields of DS.
      V* ==============================================================
     O * PROGRAM GOAL
     O * Assignment the content of DS to an element of array that is
@@ -17,58 +19,21 @@
     O * Before the fix, the error occurred was
     O *  `Cannot assign DataStructValue to StringType`.
      V* ==============================================================
-     D A40_A100        S            100    DIM(300)
+     D A40_A50         S             50    DIM(300)
      D A40_DS          DS
-     D  A40_DS_F1                    10
-     D  A40_DS_F2                    29
-     D  A40_DS_F3                    21
-     D  A40_DS_F4                    01
-     D  A40_DS_F5                    04
-     D  A40_DS_F6                    01
-     D  A40_DS_F7                    01
-     D  A40_DS_F8                    10
-     D  A40_DS_F9                    16
-     D  A40_DS_F10                   02
-     D  A40_DS_F11                   05
-     D  A40_DS_F12                  100
-     D  A40_DS_F13                  300
+     D  A40_DS_F1                    20
+     D  A40_DS_F2                    20
+     D  A40_DS_F3                    35
      D A40_A5          S              5  0
 
-     D OUTPUT          S            100
+     D OUTPUT          S             50
 
-     C                   EVAL      A40_DS_F1='Lorem ipsu'
-     C                   EVAL      A40_DS_F2='m dolor sit amet, consectetue'
-     C                   EVAL      A40_DS_F3='r adipiscing elit. Ae'
-     C                   EVAL      A40_DS_F4='e'
-     C                   EVAL      A40_DS_F5='an c'
-     C                   EVAL      A40_DS_F6='o'
-     C                   EVAL      A40_DS_F7='m'
-     C                   EVAL      A40_DS_F8='modo ligul'
-     C                   EVAL      A40_DS_F9='a eget dolor. Ae'
-     C                   EVAL      A40_DS_F10='ne'
-     C                   EVAL      A40_DS_F11='an ma'
-     C                   EVAL      A40_DS_F12='ssa. Cum sociis natoque penatib'
-     c                                            + 'us et magnis dis '
-     C                                            + 'partu rient montes, nasce'
-     C                                            + 'tur ridiculus mus.'
-     C                                            + ' Donec qua'
-     C                   EVAL      A40_DS_F13='m felis, ultricies nec, pellen'
-     C                                            + 'tesque eu, pretium'
-     C                                            + ' quis, sem. Nulla conse'
-     C                                            + 'quat massa quis '
-     C                                            + 'enim. Donec pede justo, '
-     C                                            + 'fringilla vel, '
-     C                                            + 'aliquet nec, vulputate'
-     C                                            + ' eget, arcu. '
-     C                                            + 'In enim justo, rhoncus '
-     C                                            + 'ut, imperdiet a, '
-     C                                            + 'venenatis vitae, justo. '
-     C                                            + 'Nullam dictum '
-     C                                            + 'felis eu pede mollis '
-     C                                            + 'pretium. Integer '
-     C                                            + 'tincidunt. Cras dapibus'
+     C                   EVAL      A40_DS_F1='Lorem ipsum dolor si'
+     C                   EVAL      A40_DS_F2='t amet, consectetuer'
+     C                   EVAL      A40_DS_F3=' adipiscing elit. Aeean'
+     C                                       + ' commodo lig'
 
      C                   EVAL      A40_A5=1
-     C                   EVAL      A40_A100(A40_A5)=A40_DS                           Jariko Runtime Error: `Cannot assign DataStructValue to StringType`
-     C                   EVAL      OUTPUT=A40_A100(A40_A5)
+     C                   EVAL      A40_A50(A40_A5)=A40_DS                            Jariko Runtime Error: `Cannot assign DataStructValue to StringType`
+     C                   EVAL      OUTPUT=A40_A50(A40_A5)
      C     OUTPUT        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00106.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00106.rpgle
@@ -69,6 +69,6 @@
      C                                            + 'tincidunt. Cras dapibus'
 
      C                   EVAL      A40_A5=1
-     C                   EVAL      A40_A100(A40_A5)=A40_DS
+     C                   EVAL      A40_A100(A40_A5)=A40_DS                           Jariko Runtime Error: `Cannot assign DataStructValue to StringType`
      C                   EVAL      OUTPUT=A40_A100(A40_A5)
      C     OUTPUT        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00107.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00107.rpgle
@@ -1,3 +1,22 @@
+     V* ==============================================================
+     V* 08/08/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment the content of DS to an element of array that is
+    O *  String type (varying) with size smaller than DS.
+    O * After declaration of variable there is the assignment of
+    O *  specific substring of "Lorem ipsum" to every field of DS.
+    O * Then, there is the assignment of DS content to an element
+    O *  of array. In AS400 there is a truncate of content for adapting
+    O *  to destination, smaller than DS.
+    O * The implementation is like the original source, by changing
+    O *  only the name of variables and by adding the assignment
+    O *  of substring to undestand about the behavior.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was
+    O *  `Cannot assign DataStructValue to StringType`.
+     V* ==============================================================
      D A40_A100        S            100    DIM(300) VARYING
      D A40_DS          DS
      D  A40_DS_F1                    10

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00107.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00107.rpgle
@@ -1,0 +1,55 @@
+     D A40_A100        S            100    DIM(300) VARYING
+     D A40_DS          DS
+     D  A40_DS_F1                    10
+     D  A40_DS_F2                    29
+     D  A40_DS_F3                    21
+     D  A40_DS_F4                    01
+     D  A40_DS_F5                    04
+     D  A40_DS_F6                    01
+     D  A40_DS_F7                    01
+     D  A40_DS_F8                    10
+     D  A40_DS_F9                    16
+     D  A40_DS_F10                   02
+     D  A40_DS_F11                   05
+     D  A40_DS_F12                  100
+     D  A40_DS_F13                  300
+     D A40_A5          S              5  0
+
+     D OUTPUT          S            100
+
+     C                   EVAL      A40_DS_F1='Lorem ipsu'
+     C                   EVAL      A40_DS_F2='m dolor sit amet, consectetue'
+     C                   EVAL      A40_DS_F3='r adipiscing elit. Ae'
+     C                   EVAL      A40_DS_F4='e'
+     C                   EVAL      A40_DS_F5='an c'
+     C                   EVAL      A40_DS_F6='o'
+     C                   EVAL      A40_DS_F7='m'
+     C                   EVAL      A40_DS_F8='modo ligul'
+     C                   EVAL      A40_DS_F9='a eget dolor. Ae'
+     C                   EVAL      A40_DS_F10='ne'
+     C                   EVAL      A40_DS_F11='an ma'
+     C                   EVAL      A40_DS_F12='ssa. Cum sociis natoque penatib'
+     c                                            + 'us et magnis dis '
+     C                                            + 'partu rient montes, nasce'
+     C                                            + 'tur ridiculus mus.'
+     C                                            + ' Donec qua'
+     C                   EVAL      A40_DS_F13='m felis, ultricies nec, pellen'
+     C                                            + 'tesque eu, pretium'
+     C                                            + ' quis, sem. Nulla conse'
+     C                                            + 'quat massa quis '
+     C                                            + 'enim. Donec pede justo, '
+     C                                            + 'fringilla vel, '
+     C                                            + 'aliquet nec, vulputate'
+     C                                            + ' eget, arcu. '
+     C                                            + 'In enim justo, rhoncus '
+     C                                            + 'ut, imperdiet a, '
+     C                                            + 'venenatis vitae, justo. '
+     C                                            + 'Nullam dictum '
+     C                                            + 'felis eu pede mollis '
+     C                                            + 'pretium. Integer '
+     C                                            + 'tincidunt. Cras dapibus'
+
+     C                   EVAL      A40_A5=1
+     C                   EVAL      A40_A100(A40_A5)=A40_DS
+     C                   EVAL      OUTPUT=A40_A100(A40_A5)
+     C     OUTPUT        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00107.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00107.rpgle
@@ -69,6 +69,6 @@
      C                                            + 'tincidunt. Cras dapibus'
 
      C                   EVAL      A40_A5=1
-     C                   EVAL      A40_A100(A40_A5)=A40_DS
+     C                   EVAL      A40_A100(A40_A5)=A40_DS                           Jariko Runtime Error: `Cannot assign DataStructValue to StringType`
      C                   EVAL      OUTPUT=A40_A100(A40_A5)
      C     OUTPUT        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00107.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00107.rpgle
@@ -1,5 +1,7 @@
      V* ==============================================================
      V* 08/08/2024 APU001 Creation
+     V* 20/08/2024 APU001 Simplification by removing several
+     V*                   fields of DS.
      V* ==============================================================
     O * PROGRAM GOAL
     O * Assignment the content of DS to an element of array that is
@@ -17,58 +19,21 @@
     O * Before the fix, the error occurred was
     O *  `Cannot assign DataStructValue to StringType`.
      V* ==============================================================
-     D A40_A100        S            100    DIM(300) VARYING
+     D A40_A50         S             50    DIM(300) VARYING
      D A40_DS          DS
-     D  A40_DS_F1                    10
-     D  A40_DS_F2                    29
-     D  A40_DS_F3                    21
-     D  A40_DS_F4                    01
-     D  A40_DS_F5                    04
-     D  A40_DS_F6                    01
-     D  A40_DS_F7                    01
-     D  A40_DS_F8                    10
-     D  A40_DS_F9                    16
-     D  A40_DS_F10                   02
-     D  A40_DS_F11                   05
-     D  A40_DS_F12                  100
-     D  A40_DS_F13                  300
+     D  A40_DS_F1                    20
+     D  A40_DS_F2                    20
+     D  A40_DS_F3                    35
      D A40_A5          S              5  0
 
-     D OUTPUT          S            100
+     D OUTPUT          S             50
 
-     C                   EVAL      A40_DS_F1='Lorem ipsu'
-     C                   EVAL      A40_DS_F2='m dolor sit amet, consectetue'
-     C                   EVAL      A40_DS_F3='r adipiscing elit. Ae'
-     C                   EVAL      A40_DS_F4='e'
-     C                   EVAL      A40_DS_F5='an c'
-     C                   EVAL      A40_DS_F6='o'
-     C                   EVAL      A40_DS_F7='m'
-     C                   EVAL      A40_DS_F8='modo ligul'
-     C                   EVAL      A40_DS_F9='a eget dolor. Ae'
-     C                   EVAL      A40_DS_F10='ne'
-     C                   EVAL      A40_DS_F11='an ma'
-     C                   EVAL      A40_DS_F12='ssa. Cum sociis natoque penatib'
-     c                                            + 'us et magnis dis '
-     C                                            + 'partu rient montes, nasce'
-     C                                            + 'tur ridiculus mus.'
-     C                                            + ' Donec qua'
-     C                   EVAL      A40_DS_F13='m felis, ultricies nec, pellen'
-     C                                            + 'tesque eu, pretium'
-     C                                            + ' quis, sem. Nulla conse'
-     C                                            + 'quat massa quis '
-     C                                            + 'enim. Donec pede justo, '
-     C                                            + 'fringilla vel, '
-     C                                            + 'aliquet nec, vulputate'
-     C                                            + ' eget, arcu. '
-     C                                            + 'In enim justo, rhoncus '
-     C                                            + 'ut, imperdiet a, '
-     C                                            + 'venenatis vitae, justo. '
-     C                                            + 'Nullam dictum '
-     C                                            + 'felis eu pede mollis '
-     C                                            + 'pretium. Integer '
-     C                                            + 'tincidunt. Cras dapibus'
+     C                   EVAL      A40_DS_F1='Lorem ipsum dolor si'
+     C                   EVAL      A40_DS_F2='t amet, consectetuer'
+     C                   EVAL      A40_DS_F3=' adipiscing elit. Aeean'
+     C                                       + ' commodo lig'
 
      C                   EVAL      A40_A5=1
-     C                   EVAL      A40_A100(A40_A5)=A40_DS                           Jariko Runtime Error: `Cannot assign DataStructValue to StringType`
-     C                   EVAL      OUTPUT=A40_A100(A40_A5)
+     C                   EVAL      A40_A50(A40_A5)=A40_DS                            Jariko Runtime Error: `Cannot assign DataStructValue to StringType`
+     C                   EVAL      OUTPUT=A40_A50(A40_A5)
      C     OUTPUT        DSPLY


### PR DESCRIPTION
## Description
This work fixes the assignment of DS content to an element of array which is String with size smaller than DS.
Under the hood has been removed restriction of size, by considering that RPG truncates the DS content if the target is smaller than source, in this case a String. Then, has been applied the fix with an important refactoring of code, by using `when` construct. If the target is `StringType`, performs the right padding or truncating based of size and varying flag. For truncating, the unused method `setSubstring` has been refactored for the purpose.
Finally, the two simple RPG programs for tests has been developed and executed on AS400.

Related to #LS24003755

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
