### PR TITLE
Bugfix/ls24003774/unlimited string duplications

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -2224,6 +2224,7 @@ internal fun getProgramNameToCopyBlocks(): ProgramNameToCopyBlocks {
 }
 
 internal fun <T : AbstractDataDefinition> List<T>.removeDuplicatedDataDefinition(): List<T> {
+    // NOTE: With current logic when type matches on duplications the first definition wins
     val dataDefinitionMap = mutableMapOf<String, AbstractDataDefinition>()
     return removeUnnecessaryRecordFormat().filter {
         val dataDefinition = dataDefinitionMap[it.name]
@@ -2241,14 +2242,18 @@ internal fun <T : AbstractDataDefinition> List<T>.removeDuplicatedDataDefinition
 
 internal fun AbstractDataDefinition.matchType(dataDefinition: AbstractDataDefinition): Boolean {
     fun Type.matchType(other: Any?): Boolean {
-        if (this is NumberType && other is NumberType) {
-            val resultDigits = this.entireDigits == other.entireDigits && this.decimalDigits == other.decimalDigits
-            if (rpgType?.isNotBlank()!! && other.rpgType?.isNotEmpty()!!) {
-                return resultDigits && rpgType == other.rpgType
+        // TODO: Improve logic for StringType/UnlimitedStringType matching
+        return when {
+            this is NumberType && other is NumberType -> {
+                val resultDigits = this.entireDigits == other.entireDigits && this.decimalDigits == other.decimalDigits
+                if (rpgType?.isNotBlank()!! && other.rpgType?.isNotEmpty()!!) {
+                    return resultDigits && rpgType == other.rpgType
+                }
+                resultDigits
             }
-            return resultDigits
-        } else {
-            return this == other
+            this is UnlimitedStringType && other is StringType -> true
+            this is StringType && other is UnlimitedStringType -> true
+            else -> this == other
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -2252,7 +2252,6 @@ internal fun AbstractDataDefinition.matchType(dataDefinition: AbstractDataDefini
                 resultDigits
             }
             this is UnlimitedStringType && other is StringType -> true
-            this is StringType && other is UnlimitedStringType -> true
             else -> this == other
         }
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -538,4 +538,10 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00243".outputOf(configuration = smeupConfig))
     }
+
+    @Test
+    fun executeMUDRNRAPU00246() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00246".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00246.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00246.rpgle
@@ -1,0 +1,34 @@
+     D £DBG_Str        S             2
+
+     ********** PREPROCESSOR COPYSTART QILEGEN,£UIBDS
+     V* ==============================================================
+     V* MODIFICHE Ril.  T Au Descrizione
+     V* gg/mm/aa  nn.mm i xx Breve descrizione
+     V* ==============================================================
+     V* 10/05/21  V5R1    BONMAI Creazione
+     V* 18/05/24  V6R1    FORDAR Estensione
+     V* /COPY £UIBDS
+     V* ==============================================================
+      *--------------------------------------------------------------------------------------------*
+      *IF NOT DEFINED(UIBDS_INCLUDED)
+      *DEFINE UIBDS_INCLUDED
+     D £UIBDS          DS            10
+     D £UIBME                          0
+      *--------------------------------------------------------------------------------------------*
+     ********** PREPROCESSOR COPYEND QILEGEN,£UIBDS
+
+     DXUIBME           S                   LIKE(£UIBME)
+
+      *--------------------------------------------------------------*
+    RD*  Impostazioni iniziali
+      *--------------------------------------------------------------*
+     C     IMP0          BEGSR
+     C                   IF        %SUBST(£UIBME:1:3)='STA'
+     C                   MOVEL(P)  'STA'         XUIBME           10
+     C                   ELSE
+     C                   MOVEL(P)  £UIBME        XUIBME           10
+     C                   ENDIF
+     C                   ENDSR
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Add type matching rule to allow for duplicated definition of an `UnlimitedStringType` with a `StringType`.

Related to:
- LS24003774

## Checklist:
- [x] There are tests regarding this feature
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
