### PR TITLE
Bugfix/ls24003786/occurs ds field inz

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/SymbolTable.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/SymbolTable.kt
@@ -175,17 +175,17 @@ class SymbolTable : ISymbolTable {
     private fun getLocal(data: AbstractDataDefinition): Value {
         if (data is FieldDefinition) {
             val containerValue = get(data.container)
-            return if (data.container.isArray()) {
-                TODO("We do not yet handle an array container")
-            } else if (data.declaredArrayInLine != null) {
-                ProjectedArrayValue.forData(containerValue as DataStructValue, data)
-            } else {
-                // Should be always a DataStructValue
-                when (containerValue) {
-                    is DataStructValue -> return coerce(containerValue[data], data.type)
-                    is OccurableDataStructValue -> return coerce(containerValue.value()[data], data.type)
-                    else -> {
-                        throw IllegalStateException("The container value is expected to be a DataStructValue, instead it is $containerValue")
+            return when {
+                data.container.isArray() -> TODO("We do not yet handle an array container")
+                containerValue is OccurableDataStructValue -> return coerce(containerValue.value()[data], data.type)
+                data.declaredArrayInLine != null -> ProjectedArrayValue.forData(containerValue as DataStructValue, data)
+                else -> {
+                    // Should be always a DataStructValue
+                    when (containerValue) {
+                        is DataStructValue -> return coerce(containerValue[data], data.type)
+                        else -> {
+                            throw IllegalStateException("The container value is expected to be a DataStructValue, instead it is $containerValue")
+                        }
                     }
                 }
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -277,7 +277,11 @@ open class InternalInterpreter(
                             it.fields.forEach { field ->
                                 if (field.initializationValue != null) {
                                     val fieldValue = coerce(eval(field.initializationValue), field.type)
-                                    (value as DataStructValue).set(field, fieldValue)
+                                    when (value) {
+                                        is DataStructValue -> (value as DataStructValue).set(field, fieldValue)
+                                        is OccurableDataStructValue -> (value as OccurableDataStructValue).initializeField(field, fieldValue)
+                                        else -> throw RuntimeException("Expected value to be a DataStructure")
+                                    }
                                 }
                             }
                         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -1266,6 +1266,15 @@ data class OccurableDataStructValue(val occurs: Int) : Value {
         this._occurrence = occurrence
     }
 
+    /**
+     * Initialize a specified field in all the occurrencies
+     */
+    fun initializeField(field: FieldDefinition, value: Value) {
+        this.values.forEach {
+            it.value.set(field, value)
+        }
+    }
+
     override fun assignableTo(expectedType: Type): Boolean {
         return expectedType is OccurableDataStructureType && occurs == expectedType.occurs
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -572,4 +572,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00247".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * INZ of a field inside a DS declared with OCCURS keyword
+     * @see #LS24003786
+     */
+    @Test
+    fun executeMUDRNRAPU00250() {
+        val expected = listOf(List(40) { ".00" }.toString())
+        assertEquals(expected, "smeup/MUDRNRAPU00250".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00250.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00250.rpgle
@@ -1,0 +1,6 @@
+      * INZ on fields contained in a DS with OCCURS keyword should be supported and initialize the field
+     DT$IM             DS                  OCCURS(5000)
+     D T$IMPO                        17  2 DIM(40) INZ(0)                                                Importi
+
+      * Test output
+     C     T$IMPO        DSPLY


### PR DESCRIPTION
## Description

Add support for `INZ` keyword on fields when used in conjunction with a DS declared with the `OCCURS` keyword.

Related to:
- LS24003786

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
