### PR TITLE
Bugfix/ls24003807/S to DS with negative number

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
@@ -121,8 +121,8 @@ private fun getStringOfValue(
     target: AssignableExpression,
     interpreterCore: InterpreterCore,
     value: Expression
-): String = when {
-    target.type() is BooleanType -> {
+): String = when (target.type()) {
+    is BooleanType -> {
         val valueInterpreted: String = (interpreterCore.eval(value)).asString().value
         when {
             (valueInterpreted.isInt() && valueInterpreted.toInt() in 0..1) -> valueInterpreted
@@ -131,7 +131,9 @@ private fun getStringOfValue(
             else -> throw UnsupportedOperationException("MOVE/MOVEL for ${target.type()} have to be 0, 1 or blank")
         }
     }
-
+    is DataStructureType -> {
+        value.type().toDataStructureValue(interpreterCore.eval(value)).value
+    }
     else -> valueToString(interpreterCore.eval(value), value.type())
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
@@ -449,7 +449,7 @@ abstract class AbstractTest {
             Assert.assertTrue(
                 "Errors don't correspond.\n" +
                         "Actual: ${found.joinToString(separator = "\n\\") { it.first }}\n" +
-                        "Expected: ${lines.map { it.value }.joinToString(separator = "\n\\") { it } }\n",
+                        "Expected: ${lines.map { "Line ${it.key}: \"${it.value}\"" }.joinToString(separator = "\n\\") { it } }\n",
                 found.size == found.filter { it.second }.size && found.size == lines.size
             )
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
@@ -448,8 +448,8 @@ abstract class AbstractTest {
                 }
             Assert.assertTrue(
                 "Errors don't correspond.\n" +
-                        "Actual: ${found.joinToString(separator = "\n\\") { it.first }}\n" +
-                        "Expected: ${lines.map { "Line ${it.key}: \"${it.value}\"" }.joinToString(separator = "\n\\") { it } }\n",
+                        "Expected: ${lines.map { "Line ${it.key}: \"${it.value}\"" }.joinToString(separator = "\n\\") { it } }\n" +
+                        "Actual: ${found.joinToString(separator = "\n\\") { it.first }}\n",
                 found.size == found.filter { it.second }.size && found.size == lines.size
             )
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/AbstractTest.kt
@@ -411,14 +411,14 @@ abstract class AbstractTest {
      * @param pgm The name of the program to be executed.
      * @param sourceReferenceType The expected type of the source reference (Program or Copy) where the error is expected to occur.
      * @param sourceId The expected identifier of the source where the error is expected to occur.
-     * @param lines The map of lines, number and message, expected.
+     * @param expected The map of lines, number and message, expected.
      * @param reloadConfig The reload configuration to be used for the execution of the program. Default is null.
      */
     protected fun executePgmCallBackTest(
         pgm: String,
         sourceReferenceType: SourceReferenceType,
         sourceId: String,
-        lines: Map<Int, String>,
+        expected: Map<Int, String>,
         reloadConfig: ReloadConfig? = null
     ) {
         val errorEvents = mutableListOf<ErrorEvent>()
@@ -441,16 +441,15 @@ abstract class AbstractTest {
             Assert.assertEquals(sourceId, errorEvents[0].sourceReference!!.sourceId)
             val found = errorEvents
                 .associate { errorEvent ->
-                    errorEvent.sourceReference!!.relativeLine to (errorEvent.error).message!!
+                    errorEvent.sourceReference!!.relativeLine to ((errorEvent.error).cause?.message ?: (errorEvent.error).message!!)
                 }
-                .map {
-                    Pair(it.value, it.contains(lines))
-                }
+                .toSortedMap()
+            val expectedSorted = expected.toSortedMap()
             Assert.assertTrue(
                 "Errors don't correspond.\n" +
-                        "Expected: ${lines.map { "Line ${it.key}: \"${it.value}\"" }.joinToString(separator = "\n\\") { it } }\n" +
-                        "Actual: ${found.joinToString(separator = "\n\\") { it.first }}\n",
-                found.size == found.filter { it.second }.size && found.size == lines.size
+                        "Expected:\n${expectedSorted.map { "Line ${it.key}, \"${it.value}\"" }.joinToString(separator = "\n") { it } }\n" +
+                        "Actual:\n${found.map { "Line ${it.key}, \"${it.value}\"" }.joinToString(separator = "\n") { it } }\n",
+                found == expectedSorted
             )
         }
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -528,32 +528,32 @@ class JarikoCallbackTest : AbstractTest() {
     @Test
     fun executeERROR23CallBackTest() {
         executePgmCallBackTest("ERROR23", SourceReferenceType.Program, "ERROR23", mapOf(
-            9 to "Factor 2 cannot be null",
-            14 to "Factor 1 cannot be null"
+            9 to "Factor 2 cannot be null at: Position(start=Line 9, Column 11, end=Line 9, Column 16) com.smeup.rpgparser.RpgParser\$FactorContext",
+            14 to "Factor 1 cannot be null at: Position(start=Line 14, Column 11, end=Line 14, Column 25) com.smeup.rpgparser.RpgParser\$FactorContext"
         ))
     }
 
     @Test
     fun executeERROR24CallBackTest() {
         executePgmCallBackTest("ERROR24", SourceReferenceType.Program, "ERROR24", mapOf(
-            8 to "Initialization value is incorrect. Must be 'YYYY-MM-DD'",
-            9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD'"
+            8 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
+            9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
         ))
     }
 
     @Test
     fun executeERROR25CallBackTest() {
         executePgmCallBackTest("ERROR25", SourceReferenceType.Program, "ERROR25", mapOf(
-            8 to "For JUL format the date must be between 1940 and 2039",
-            9 to "For JUL format the date must be between 1940 and 2039"
+            8 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
+            9 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
         ))
     }
 
     @Test
     fun executeERROR26CallBackTest() {
         executePgmCallBackTest("ERROR26", SourceReferenceType.Program, "ERROR26", mapOf(
-            8 to "For ISO format the date must be between 0001 and 9999",
-            9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD'"
+            8 to "For ISO format the date must be between 0001 and 9999 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
+            9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
         ))
     }
 
@@ -565,8 +565,9 @@ class JarikoCallbackTest : AbstractTest() {
     @Test
     fun executeERROR27CallBackTest() {
         executePgmCallBackTest("ERROR27", SourceReferenceType.Program, "ERROR27", mapOf(
-            10 to "Error while creating data definition from statement: DefineStmt(originalName=*LDA, newVarName=£UDLDA",
-            11 to "An operation is not implemented: IN£UDLDA"
+            10 to "No element of the collection was transformed to a non-null value.",
+            11 to "An operation is not implemented: IN£UDLDA                           \n" +
+                    " at Position(start=Line 11, Column 25, end=Line 11, Column 81) com.smeup.rpgparser.RpgParser\$Cspec_fixed_standardContext"
         ))
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -97,6 +97,36 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
     }
 
     /**
+     * Assigns content of String (which has negative number) to a DS.
+     * In this test is used `MOVEL`
+     * @see #LS24003807
+     */
+    @Test
+    fun executeMUDRNRAPU00110() {
+        val expected = listOf(
+            "-1", "0000J", "-2", "0000K", "-3", "0000L", "-4", "0000M", "-5", "0000N", "-6", "0000O", "-7", "0000P", "-8",
+            "0000Q", "-9", "0000R", "-10", "0001I", "-1.00", "0010I", "-2.00", "0020I", "-3.00", "0030I", "-4.00", "0040I",
+            "-5.00", "0050I", "-6.00", "0060I", "-7.00", "0070I", "-8.00", "0080I", "-9.00", "0090I", "-10.00", "0100I"
+        )
+        assertEquals(expected, "smeup/MUDRNRAPU00110".outputOf())
+    }
+
+    /**
+     * Assigns content of String (which has negative number) to a DS.
+     * In this test is used `EVAL`
+     * @see #LS24003807
+     */
+    @Test
+    fun executeMUDRNRAPU00111() {
+        val expected = listOf(
+            "-1", "0000J", "-2", "0000K", "-3", "0000L", "-4", "0000M", "-5", "0000N", "-6", "0000O", "-7", "0000P", "-8",
+            "0000Q", "-9", "0000R", "-10", "0001I", "-1.00", "0010I", "-2.00", "0020I", "-3.00", "0030I", "-4.00", "0040I",
+            "-5.00", "0050I", "-6.00", "0060I", "-7.00", "0070I", "-8.00", "0080I", "-9.00", "0090I", "-10.00", "0100I"
+        )
+        assertEquals(expected, "smeup/MUDRNRAPU00111".outputOf())
+    }
+
+    /**
      * %DIFF with several DurationCodes
      * @see #LS24003282
      */

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00110.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00110.rpgle
@@ -1,0 +1,34 @@
+     V* ==============================================================
+     V* 28/08/2024 BMA    Creation
+     V* 29/08/2024 APU001 Edit
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment, with MOVEL, the content of S (with negative number)
+    O *  to two different DS:
+    O *  - declared as integer;
+    O *  - declared as decimal.
+    O * This program doesn't crash.
+     V* ==============================================================
+     D $NR1            S              5S 0
+     D $NR2            S              5S 2
+     D DSNR1           DS
+     D  NR1                           5  0
+     D DSNR2           DS
+     D  NR2                           5  2
+     D AAA10           S             10
+
+     C                   DO        10            $X                2 0
+     C                   EVAL      $NR1=$X*-1                                                           # -1
+     C                   MOVEL     $NR1          DSNR1
+     C                   EVAL      AAA10=%CHAR(NR1)
+     C     AAA10         DSPLY
+     C     DSNR1         DSPLY
+     C                   ENDDO
+
+     C                   DO        10            $X                2 0
+     C                   EVAL      $NR2=$X*-1
+     C                   MOVEL     $NR2          DSNR2
+     C                   EVAL      AAA10=%CHAR(NR2)
+     C     AAA10         DSPLY
+     C     DSNR2         DSPLY
+     C                   ENDDO

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00111.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00111.rpgle
@@ -1,0 +1,30 @@
+     V* ==============================================================
+     V* 28/08/2024 BMA    Creation
+     V* 29/08/2024 APU001 Edit
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment, with EVAL, the content of S (with negative number)
+    O *  to two different DS:
+    O *  - declared as integer;
+    O *  - declared as decimal.
+    O * This program doesn't crash.
+     V* ==============================================================
+     D AAA10           S             10
+     D DSNR1           DS
+     D  NR1                           5  0
+     D DSNR2           DS
+     D  NR2                           5  2
+
+     C                   DO        10            $X                2 0
+     C                   EVAL      NR1=$X*-1
+     C                   EVAL      AAA10=%CHAR(NR1)
+     C     AAA10         DSPLY
+     C     DSNR1         DSPLY
+     C                   ENDDO
+
+     C                   DO        10            $X                2 0
+     C                   EVAL      NR2=$X*-1
+     C                   EVAL      AAA10=%CHAR(NR2)
+     C     AAA10         DSPLY
+     C     DSNR2         DSPLY
+     C                   ENDDO


### PR DESCRIPTION
## Description
This work adds the capability to assign negative number from standalone field into data structure field, by using `MOVEL`.

### Technical notes
To achieve the goal, after a long analysis I discovered an easy solution in `getStringOfValue` of `movel.kt`, by executing `toDataStructureValue(...)`.

Related to #LS24003807

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
