### PR TITLE
Bugfix/ls24003806/dynamic array realloc

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
@@ -20,9 +20,6 @@ import com.smeup.rpgparser.parsing.ast.*
 import com.smeup.rpgparser.parsing.parsetreetoast.LogicalCondition
 
 interface Evaluator {
-    fun eval(expression: AddrExpr): Value
-    fun eval(expression: AllocExpr): Value
-    fun eval(expression: ReallocExpr): Value
     fun eval(expression: IntLiteral): Value
     fun eval(expression: RealLiteral): Value
     fun eval(expression: StringLiteral): Value

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/Evaluator.kt
@@ -98,4 +98,5 @@ interface Evaluator {
     fun eval(expression: NullValExpr): Value
     fun eval(expression: XFootExpr): Value
     fun eval(expression: MockExpression): Value
+    fun eval(expression: ReallocExpr): Value
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -65,10 +65,6 @@ class ExpressionEvaluation(
         return value
     }
 
-    override fun eval(expression: AddrExpr): Value = proxyLogging(expression) { throw NotImplementedError("AddrExpr are not implemented yet") }
-    override fun eval(expression: AllocExpr): Value = proxyLogging(expression) { throw NotImplementedError("AllocExpr are not implemented yet") }
-    override fun eval(expression: ReallocExpr): Value = proxyLogging(expression) { throw NotImplementedError("ReallocExpr are not implemented yet") }
-
     override fun eval(expression: StringLiteral): Value = proxyLogging(expression) { StringValue(expression.value) }
     override fun eval(expression: IntLiteral) = proxyLogging(expression) { IntValue(expression.value) }
     override fun eval(expression: RealLiteral) = proxyLogging(expression) { DecimalValue(expression.value) }
@@ -854,7 +850,7 @@ class ExpressionEvaluation(
 
     override fun eval(expression: MockExpression): Value {
         MainExecutionContext.getConfiguration().jarikoCallback.onMockExpression(expression)
-        return NullValue
+        return expression.defaultValue
     }
 
     private fun lookupLinearSearch(values: List<Value>, target: Value): Int {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -848,6 +848,15 @@ class ExpressionEvaluation(
         xfoot(array)
     }
 
+    override fun eval(expression: ReallocExpr): Value = proxyLogging(expression) {
+        val pointer = expression.value as? DataRefExpr ?: error("%REALLOC is only allowed for pointers")
+        val references = interpreterStatus.getReferences(pointer)
+        require(references.all { it.key.type is ArrayType }) {
+            "%REALLOC is only supported for pointers referencing arrays"
+        }
+        expression.defaultValue
+    }
+
     override fun eval(expression: MockExpression): Value {
         MainExecutionContext.getConfiguration().jarikoCallback.onMockExpression(expression)
         return expression.defaultValue

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -48,6 +48,7 @@ abstract class AbstractDataDefinition(
      * */
     @Transient open val const: Boolean = false,
     @Transient open val static: Boolean = false,
+    @Transient open var basedOn: Expression? = null,
     /**
      * This scope. Default: got by current parsing entity
      * */
@@ -193,14 +194,17 @@ data class DataDefinition(
     var paramPassedBy: ParamPassedBy = ParamPassedBy.Reference,
     var paramOptions: List<ParamOption> = mutableListOf(),
     @Transient var defaultValue: Value? = null,
+    override var basedOn: Expression? = null,
     override val static: Boolean = false
 ) :
     AbstractDataDefinition(
         name = name,
         type = type,
         position = position,
+        basedOn = basedOn,
         const = const,
-        static = static) {
+        static = static
+    ) {
 
     override fun isArray() = type is ArrayType
     fun isCompileTimeArray() = type is ArrayType && (type as ArrayType).compileTimeArray()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -80,6 +80,10 @@ class InterpreterStatus(
         }
         return tmpValue
     }
+    fun getReferences(pointer: DataRefExpr) = symbolTable.getValues().filter {
+        val target = it.key.basedOn as? DataRefExpr
+        target?.variable == pointer.variable
+    }
 }
 
 open class InternalInterpreter(

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/typesystem.kt
@@ -236,7 +236,7 @@ data class NumberType(val entireDigits: Int, val decimalDigits: Int, val rpgType
     constructor(entireDigits: Int, decimalDigits: Int, rpgType: RpgType) : this(entireDigits, decimalDigits, rpgType.rpgType)
 
     init {
-        if (rpgType == RpgType.INTEGER.rpgType || rpgType == RpgType.UNSIGNED.rpgType || rpgType == RpgType.POINTER.rpgType) {
+        if (rpgType == RpgType.INTEGER.rpgType || rpgType == RpgType.UNSIGNED.rpgType) {
             require(entireDigits <= MAX_INTEGER_DIGITS) {
                 "Integer or Unsigned integer can have only length up to 20. Value specified: $this"
             }
@@ -253,7 +253,7 @@ data class NumberType(val entireDigits: Int, val decimalDigits: Int, val rpgType
         get() {
             return when (rpgType) {
                 RpgType.PACKED.rpgType -> ceil((numberOfDigits + 1).toDouble() / 2.toFloat()).toInt()
-                RpgType.INTEGER.rpgType, RpgType.UNSIGNED.rpgType, RpgType.POINTER.rpgType -> {
+                RpgType.INTEGER.rpgType, RpgType.UNSIGNED.rpgType -> {
                     when (entireDigits) {
                         in 1..3 -> 1
                         in 4..5 -> 2
@@ -286,6 +286,18 @@ data class NumberType(val entireDigits: Int, val decimalDigits: Int, val rpgType
         } else {
             return false
         }
+    }
+
+    override fun isNumeric() = true
+}
+
+@Serializable
+object PointerType : Type() {
+    override val size: Int get() = 8
+
+    override fun canBeAssigned(type: Type): Boolean = when (type) {
+        is PointerType, is NumberType -> true
+        else -> false
     }
 
     override fun isNumeric() = true

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -311,6 +311,7 @@ data class IntValue(val value: Long) : NumberValue() {
     override operator fun compareTo(other: Value): Int = when (other) {
         is IntValue -> value.compareTo(other.value)
         is DecimalValue -> this.asDecimal().compareTo(other)
+        is PointerValue -> value.compareTo(other.address)
         else -> super.compareTo(other)
     }
 
@@ -327,6 +328,43 @@ data class IntValue(val value: Long) : NumberValue() {
     operator fun minus(other: IntValue) = IntValue(this.bigDecimal.minus(other.bigDecimal).longValueExact())
 
     operator fun times(other: IntValue) = IntValue(this.bigDecimal.times(other.bigDecimal).longValueExact())
+}
+
+@Serializable
+data class PointerValue(val address: Long) : NumberValue() {
+    companion object {
+        val NULL = PointerValue(0)
+    }
+
+    override fun negate(): NumberValue = throw UnsupportedOperationException("Pointers cannot be negative")
+    override fun increment(amount: Long): NumberValue = this + PointerValue(amount)
+    override val bigDecimal: BigDecimal by lazy { BigDecimal(address) }
+
+    override fun asString(): StringValue = StringValue(render())
+
+    override fun compareTo(other: Value): Int = when (other) {
+        is IntValue -> address.compareTo(other.value)
+        is DecimalValue -> this.asDecimal().compareTo(other)
+        is PointerValue -> address.compareTo(other.address)
+        else -> super.compareTo(other)
+    }
+
+    override fun assignableTo(expectedType: Type): Boolean = when (expectedType) {
+        is NumberType -> true
+        is PointerType -> true
+        else -> expectedType is ArrayType && expectedType.element is NumberType
+    }
+
+    override fun copy() = PointerValue(address)
+
+    operator fun plus(other: PointerValue) = PointerValue(address + other.address)
+    operator fun plus(other: IntValue) = PointerValue(address + other.value)
+
+    operator fun minus(other: PointerValue) = PointerValue(address - other.address)
+    operator fun minus(other: IntValue) = PointerValue(address - other.value)
+
+    operator fun times(other: PointerValue) = PointerValue(address * other.address)
+    operator fun times(other: IntValue) = PointerValue(address * other.value)
 }
 
 @Serializable
@@ -973,6 +1011,7 @@ fun Type.blank(): Value {
             }
         }
         is NumberType -> IntValue(0)
+        is PointerType -> PointerValue(0)
         is BooleanType -> BooleanValue.FALSE
         is TimeStampType -> TimeStampValue.LOVAL
         is DateType -> BlanksValue

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -17,6 +17,8 @@
 package com.smeup.rpgparser.parsing.ast
 
 import com.smeup.rpgparser.interpreter.Evaluator
+import com.smeup.rpgparser.interpreter.IntValue
+import com.smeup.rpgparser.interpreter.NullValue
 import com.smeup.rpgparser.interpreter.Value
 import com.strumenta.kolasu.model.Position
 import kotlinx.serialization.Serializable
@@ -25,7 +27,9 @@ import kotlinx.serialization.Transient
 /**
  * For expressions with this interface there isn't resolution but will be called the callback `onMockExpression` and returned a null value.
  */
-interface MockExpression
+interface MockExpression {
+    val defaultValue get(): Value = NullValue
+}
 
 // %LOOKUP
 @Serializable
@@ -486,6 +490,7 @@ data class XFootExpr(var value: Expression, override val position: Position? = n
 // %ADDR
 @Serializable
 data class AddrExpr(override val position: Position? = null) : Expression(position), MockExpression {
+    override val defaultValue: Value get() = IntValue(0)
     override val loggableEntityName get() = "%ADDR"
     override fun render() = "%ADDR"
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
@@ -494,6 +499,7 @@ data class AddrExpr(override val position: Position? = null) : Expression(positi
 // %ALLOC
 @Serializable
 data class AllocExpr(override val position: Position? = null) : Expression(position), MockExpression {
+    override val defaultValue: Value get() = IntValue(0)
     override val loggableEntityName get() = "%ALLOC"
     override fun render() = "%ALLOC"
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
@@ -502,6 +508,7 @@ data class AllocExpr(override val position: Position? = null) : Expression(posit
 // %REALLOC
 @Serializable
 data class ReallocExpr(override val position: Position? = null) : Expression(position), MockExpression {
+    override val defaultValue: Value get() = IntValue(0)
     override val loggableEntityName get() = "%REALLOC"
     override fun render() = "%REALLOC"
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/builtin_functions.kt
@@ -16,10 +16,7 @@
 
 package com.smeup.rpgparser.parsing.ast
 
-import com.smeup.rpgparser.interpreter.Evaluator
-import com.smeup.rpgparser.interpreter.IntValue
-import com.smeup.rpgparser.interpreter.NullValue
-import com.smeup.rpgparser.interpreter.Value
+import com.smeup.rpgparser.interpreter.*
 import com.strumenta.kolasu.model.Position
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -499,7 +496,7 @@ data class AddrExpr(override val position: Position? = null) : Expression(positi
 // %ALLOC
 @Serializable
 data class AllocExpr(override val position: Position? = null) : Expression(position), MockExpression {
-    override val defaultValue: Value get() = IntValue(0)
+    override val defaultValue: Value get() = PointerValue.NULL
     override val loggableEntityName get() = "%ALLOC"
     override fun render() = "%ALLOC"
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)
@@ -507,8 +504,8 @@ data class AllocExpr(override val position: Position? = null) : Expression(posit
 
 // %REALLOC
 @Serializable
-data class ReallocExpr(override val position: Position? = null) : Expression(position), MockExpression {
-    override val defaultValue: Value get() = IntValue(0)
+data class ReallocExpr(val value: Expression, override val position: Position? = null) : Expression(position), MockExpression {
+    override val defaultValue: Value get() = PointerValue.NULL
     override val loggableEntityName get() = "%REALLOC"
     override fun render() = "%REALLOC"
     override fun evalWith(evaluator: Evaluator): Value = evaluator.eval(this)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -2505,10 +2505,9 @@ data class TestnStmt(
 @Serializable
 data class DeallocStmt(
     override val position: Position? = null
-) : Statement(position) {
-    override fun execute(interpreter: InterpreterCore) {
-        throw NotImplementedError("DEALLOC statement is not implemented yet")
-    }
+) : Statement(position), MockStatement {
+    override val loggableEntityName get() = "DEALLOC"
+    override fun execute(interpreter: InterpreterCore) { }
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/bif.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/bif.kt
@@ -343,5 +343,8 @@ internal fun RpgParser.Bif_allocContext.toAst(conf: ToAstConfiguration = ToAstCo
 }
 
 internal fun RpgParser.Bif_reallocContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): ReallocExpr {
-    return ReallocExpr(toPosition(conf.considerPosition))
+    return ReallocExpr(
+        this.identifier().toAst(conf),
+        toPosition(conf.considerPosition)
+    )
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -341,6 +341,7 @@ internal fun RpgParser.DspecContext.toAst(
     var ascend: Boolean? = null
     var static = false
     var len: Expression? = null
+    var based: Expression? = null
 
     /* Default value is ISO. */
     var dateFormat: DateFormat = DateFormat.ISO
@@ -382,6 +383,9 @@ internal fun RpgParser.DspecContext.toAst(
         }
         it.keyword_len()?.let {
             len = it.simpleExpression().toAst(conf)
+        }
+        it.keyword_based()?.let {
+            based = it.simpleExpression().toAst(conf)
         }
     }
 
@@ -471,9 +475,7 @@ internal fun RpgParser.DspecContext.toAst(
             RpgType.UNLIMITED_STRING.rpgType -> {
                 UnlimitedStringType
             }
-            RpgType.POINTER.rpgType -> {
-                NumberType(NumberType.MAX_INTEGER_DIGITS, NumberType.INTEGER_DECIMAL_DIGITS, RpgType.POINTER.rpgType)
-            }
+            RpgType.POINTER.rpgType -> PointerType
             else -> todo("Unknown type: <${this.DATA_TYPE().text}>", conf)
     }
 
@@ -504,7 +506,8 @@ internal fun RpgParser.DspecContext.toAst(
         type = type,
         initializationValue = initializationValue,
         position = this.toPosition(true),
-        static = static
+        static = static,
+        basedOn = based
     )
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -686,6 +686,44 @@ class JarikoCallbackTest : AbstractTest() {
         executeSourceLineTest(pgm = "ERROR36")
     }
 
+    /**
+     * NOTE: At the current state of implementation dynamic memory allocation and pointers are NOT fully supported
+     * If this behaviour changes and [ReallocExpr] is expanded to support every type of pointer, please remove this test
+     */
+    @Test
+    fun executeERROR37CallBackTest() {
+        executePgmCallBackTest(
+            pgm = "ERROR37",
+            sourceReferenceType = SourceReferenceType.Program,
+            sourceId = "ERROR37",
+            lines = listOf(9)
+        )
+    }
+
+    @Test
+    fun executeERROR37SourceLineTest() {
+        executeSourceLineTest(pgm = "ERROR37")
+    }
+
+    /**
+     * NOTE: At the current state of implementation dynamic memory allocation and pointers are NOT fully supported
+     * If this behaviour changes and [ReallocExpr] is expanded to support every type of pointer, please remove this test
+     */
+    @Test
+    fun executeERROR38CallBackTest() {
+        executePgmCallBackTest(
+            pgm = "ERROR38",
+            sourceReferenceType = SourceReferenceType.Program,
+            sourceId = "ERROR38",
+            lines = listOf(12)
+        )
+    }
+
+    @Test
+    fun executeERROR38SourceLineTest() {
+        executeSourceLineTest(pgm = "ERROR38")
+    }
+
     @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
@@ -75,4 +75,14 @@ open class MULANGT15BaseBif1Test : MULANGTTest() {
             "smeup/MUDRNRAPU00211".outputOf(configuration = smeupConfig)
         }
     }
+
+    /**
+     * %REALLOC and %ALLOC for dynamic array resizing
+     * @see #LS24003806
+     */
+    @Test
+    fun executeMUDRNRAPU00252() {
+        val expected = listOf("10000", "10000", "10000")
+        assertEquals(expected, "smeup/MUDRNRAPU00252".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT15BaseBif1Test.kt
@@ -85,4 +85,14 @@ open class MULANGT15BaseBif1Test : MULANGTTest() {
         val expected = listOf("10000", "10000", "10000")
         assertEquals(expected, "smeup/MUDRNRAPU00252".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * %REALLOC for dynamic array resizing when multiple arrays based on the same pointer are present
+     * @see #LS24003806
+     */
+    @Test
+    fun executeMUDRNRAPU00253() {
+        val expected = listOf("10000", "10000", "10000", "10000")
+        assertEquals(expected, "smeup/MUDRNRAPU00253".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR37.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR37.rpgle
@@ -1,0 +1,11 @@
+      * Helper declarations
+     D £DBG_Str        S            512
+
+      * Declarations needed for test purpose
+     D COD1            S             20    BASED(SWKpt1)
+     D SWKpt1          S               *   INZ(*Null)
+
+      * %REALLOC is not allowed when pointer has variables based on it that are not arrays
+     C                   EVAL      SWKpt1 =%ReAlloc(SWKpt1:10000)
+     C                   EVAL      £DBG_Str=COD1
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR38.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR38.rpgle
@@ -1,0 +1,14 @@
+      * Helper declarations
+     D £DBG_Str        S            512
+
+      * Declarations needed for test purpose
+     D COD1            S             20    BASED(SWKpt1)
+     D COD2            S             20    DIM(500) BASED(SWKpt1)
+     D COD3            S             20    DIM(500) BASED(SWKpt1)
+     D COD4            S             20    DIM(500) BASED(SWKpt1)
+     D SWKpt1          S               *   INZ(*Null)
+
+      * %REALLOC is not allowed when pointer has any variable based on it that is not an array
+     C                   EVAL      SWKpt1 =%ReAlloc(SWKpt1:10000)
+     C                   EVAL      £DBG_Str=COD1
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00252.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00252.rpgle
@@ -1,0 +1,41 @@
+      * Helper declarations
+     D £DBG_Str        S            512
+
+      * Subrouting that increases the number of elements in SWKpt1
+     C     REALCOD       BEGSR
+      *
+     C                   EVAL      SWKpt1 =%ReAlloc(SWKpt1  :
+     C                              %Size(COD) * (nElAl1+nElAg1))
+      *
+     C*                   EVAL      %SUBARR(COD:nElAl1+1:nElAg1)=*BLANKS
+     C                   EVAL      nElAl1=nElAl1+nElAg1
+      *
+     C                   ENDSR
+
+      * Declarations needed for test purpose
+     D DIMSCH          C                   CONST(10000)
+     D COD             S             20    DIM(DIMSCH) BASED(SWKpt1)            Codice
+     D SWKpt1          S               *   INZ(*Null)
+     D nElAg1          S              5I 0
+     D nElAl1          S              5I 0
+
+      * DEALLOC and %ALLOC should not crash the program
+     C                   EVAL      SWKpt1 = %Alloc(%Size(COD) * nElAl1)
+     C                   DEALLOC                 SWKpt1
+
+      * Setting up the number of element to add to SWKpt1 every time we call REALCOD
+     C                   EVAL      nElAg1=250
+
+      * Dynamic array resizing using a pointer on top of it with %realloc should not crash the program
+     C                   EVAL      £DBG_Str=%ELEM(COD)
+     C     £DBG_Str      DSPLY
+
+      * Test on one iteration
+     C                   EXSR      REALCOD
+     C                   EVAL      £DBG_Str=%ELEM(COD)
+     C     £DBG_Str      DSPLY
+
+      * Test on subsequent iteration
+     C                   EXSR      REALCOD
+     C                   EVAL      £DBG_Str=%ELEM(COD)
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00252.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00252.rpgle
@@ -1,17 +1,6 @@
       * Helper declarations
      D £DBG_Str        S            512
 
-      * Subrouting that increases the number of elements in SWKpt1
-     C     REALCOD       BEGSR
-      *
-     C                   EVAL      SWKpt1 =%ReAlloc(SWKpt1  :
-     C                              %Size(COD) * (nElAl1+nElAg1))
-      *
-     C*                   EVAL      %SUBARR(COD:nElAl1+1:nElAg1)=*BLANKS
-     C                   EVAL      nElAl1=nElAl1+nElAg1
-      *
-     C                   ENDSR
-
       * Declarations needed for test purpose
      D DIMSCH          C                   CONST(10000)
      D COD             S             20    DIM(DIMSCH) BASED(SWKpt1)            Codice
@@ -39,3 +28,15 @@
      C                   EXSR      REALCOD
      C                   EVAL      £DBG_Str=%ELEM(COD)
      C     £DBG_Str      DSPLY
+     C                   SETON                                        LR
+
+      * Subrouting that increases the number of elements in SWKpt1
+     C     REALCOD       BEGSR
+      *
+     C                   EVAL      SWKpt1 =%ReAlloc(SWKpt1  :
+     C                              %Size(COD) * (nElAl1+nElAg1))
+      *
+     C*                   EVAL      %SUBARR(COD:nElAl1+1:nElAg1)=*BLANKS
+     C                   EVAL      nElAl1=nElAl1+nElAg1
+      *
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00253.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00253.rpgle
@@ -1,0 +1,36 @@
+      * Helper declarations
+     D £DBG_Str        S            512
+
+      * Declarations needed for test purpose
+     D DIMSCH          C                   CONST(10000)
+     D COD1            S             20    DIM(DIMSCH) BASED(SWKpt1)
+     D COD2            S             20    DIM(DIMSCH) BASED(SWKpt1)
+     D COD3            S             20    DIM(DIMSCH) BASED(SWKpt1)
+     D COD4            S             20    DIM(DIMSCH) BASED(SWKpt1)
+     D SWKpt1          S               *   INZ(*Null)
+     D nElAg1          S              5I 0
+     D nElAl1          S              5I 0
+
+      * Setting up the number of element to add to SWKpt1 every time we call REALCOD
+     C                   EVAL      nElAg1=250
+
+      * Dynamic array resizing using %REALLOC must be allowed when there are multiple arrays based on the same pointer
+     C                   EXSR      REALCOD
+     C                   EVAL      £DBG_Str=%ELEM(COD1)
+     C     £DBG_Str      DSPLY
+     C                   EVAL      £DBG_Str=%ELEM(COD2)
+     C     £DBG_Str      DSPLY
+     C                   EVAL      £DBG_Str=%ELEM(COD3)
+     C     £DBG_Str      DSPLY
+     C                   EVAL      £DBG_Str=%ELEM(COD4)
+     C     £DBG_Str      DSPLY
+
+      * Subrouting that increases the number of elements in SWKpt1
+     C     REALCOD       BEGSR
+      *
+     C                   EVAL      SWKpt1 =%ReAlloc(SWKpt1  :
+     C                              %Size(COD1) * (nElAl1+nElAg1))
+      *
+     C                   EVAL      nElAl1=nElAl1+nElAg1
+      *
+     C                   ENDSR


### PR DESCRIPTION
## Description

Remove runtime error when calling `DEALLOC`, `%REALLOC`, `%ALLOC`, `%ADDR`. This decision was made in order to allow the execution of code trying to dynamically increase the size of an array using a `BASED` pointer (see `MUDRNRAPU00252.rpgle`).

Following there is a table describing how the behaviour of each operation has changed.

codop/bif | previous behavior | current behaviour
-- | -- | --
`%REALLOC` | throws runtime error | If pointing only to arrays returns a null pointer else-wise throws a runtime error
`%ALLOC` | throws runtime error | returns  a null pointer, notifies mock execution
`%ADDR` | throws runtime error | returns a null pointer, notifies mock execution
`DEALLOC` | throws runtime error | does nothing, notifies mock execution



From a technical standpoint the changes are the following:
- Removed the throw rules causing the runtime error.
- Added a `defaultValue` field in the `MockExpression` interface to allow values different from `NullValue` on mock execution.
- Added `PointerValue` and `PointerType` (to differentiate them from every other numeric value).
- Added support for `BASED` keyword on D-specs.

Related to:
- LS24003806

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
