### PR TITLE
Feature/ls24003769/instatement definitions inside compositestmt

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -538,4 +538,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00243".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Resolution of InStatement data definitions contained in CompositeStatements
+     * @see #LS24003769
+     */
+    @Test
+    fun executeMUDRNRAPU00245() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00245".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/DUMMY00245.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/DUMMY00245.rpgle
@@ -1,0 +1,2 @@
+     C     *entry        plist
+     C                   parm                    £GGPNP           10

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00245.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00245.rpgle
@@ -1,0 +1,19 @@
+     D £DBG_Str        S             2
+
+     C     'C5C5L0'      CAT(P)    £C5LLC        £GGPNP
+     C     *LIKE         DEFINE    £C5L36        £C5LLC
+      *
+     C                   IF        1
+     C                   CALL      £GGPNP                               37
+     C                   PARM                    £C5L36            1
+     C                   ELSE
+     C                   CALL      £GGPNP
+     C                   PARM                    £C5L36            1
+      *
+     C                   ENDIF
+      *
+     C                   CALL      'DUMMY00245'
+     C                   PARM                    £GGPNP           10
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add support for instatement data definitions inside composite statements.

Related to:
- LS24003769

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
