### PR TITLE
bufix/Could not resolve io.opentelemetry:opentelemetry-bom:1.41.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+#
 
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 FlightRecorderOptions=stackdepth=64
 kotlinVersion=1.8.20
 serializationVersion=1.5.0
 jvmVersion=11
-reloadVersion=develop-SNAPSHOT
+reloadVersion=1.4.0
 jarikoGroupId=io.github.smeup.jariko
 jarikoVersion=develop-SNAPSHOT


### PR DESCRIPTION
## Description

Reload `develop-SNAPSHOT` is no longer compatible with Jariko due to OpenTelemetry dependencies. 
As a workaround, I have reverted the Reload dependency to version 1.4.0.


## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [ ] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [X] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
