### PR TITLE
Bugfix/ls24003931/comp between string boolean

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -21,6 +21,7 @@ import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.smeup.rpgparser.parsing.parsetreetoast.DateFormat
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
 import com.smeup.rpgparser.parsing.parsetreetoast.isInt
+import com.smeup.rpgparser.parsing.parsetreetoast.toInt
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal
@@ -210,7 +211,7 @@ data class StringValue(var value: String, var varying: Boolean = false) : Abstra
         when (other) {
             is StringValue -> compare(other, DEFAULT_CHARSET)
             is BlanksValue -> if (this.isBlank()) EQUAL else SMALLER
-            is BooleanValue -> if (this.value.isInt() && this.value.toInt() == 1) EQUAL else GREATER
+            is BooleanValue -> if (this.value.isInt() && this.value.toInt() == other.value.toInt()) EQUAL else GREATER
             else -> super.compareTo(other)
         }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -20,6 +20,7 @@ import com.smeup.dspfparser.linesclassifier.DSPFValue
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.smeup.rpgparser.parsing.parsetreetoast.DateFormat
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
+import com.smeup.rpgparser.parsing.parsetreetoast.isInt
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal
@@ -209,6 +210,7 @@ data class StringValue(var value: String, var varying: Boolean = false) : Abstra
         when (other) {
             is StringValue -> compare(other, DEFAULT_CHARSET)
             is BlanksValue -> if (this.isBlank()) EQUAL else SMALLER
+            is BooleanValue -> if (this.value.isInt() && this.value.toInt() == 1) EQUAL else GREATER
             else -> super.compareTo(other)
         }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -674,6 +674,8 @@ internal fun String.toDecimal() = this.toDouble()
 
 internal fun String.isNumber() = this.isInt() || this.isDecimal()
 
+internal fun Boolean.toInt() = if (this) 1 else 0
+
 internal fun ParserRuleContext.rContext(): RContext {
     return if (this.parent == null) {
         this as RContext

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -147,7 +147,7 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
     }
 
     /**
-     * Using `COMP` between string and boolean with values not equals to `0` and `1`.
+     * Using `COMP` between string and boolean with values not equal to `0` and `1`.
      * @see #LS24003931
      */
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -137,6 +137,16 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
     }
 
     /**
+     * Using `COMP` between string and boolean.
+     * @see #LS24003931
+     */
+    @Test
+    fun executeMUDRNRAPU00113() {
+        val expected = listOf("1", "0", "1", "0")
+        assertEquals(expected, "smeup/MUDRNRAPU00113".outputOf())
+    }
+
+    /**
      * %DIFF with several DurationCodes
      * @see #LS24003282
      */

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -152,7 +152,7 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00114() {
-        val expected = listOf("0", "0", "0", "0", "0")
+        val expected = listOf("0", "0", "0", "0", "0", "0", "0", "0", "0", "0")
         assertEquals(expected, "smeup/MUDRNRAPU00114".outputOf())
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -142,7 +142,7 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00113() {
-        val expected = listOf("1", "0", "1", "0")
+        val expected = listOf("1", "0")
         assertEquals(expected, "smeup/MUDRNRAPU00113".outputOf())
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -147,6 +147,16 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
     }
 
     /**
+     * Using `COMP` between string and boolean.
+     * @see #LS24003931
+     */
+    @Test
+    fun executeMUDRNRAPU00114() {
+        val expected = listOf("0", "0", "0", "0", "0")
+        assertEquals(expected, "smeup/MUDRNRAPU00114".outputOf())
+    }
+
+    /**
      * %DIFF with several DurationCodes
      * @see #LS24003282
      */

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -147,7 +147,7 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
     }
 
     /**
-     * Using `COMP` between string and boolean.
+     * Using `COMP` between string and boolean with values not equals to `0` and `1`.
      * @see #LS24003931
      */
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT04EssentialsCodopAndBifTest.kt
@@ -142,7 +142,7 @@ open class MULANGT04EssentialsCodopAndBifTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00113() {
-        val expected = listOf("1", "0")
+        val expected = listOf("1", "0", "0", "1")
         assertEquals(expected, "smeup/MUDRNRAPU00113".outputOf())
     }
 

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00113.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00113.rpgle
@@ -1,0 +1,19 @@
+     V* ==============================================================
+     V* 05/09/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Comparing String and Boolean with `COMP` operator
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *  Cannot compare StringValue to BooleanValue.
+     V* ==============================================================
+     D £C5G35          S              1
+
+     C                   MOVEL     *ON           £C5G35
+     C     £C5G35        COMP      *ON                                    35    # An operation is not implemented: Cannot compare StringValue[1](1) to BooleanValue(value=true),
+     C     *IN35         DSPLY
+
+     C                   MOVEL     *OFF          £C5G35
+     C     £C5G35        COMP      *ON                                    35
+     C     *IN35         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00113.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00113.rpgle
@@ -17,3 +17,11 @@
      C                   MOVEL     *OFF          £C5G35
      C     £C5G35        COMP      *ON                                    35
      C     *IN35         DSPLY
+
+     C                   MOVEL     *ON           £C5G35
+     C     £C5G35        COMP      *OFF                                   35
+     C     *IN35         DSPLY
+
+     C                   MOVEL     *OFF          £C5G35
+     C     £C5G35        COMP      *OFF                                   35
+     C     *IN35         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00114.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00114.rpgle
@@ -26,3 +26,23 @@
      C                   MOVEL     ''            £C5G35
      C     £C5G35        COMP      *ON                                    35
      C     *IN35         DSPLY
+
+     C                   MOVEL     '2'           £C5G35
+     C     £C5G35        COMP      *OFF                                   35
+     C     *IN35         DSPLY
+
+     C                   MOVEL     'a'           £C5G35
+     C     £C5G35        COMP      *OFF                                   35
+     C     *IN35         DSPLY
+
+     C                   MOVEL     '-1'          £C5G35
+     C     £C5G35        COMP      *OFF                                   35
+     C     *IN35         DSPLY
+
+     C                   MOVEL     ' '           £C5G35
+     C     £C5G35        COMP      *OFF                                   35
+     C     *IN35         DSPLY
+
+     C                   MOVEL     ''            £C5G35
+     C     £C5G35        COMP      *OFF                                   35
+     C     *IN35         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00114.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00114.rpgle
@@ -3,7 +3,7 @@
      V* ==============================================================
     O * PROGRAM GOAL
     O * Comparing String and Boolean with `COMP` operator with
-    O *  values not equals to `0` and `1`.
+    O *  values not equal to `0` and `1`.
      V* ==============================================================
      D £C5G35          S              1
 

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00114.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00114.rpgle
@@ -1,0 +1,28 @@
+     V* ==============================================================
+     V* 05/09/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Comparing String and Boolean with `COMP` operator with
+    O *  values not equals to `0` and `1`.
+     V* ==============================================================
+     D £C5G35          S              1
+
+     C                   MOVEL     '2'           £C5G35
+     C     £C5G35        COMP      *ON                                    35
+     C     *IN35         DSPLY
+
+     C                   MOVEL     'a'           £C5G35
+     C     £C5G35        COMP      *ON                                    35
+     C     *IN35         DSPLY
+
+     C                   MOVEL     '-1'          £C5G35
+     C     £C5G35        COMP      *ON                                    35
+     C     *IN35         DSPLY
+
+     C                   MOVEL     ' '           £C5G35
+     C     £C5G35        COMP      *ON                                    35
+     C     *IN35         DSPLY
+
+     C                   MOVEL     ''            £C5G35
+     C     £C5G35        COMP      *ON                                    35
+     C     *IN35         DSPLY


### PR DESCRIPTION
## Description
This work resolves comparison (with `COMP`) between Standalone field and Indicator. An example:
```
     D £C5G35          S              1
     C                   MOVEL     *ON           £C5G35
     C     £C5G35        COMP      *ON                                    35  
```

### Technical notes
The fix has been simple, by adding the right check for `StringValue.compareTo`.

Related to #LS24003931

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
