### PR TITLE
Bugfix/ls24003938/exceeding caller params

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -738,7 +738,9 @@ data class CallStmt(
             "Line: ${this.position.line()} - Program '$programToCall' cannot be found"
         }
 
-        val params = this.params.mapIndexed { index, it ->
+        // Ignore exceeding params
+        val targetProgramParams = program.params()
+        val params = this.params.take(targetProgramParams.size).mapIndexed { index, it ->
             if (it.dataDefinition != null) {
                 // handle declaration of new variable
                 if (it.dataDefinition.initializationValue != null) {
@@ -765,10 +767,7 @@ data class CallStmt(
                     )
                 }
             }
-            require(program.params().size > index) {
-                "Line: ${this.position.line()} - Parameter nr. ${index + 1} can't be found"
-            }
-            program.params()[index].name to interpreter[it.param.name]
+            targetProgramParams[index].name to interpreter[it.param.name]
         }.toMap(LinkedHashMap())
 
         val paramValuesAtTheEnd =

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2453,4 +2453,10 @@ Test 6
         val expected = listOf("1")
         assertEquals(expected, "VPARMSCALLER".outputOf())
     }
+
+    @Test
+    fun executeEXCPCALL() {
+        val expected = listOf("ok")
+        assertEquals(expected, "EXCPCALLER".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/EXCPCALLEE.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/EXCPCALLEE.rpgle
@@ -1,0 +1,3 @@
+      * Called by 'EXCPCALLER', see it for more details on this test
+     C     *ENTRY        PLIST
+     C                   PARM                    $A                1

--- a/rpgJavaInterpreter-core/src/test/resources/EXCPCALLER.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/EXCPCALLER.rpgle
@@ -1,0 +1,11 @@
+      * Test declarations
+     D £DBG_Str        S             2
+
+      * When calling a program with more parameters than it expects, exceeding parameters should be ignored
+     C                   CALL      'EXCPCALLEE'
+     C                   PARM      *OFF          $A                1
+     C                   PARM      *OFF          $B                1
+
+      * Test output
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY


### PR DESCRIPTION
## Description

Given two programs `A` and `B`, when `A` calls `B` providing more params than `B` expects in its `PLIST`, exceeding params should be ignored and no error should be thrown.

From a technical standpoint changes are the following:
- Removed the requirement causing the error to be thrown
- Added an instruction to ignore any param whose index exceeds the number of params expected by the callee

Related to:
- LS24003938

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
