### PR TITLE
Bugfix/ls24003380/immutable base not expression

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/expressions.kt
@@ -210,7 +210,7 @@ data class DifferentThanExpr(var left: Expression, var right: Expression, overri
 // / Logical operations
 // /
 @Serializable
-data class NotExpr(val base: Expression, override val position: Position? = null) : Expression(position) {
+data class NotExpr(var base: Expression, override val position: Position? = null) : Expression(position) {
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -538,4 +538,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00243".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Access to an array detected as a function call in NOT expressions
+     * @see #LS24003380
+     */
+    @Test
+    fun executeMUDRNRAPU00247() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00247".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00247.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00247.rpgle
@@ -1,0 +1,11 @@
+     D £DBG_Str        S             2
+
+     D C§IN            S              1N   DIM(40)
+     D$C               S              5  0
+     C                   EVAL      $C=2
+     C                   IF        NOT(C§IN($C))
+     C                   EVAL      C§IN($C)=*ON
+     C                   ENDIF
+
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00247.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00247.rpgle
@@ -1,11 +1,20 @@
+      * Helper declarations
      D £DBG_Str        S             2
 
+      * Declarations needed for test purpose
      D C§IN            S              1N   DIM(40)
      D$C               S              5  0
+
+      * Initializing array indices to avoid null value exception
      C                   EVAL      $C=2
+
+      * Using an array access inside a NOT expression should be valid.
+      * C§IN($C) must be properly detected as an array access expression.
+      * Standalone C§IN($C) access must remain valid too.
      C                   IF        NOT(C§IN($C))
      C                   EVAL      C§IN($C)=*ON
      C                   ENDIF
 
+      * Test output
      C                   EVAL      £DBG_Str='ok'
      C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

In expressions like `NOT($A($X))` where `$A` is an array and `$X` is an index the program crashed because the expression `$A($X)` was firstly detected a function call and then converted in an array access.

This conversion failed because of a mutability issue.

For this reason the `base` field of `NotExpr` is now mutable.

Related to:
- #559 
- #589 
- #574 

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests regarding this feature
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows the Kotlin conventions (run `./gradlew ktlintCheck`)
- [x] The code passes all tests (run `./gradlew check`)
- [ ] There is a specific documentation in the `docs` directory
