### PR TITLE
Bugfix/ls24004074/not whole input consumed compiler directives

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
@@ -33,6 +33,8 @@ val ELSE_PATTERN = Regex(""".{6}/ELSE\s*$""", RegexOption.IGNORE_CASE)
 val ENDIF_PATTERN = Regex(""".{6}/ENDIF\s*$""", RegexOption.IGNORE_CASE)
 val EOF_PATTERN = Regex(""".{6}/EOF\s*$""", RegexOption.IGNORE_CASE)
 
+private const val SIX_COLUMNS_PADDING = "      "
+
 /**
  * Resolve the EOF directive: after this directive, all rows are ignored until the end of the file
  * and marked in the result string as comments.
@@ -220,10 +222,11 @@ internal fun String.resolveCompilerDirectives(): String {
 }
 
 private fun String.transformToComment(): String {
+    // We expect to output [6 characters][*][remaining comment]
     return when {
-        this.isBlank() -> "     *"
+        this.isBlank() -> "$SIX_COLUMNS_PADDING*"
         this.length >= 7 -> "${this.substring(0, 6)}*${this.substring(7)}"
-        else -> "$this${"       ".substring(0, 7 - this.length)}*"
+        else -> "${this.padEnd(6, ' ')}*"
     }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/compilerDirectives.kt
@@ -220,14 +220,11 @@ internal fun String.resolveCompilerDirectives(): String {
 }
 
 private fun String.transformToComment(): String {
-    val newString: String
-    if (this.length >= 7) {
-        newString = this.substring(0, 6) + '*' + this.substring(7)
-    } else {
-        val padding = "       "
-        newString = this + padding.substring(0, 7 - this.length) + '*'
+    return when {
+        this.isBlank() -> "     *"
+        this.length >= 7 -> "${this.substring(0, 6)}*${this.substring(7)}"
+        else -> "$this${"       ".substring(0, 7 - this.length)}*"
     }
-    return newString
 }
 
 private fun containDirectives(inputString: String): Boolean {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/compilerDirectives/CompilerDirectivesTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/compilerDirectives/CompilerDirectivesTest.kt
@@ -2,6 +2,7 @@ package com.smeup.rpgparser.compilerDirectives
 
 import com.smeup.rpgparser.AbstractTest
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
 class CompilerDirectivesTest : AbstractTest() {
@@ -31,5 +32,15 @@ class CompilerDirectivesTest : AbstractTest() {
         assertFails {
             "compilerDirectives/ERROR04".outputOf()
         }.printStackTrace()
+    }
+
+    /**
+     * Duplicate definition in two different copies
+     * @see #LS24004074
+     */
+    @Test
+    fun executeDUPDEF() {
+        val expected = listOf("ok")
+        assertEquals(expected, "compilerDirectives/DUPDEF".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/compilerDirectives/DUPDEF.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/compilerDirectives/DUPDEF.rpgle
@@ -1,0 +1,10 @@
+      * Helper declarations
+     D £DBG_Str        S             2
+
+      * Copies containing a duplicate DEFINE
+      /COPY DUPDEF1
+      /COPY DUPDEF2
+
+      * Test output
+     C                   EVAL      £DBG_Str='ok'
+     C     £DBG_Str      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/compilerDirectives/DUPDEF1.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/compilerDirectives/DUPDEF1.rpgle
@@ -1,0 +1,8 @@
+      /IF NOT DEFINED(DUPLICATE_DEF_INCLUDED)
+      /DEFINE DUPLICATE_DEF_INCLUDED
+     C     SR1           BEGSR
+     C                   ENDSR
+
+     C     SR2           BEGSR
+     C                   ENDSR
+      /ENDIF

--- a/rpgJavaInterpreter-core/src/test/resources/compilerDirectives/DUPDEF2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/compilerDirectives/DUPDEF2.rpgle
@@ -1,0 +1,8 @@
+      /IF NOT DEFINED(DUPLICATE_DEF_INCLUDED)
+      /DEFINE DUPLICATE_DEF_INCLUDED
+     C     SR1           BEGSR
+     C                   ENDSR
+
+     C     SR2           BEGSR
+     C                   ENDSR
+      /ENDIF


### PR DESCRIPTION
## Description

Fix an issue where a program containing two `COPY` containing a `IF DEFINED` or `IF NOT DEFINED` directive with the same definition resulted in a wrong file output on the second one if it contained empty lines.

Related to:
- LS24004074

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
