### PR TITLE
Fix infinite recursion in RPG programs by restoring their error state

### DIFF
--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_05.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_05.rpgle
@@ -36,7 +36,7 @@
       * Variable for loop
      C                   EVAL      $CICL=10000
       * Call
-     C                   CALL      'MUTE10_05'
+     C                   CALL      'WAIT4BENETTI'
      C                   PARM                    $CICL
       * End time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_06.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_06.rpgle
@@ -32,7 +32,7 @@
       * Loop on PGM
      C                   DO        500
      C                   EVAL      XXRET='1'
-     C                   CALL      'MUTE10_06'
+     C                   CALL      'WAIT4BENETTI'
      C                   PARM                    ARRAY
      C                   PARM                    XXRET
      C

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_08.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_08.rpgle
@@ -32,7 +32,7 @@
       * Variable for loop
      C                   EVAL      $CICL=10000
       * Call
-     C                   CALL      'MUTE10_08'
+     C                   CALL      'WAIT4BENETTI'
      C                   PARM                    $CICL
       * End time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_82.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_82.rpgle
@@ -32,7 +32,7 @@
       * Loop on PGM
      C                   DO        500
      C                   EVAL      XXRET=' '
-     C                   CALL      'MUTE10_06'
+     C                   CALL      'WAIT4BENETTI'
      C                   PARM                    ARRAY
      C                   PARM                    XXRET
      C

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_84.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_84.rpgle
@@ -36,7 +36,7 @@
       * Varable for loop
      C                   EVAL      $CICL=100000
       * Call
-     C                   CALL      'MUTE10_05'
+     C                   CALL      'WAIT4BENETTI'
      C                   PARM                    $CICL
       * End time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_85.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_85.rpgle
@@ -36,7 +36,7 @@
       * Variable for loop
      C                   EVAL      $CICL=1000000
       * Call
-     C                   CALL      'MUTE10_05'
+     C                   CALL      'WAIT4BENETTI'
      C                   PARM                    $CICL
       * end time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_86.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_86.rpgle
@@ -32,7 +32,7 @@
       * Varable for loop
      C                   EVAL      $CICL=100000
       * Call
-     C                   CALL      'MUTE10_08'
+     C                   CALL      'WAIT4BENETTI'
      C                   PARM                    $CICL
       * End time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_87.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_87.rpgle
@@ -32,7 +32,7 @@
       * Variable for loop
      C                   EVAL      $CICL=1000000
       * Call
-     C                   CALL      'MUTE10_08'
+     C                   CALL      'WAIT4BENETTI'
      C                   PARM                    $CICL
       * end time
      C                   TIME                    $TIMEN


### PR DESCRIPTION
## Description

As the title says, this PR restores the previous error state for MUTE test with infinite recursion in `CALL` statements while we wait for them to be fixed.

Related to:
- LS24004037

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
