### PR TITLE
Feature/ls24003884/Evaluation blank value of DS field

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -1104,7 +1104,7 @@ data class DataStructValue(var value: String, private val optionalExternalLen: I
 
     /**
      * On AS400 for DS there are some syntax rule for number. In example,
-     *  ZONED number with at least space at the end is not allowed.
+     *  ZONED number with at least space at the end is not allowed, if it has at least a number.
      * This function provides to check if the number follow these requirements.
      * @param value to check.
      * @param type necessary for checking based of `RpgType`
@@ -1115,7 +1115,7 @@ data class DataStructValue(var value: String, private val optionalExternalLen: I
         type: NumberType
     ): Boolean {
         return when {
-            type.rpgType == RpgType.ZONED.rpgType -> value.trimEnd().length == value.length
+            type.rpgType == RpgType.ZONED.rpgType -> if (value.isNotBlank()) value.trimEnd().length == value.length else true
             else -> true
         }
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -1115,7 +1115,7 @@ data class DataStructValue(var value: String, private val optionalExternalLen: I
         type: NumberType
     ): Boolean {
         return when {
-            type.rpgType == RpgType.ZONED.rpgType -> if (value.isNotBlank()) value.trimEnd().length == value.length else true
+            type.rpgType == RpgType.ZONED.rpgType -> value.isBlank() || value.trimEnd().length == value.length
             else -> true
         }
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -20,8 +20,6 @@ import com.smeup.dspfparser.linesclassifier.DSPFValue
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.smeup.rpgparser.parsing.parsetreetoast.DateFormat
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
-import com.smeup.rpgparser.parsing.parsetreetoast.isDecimal
-import com.smeup.rpgparser.parsing.parsetreetoast.isInt
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -20,6 +20,8 @@ import com.smeup.dspfparser.linesclassifier.DSPFValue
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.smeup.rpgparser.parsing.parsetreetoast.DateFormat
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
+import com.smeup.rpgparser.parsing.parsetreetoast.isDecimal
+import com.smeup.rpgparser.parsing.parsetreetoast.isInt
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal
@@ -1171,7 +1173,8 @@ data class DataStructValue(var value: String, private val optionalExternalLen: I
 
         /**
          * On AS400 for DS there are some syntax rule for number. In example,
-         *  ZONED number with at least space at the end is not allowed, if it has at least a number.
+         *  ZONED number with at least space at the end is not allowed. Instead, is allowed `value` as
+         *   only blank chars.
          * This function provides to check if the number follow these requirements.
          * @param value to check.
          * @param type necessary for checking based of `RpgType`

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -1103,24 +1103,6 @@ data class DataStructValue(var value: String, private val optionalExternalLen: I
     }
 
     /**
-     * On AS400 for DS there are some syntax rule for number. In example,
-     *  ZONED number with at least space at the end is not allowed, if it has at least a number.
-     * This function provides to check if the number follow these requirements.
-     * @param value to check.
-     * @param type necessary for checking based of `RpgType`
-     * @return true if the `value` follows the syntax.
-     */
-    fun checkNumberSyntax(
-        value: String,
-        type: NumberType
-    ): Boolean {
-        return when {
-            type.rpgType == RpgType.ZONED.rpgType -> value.isBlank() || value.trimEnd().length == value.length
-            else -> true
-        }
-    }
-
-    /**
      * See setSingleField
      */
     fun getSingleField(data: FieldDefinition): Value {
@@ -1180,6 +1162,24 @@ data class DataStructValue(var value: String, private val optionalExternalLen: I
             val fieldDefinitions = fields.map { it.key }.toFieldDefinitions()
             fields.onEachIndexed { index, entry -> newInstance.set(fieldDefinitions[index], entry.value) }
             return newInstance
+        }
+
+        /**
+         * On AS400 for DS there are some syntax rule for number. In example,
+         *  ZONED number with at least space at the end is not allowed, if it has at least a number.
+         * This function provides to check if the number follow these requirements.
+         * @param value to check.
+         * @param type necessary for checking based of `RpgType`
+         * @return true if the `value` follows the syntax.
+         */
+        internal fun checkNumberSyntax(
+            value: String,
+            type: NumberType
+        ): Boolean {
+            return when {
+                type.rpgType == RpgType.ZONED.rpgType -> value.isBlank() || value.trimEnd().length == value.length
+                else -> true
+            }
         }
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -97,6 +97,16 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
     }
 
     /**
+     * Evaluation at runtime of a DS' field that is blank.
+     * @see #LS24003884
+     */
+    @Test
+    fun executeMUDRNRAPU00112() {
+        val expected = listOf("0", "0", "0", "0")
+        assertEquals(expected, "smeup/MUDRNRAPU00112".outputOf())
+    }
+
+    /**
      * %DIFF with several DurationCodes
      * @see #LS24003282
      */

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00112.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00112.rpgle
@@ -1,0 +1,27 @@
+     V* ==============================================================
+     V* 26/08/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment, with Z-ADD, the content of S (declared inline)
+    O * to a DS field.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was
+    O *  `Cannot assign DataStructValue to StringType`.
+     V* ==============================================================
+     D DS1             DS           100
+     D  DS1_FL1                1      6  0
+     D  DS1_FL2                7     12  0
+
+     D TMP             S             10
+
+     C                   CLEAR                   DS1
+
+     C     DS1_FL1       DSPLY                                                  #Cannot coerce sub-string `      `
+     C     STD8          DSPLY
+
+     C                   Z-ADD     DS1_FL1       STD8
+     C                   Z-ADD     STD8          STD8              8 0
+
+     C     DS1_FL1       DSPLY
+     C     STD8          DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00112.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00112.rpgle
@@ -7,7 +7,7 @@
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, the error occurred was
-    O *  `Cannot assign DataStructValue to StringType`.
+    O *  Cannot coerce sub-string `      `.
      V* ==============================================================
      D DS1             DS           100
      D  DS1_FL1                1      6  0

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00112.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00112.rpgle
@@ -1,5 +1,5 @@
      V* ==============================================================
-     V* 26/08/2024 APU001 Creation
+     V* 03/09/2024 APU001 Creation
      V* ==============================================================
     O * PROGRAM GOAL
     O * Assignment, with Z-ADD, the content of S (declared inline)


### PR DESCRIPTION
## Description
This work resolves evaluation at runtime of a DS' field with only blank values.

### Technical notes
This is a regression issue of `checkNumberSyntax`. To resolve this problem I put a checking if the value is completely blank. In this case passes and coerce to right value.

Related to:
- Action _LS24003884_;
- #600.

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
