### PR TITLE
Bugfix/ls24004010/conversion to ds for unlimited string type

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -303,6 +303,9 @@ fun Type.toDataStructureValue(value: Value): StringValue {
         is StringType -> {
             return StringValue(value.asString().value)
         }
+        is UnlimitedStringType -> {
+            return StringValue(value.asString().value)
+        }
         is ArrayType -> {
             val sb = StringBuilder()
             when (value) {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -598,4 +598,10 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("test", "test")
         assertEquals(expected, "smeup/MUDRNRAPU01101".outputOf(configuration = smeupConfig))
     }
+
+    @Test
+    fun executeMUDRNRAPU01102() {
+        val expected = listOf("test", "te", "st")
+        assertEquals(expected, "smeup/MUDRNRAPU01102".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01102.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01102.rpgle
@@ -1,0 +1,26 @@
+     V* ==============================================================
+     V* 12/09/2024 APU011 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Verifies the conversion of values to a data structure when
+    O * using the UnlimitedStringType and displays the results.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O * Conversion to data struct value not implemented for UnlimitedStringType
+     V* ==============================================================
+
+     D DSMETO          DS
+     D  §FUNZ                         2
+     D  §METO                         2
+
+     D £UIBDS          DS             10
+     D £UIBME                          0    INZ('test')
+
+     C                   MOVEL(P)  £UIBME        DSMETO
+
+     C     DSMETO        DSPLY
+     C     §FUNZ         DSPLY
+     C     §METO         DSPLY
+
+


### PR DESCRIPTION
## Description

This work adds the ability to convert values of type `UnlimitedStringType` into a data structure during MOVEL operations.

**Technical notes**

To achieve the goal, `data_definitions.kt` was updated to handle `UnlimitedStringType` correctly, ensuring no modification or padding of unlimited strings.

Related to #LS24004010 

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [ ] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
