### PR TITLE
Bugfix/ls24003783/array in ds inz

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -243,7 +243,6 @@ fun coerce(value: Value, type: Type): Value {
                     } else {
                         return DecimalValue(value.value.setScale(type.decimalDigits))
                     }
-                    return value
                 }
                 else -> TODO("Converting DecimalValue to $type")
             }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -574,4 +574,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00247".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Array declaration inside a DS with an empty INZ keyword
+     * @see #LS24003783
+     */
+    @Test
+    fun executeMUDRNRAPU00249() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00249".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -581,7 +581,7 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00249() {
-        val expected = listOf("ok")
+        val expected = listOf(List(99) { "0" }.toString())
         assertEquals(expected, "smeup/MUDRNRAPU00249".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00249.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00249.rpgle
@@ -8,4 +8,4 @@
 
       * Test output
      C                   EVAL      £DBG_Str='ok'
-     C     £DBG_Str      DSPLY
+     C     £6I           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00249.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00249.rpgle
@@ -1,11 +1,7 @@
-      * Helper declarations
-     D £DBG_Str        S             2
-
       * Declaring an array field (£6I) in a data structure with an empty INZ keyword.
       * Should not be assigned to a numeric
      D £C6MIM          DS
      D  £6I                          20P 6 DIM(99) INZ                          Importi
 
       * Test output
-     C                   EVAL      £DBG_Str='ok'
      C     £6I           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00249.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00249.rpgle
@@ -1,0 +1,11 @@
+      * Helper declarations
+     D £DBG_Str        S             2
+
+      * Declaring an array field (£6I) in a data structure with an empty INZ keyword.
+      * Should not be assigned to a numeric
+     D £C6MIM          DS
+     D  £6I                          20P 6 DIM(99) INZ                          Importi
+
+      * Test output
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Given a DataStructure `$A` containing an array field `$B`, if `$B` was also marked with empty `INZ` keyword the system tried to initialize `$B` with a real number, throwing a runtime error.

To avoid this issue I added a check on the definition being an array during the creation process.

Related to:
- LS24003783

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
