### PR TITLE
Feature/ls24003953/parm factor1

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -212,6 +212,10 @@ class ExpressionEvaluation(
                     StringValue(s)
                 }
             }
+            left is StringValue && right is BooleanValue -> {
+                val s = left.withoutVarying() + right.asString().value
+                s.asValue()
+            }
             else -> {
                 throw UnsupportedOperationException("I do not know how to sum $left and $right at ${expression.position}")
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -213,7 +213,7 @@ class ExpressionEvaluation(
                 }
             }
             left is StringValue && right is BooleanValue -> {
-                val s = left.withoutVarying() + right.asString().value
+                val s = left.trimEndIfVarying() + right.asString().value
                 s.asValue()
             }
             else -> {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -215,7 +215,7 @@ data class StringValue(var value: String, var varying: Boolean = false) : Abstra
             else -> super.compareTo(other)
         }
 
-    fun withoutVarying() = if (varying) value.trimEnd() else value
+    internal fun trimEndIfVarying() = if (varying) value.trimEnd() else value
 
     override fun getWrappedString() = value
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -212,6 +212,8 @@ data class StringValue(var value: String, var varying: Boolean = false) : Abstra
             else -> super.compareTo(other)
         }
 
+    fun withoutVarying() = if (varying) value.trimEnd() else value
+
     override fun getWrappedString() = value
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -794,7 +794,11 @@ data class CallStmt(
             }
         paramValuesAtTheEnd?.forEachIndexed { index, value ->
             if (this.params.size > index) {
-                interpreter.assign(this.params[index].param.referred!!, value)
+                val currentParam = this.params[index]
+                interpreter.assign(currentParam.param.referred!!, value)
+
+                // If we also have a result field, assign to it
+                currentParam.result?.let { interpreter.assign(it, value) }
             }
         }
     }
@@ -1108,6 +1112,7 @@ data class PlistStmt(
 
 @Serializable
 data class PlistParam(
+    val result: AssignableExpression?,
     val param: ReferenceByName<AbstractDataDefinition>,
     // TODO @Derived????
     @Derived val dataDefinition: InStatementDataDefinition? = null,

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1184,11 +1184,7 @@ internal fun CsPARMContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
     if (paramName.contains(".")) {
         val parts = paramName.split(".")
         require(parts.isNotEmpty())
-        if (parts.size == 1) {
-            paramName = parts[0]
-        } else {
-            paramName = parts.last()
-        }
+        paramName = parts.last()
     }
     // initialization value valid only if there isn't a variable declaration
     val initializationValue = if (this.cspec_fixed_standard_parts().len.asInt() == null) {
@@ -1196,8 +1192,14 @@ internal fun CsPARMContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()
     } else {
         null
     }
+
+    val factor1Text = this.factor1.text.trim()
+    val factor1Position = this.factor1.toPosition(conf.considerPosition)
+    val result = if (factor1Text.isNotEmpty()) annidatedReferenceExpression(factor1Text, factor1Position) else null
+
     val position = toPosition(conf.considerPosition)
     return PlistParam(
+        result,
         ReferenceByName(paramName),
         this.cspec_fixed_standard_parts().toDataDefinition(
             paramName,

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2459,4 +2459,10 @@ Test 6
         val expected = listOf("(1,1)", "(0,0)", "(1,1,0,0,0)")
         assertEquals(expected, "PRSLTCALLER".outputOf())
     }
+
+    @Test
+    fun executePRSLTCALLERDUPLICATE() {
+        val expected = listOf("0", "0", "0", "1")
+        assertEquals(expected, "PRSLTCALLERDUPLICATE".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2456,7 +2456,7 @@ Test 6
 
     @Test
     fun executePRSLTCALLER() {
-        val expected = listOf("(1,1)","(0,0)","(1,1,0,0,0)")
+        val expected = listOf("(1,1)", "(0,0)", "(1,1,0,0,0)")
         assertEquals(expected, "PRSLTCALLER".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2453,4 +2453,10 @@ Test 6
         val expected = listOf("1")
         assertEquals(expected, "VPARMSCALLER".outputOf())
     }
+
+    @Test
+    fun executePRSLTCALLER() {
+        val expected = listOf("1", "1")
+        assertEquals(expected, "PRSLTCALLER".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2456,7 +2456,7 @@ Test 6
 
     @Test
     fun executePRSLTCALLER() {
-        val expected = listOf("1", "1")
+        val expected = listOf("(1,1)","(0,0)","(1,1,0,0,0)")
         assertEquals(expected, "PRSLTCALLER".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLEE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLEE.rpgle
@@ -2,4 +2,6 @@
       * Takes $A as parameter and updates it's value
      C     *ENTRY        PLIST
      C                   PARM                    $A                1
+     C                   PARM                    $B                1
+     C                   PARM                    $C                1
      C                   EVAL      $A = *ON

--- a/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLEE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLEE.rpgle
@@ -1,0 +1,5 @@
+      * Called by PRSLTCALLER.rpgle
+      * Takes $A as parameter and updates it's value
+     C     *ENTRY        PLIST
+     C                   PARM                    $A                1
+     C                   EVAL      $A = *ON

--- a/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLEE2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLEE2.rpgle
@@ -1,0 +1,7 @@
+      * Called by PRSLTCALLERDUPLICATE.rpgle
+     C     *ENTRY        PLIST
+     C                   PARM                    $A                1
+     C                   PARM                    $B                1
+     C                   PARM                    $C                1
+     C                   EVAL      $A = *ON
+     C                   EVAL      $B = *OFF

--- a/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLEE3.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLEE3.rpgle
@@ -1,0 +1,8 @@
+      * Called by PRSLTCALLERDUPLICATE.rpgle
+     C     *ENTRY        PLIST
+     C                   PARM                    $A                1
+     C                   PARM                    $B                1
+     C                   PARM                    $C                1
+     C                   EVAL      $A = *ON
+     C                   EVAL      $B = *OFF
+     C                   EVAL      $A = *ON

--- a/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLER.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLER.rpgle
@@ -1,13 +1,13 @@
       * Helper declarations
      D £DBG_Str        S           512
 
-      * Call PRSLTCALLEE passing parameter $A
-      * If a gets updated by PRSLTCALLEE, the new value must be
-      * bound to the factor 1 of the param (*IN36)
+      * Call PRSLTCALLEE passing parameter $A bound with *IN35 and $B bound with *IN36
+      * If $A or $B get updated by PRSLTCALLEE, the new value must be
+      * bound to the factor 1 of the param (*IN35 or *IN36)
      C                   CALL      'PRSLTCALLEE'
      C     *IN35         PARM      *OFF          $A                1            Should be updated
-     C                   PARM      *OFF          $B                1            Should not be updated
-     C                   PARM      *OFF          $C                1            Shoud have no influence
+     C     *IN36         PARM      *OFF          $B                1            Should not be updated
+     C                   PARM      *OFF          $C                1            Should have no influence
 
       * Updated value output
      C                   EVAL      £DBG_Str = '('+$A+','+*IN35+')'

--- a/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLER.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLER.rpgle
@@ -1,0 +1,9 @@
+      * Call PRSLTCALLEE passing parameter $A
+      * If a gets updated by PRSLTCALLEE, the new value must be
+      * bound to the factor 1 of the param (*IN36)
+     C                   CALL      'PRSLTCALLEE'
+     C     *IN36         PARM      *OFF          $A                1
+
+      * Test output
+     C     $A            DSPLY
+     C     *IN36         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLER.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLER.rpgle
@@ -6,7 +6,7 @@
       * bound to the factor 1 of the param (*IN36)
      C                   CALL      'PRSLTCALLEE'
      C     *IN35         PARM      *OFF          $A                1            Should be updated
-     C     *IN35         PARM      *OFF          $B                1            Should not be updated
+     C                   PARM      *OFF          $B                1            Should not be updated
      C                   PARM      *OFF          $C                1            Shoud have no influence
 
       * Updated value output

--- a/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLER.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLER.rpgle
@@ -1,9 +1,21 @@
+      * Helper declarations
+     D £DBG_Str        S           512
+
       * Call PRSLTCALLEE passing parameter $A
       * If a gets updated by PRSLTCALLEE, the new value must be
       * bound to the factor 1 of the param (*IN36)
      C                   CALL      'PRSLTCALLEE'
-     C     *IN36         PARM      *OFF          $A                1
+     C     *IN35         PARM      *OFF          $A                1            Should be updated
+     C     *IN35         PARM      *OFF          $B                1            Should not be updated
+     C                   PARM      *OFF          $C                1            Shoud have no influence
 
-      * Test output
-     C     $A            DSPLY
-     C     *IN36         DSPLY
+      * Updated value output
+     C                   EVAL      £DBG_Str = '('+$A+','+*IN35+')'
+     C     £DBG_Str      DSPLY
+      * Not updated value output
+     C                   EVAL      £DBG_Str = '('+$B+','+*IN36+')'
+     C     £DBG_Str      DSPLY
+      * No influence output
+     C                   EVAL      £DBG_Str = '('+$A+','+*IN35+','+$B+','+
+     C                                    *IN36+','+$C+')'
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLERDUPLICATE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/PRSLTCALLERDUPLICATE.rpgle
@@ -1,0 +1,41 @@
+      * Helper declarations
+     D £DBG_Str        S           512
+
+      * A variant of PRSLTCALLER binding the same identifier (*IN35) to parameters $A and $B
+      * Assignment should happen sequentially from first to last on call exit
+
+      * Only update $A
+     C                   CALL      'PRSLTCALLEE'
+     C     *IN35         PARM      *OFF          $A                1            Should be updated
+     C     *IN35         PARM      *OFF          $B                1            Should not be updated
+     C                   PARM      *OFF          $C                1            Should have no influence
+
+      * $A is the last value updated output
+     C     *IN35         DSPLY
+
+      * Update $A then $B
+     C                   CALL      'PRSLTCALLEE2'
+     C     *IN35         PARM      *OFF          $A                1            Should be updated
+     C     *IN35         PARM      *OFF          $B                1            Should be updated
+     C                   PARM      *OFF          $C                1            Should have no influence
+
+      * $B is the last value updated output
+     C     *IN35         DSPLY
+
+      * Update $A then $B then $A again
+     C                   CALL      'PRSLTCALLEE3'
+     C     *IN35         PARM      *OFF          $A                1            Should be updated
+     C     *IN35         PARM      *OFF          $B                1            Should be updated
+     C                   PARM      *OFF          $C                1            Should have no influence
+
+      * Mixed update test
+     C     *IN35         DSPLY
+
+      * Update $A then $B then $A again without duplicate binding
+     C                   CALL      'PRSLTCALLEE3'
+     C     *IN35         PARM      *OFF          $A                1            Should be updated
+     C                   PARM      *OFF          $B                1            Should be updated
+     C                   PARM      *OFF          $C                1            Should have no influence
+
+      * Mixed update test
+     C     *IN35         DSPLY


### PR DESCRIPTION
## Description

When using `PARM` with `CALL` operations, the first factor of the `PARM` can be used to specify where to put the "updated" value of the parameter when callee terminates its execution.

For instance in the following snippet, when `PROCEDURE` ends its execution, the new value of `$A` gets put in `*IN36`
```
     C                   CALL      'PROCEDURE'
     C     *IN36         PARM      *OFF          $A                1
```

This feature of `PARM` was unsupported.

From a technical standpoint changes concern:
- The addition of a `result` field in `PlistParam`
- The new AST creation rule for `PARM` factor 1
- The new assignment rule in the `execute` method of `CallStmt`
- The removal of a useless check in `misc.kt` during the creation of `PlistParam`s

Related to:
- LS24003953

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
