### PR TITLE
Bugfix/LS24004081/Z-ADD with Scalar to Array

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -286,6 +286,10 @@ fun coerce(value: Value, type: Type): Value {
             when (type) {
                 is StringType -> StringValue(value.value.toString(), varying = type.varying)
                 is DateType -> DateValue(value.value, type.format)
+                is ArrayType -> {
+                    val coercedValue = coerce(value, type.element)
+                    ConcreteArrayValue(MutableList(type.nElements) { coercedValue }, type.element)
+                }
                 else -> value
             }
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -182,17 +182,25 @@ open class InternalInterpreter(
                     var startOffset = data.startOffset
                     val size = data.endOffset - data.startOffset
 
-                    // for (i in 1..data.declaredArrayInLine!!) {
-                    // If the size of the arrays are different
-                    val maxElements = min(value.asArray().arrayLength(), data.declaredArrayInLine!!)
-                    for (i in 1..maxElements) {
+                    fun assignValueToArray(value: Value, data: FieldDefinition) {
                         // Added coerce
-                        val valueToAssign = coerce(value.asArray().getElement(i), data.type.asArray().element)
+                        val valueToAssign = coerce(value, data.type.asArray().element)
                         dataStructValue.setSubstring(
                             startOffset, startOffset + size,
                             data.type.asArray().element.toDataStructureValue(valueToAssign)
                         )
                         startOffset += data.stepSize
+                    }
+
+                    if (value is ArrayValue) {
+                        // If the size of the arrays are different
+                        for (i in 1..min(value.asArray().arrayLength(), data.declaredArrayInLine!!)) {
+                            assignValueToArray(value.asArray().getElement(i), data)
+                        }
+                    } else {
+                        for (i in 1..data.declaredArrayInLine!!) {
+                            assignValueToArray(value, data)
+                        }
                     }
                 } else {
                     when (val containerValue = get(ds.name)) {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -182,4 +182,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("99.000000", ".000000")
         assertEquals(expected, "smeup/MUDRNRAPU00115".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Z-ADD to a Standalone defined as array.
+     * @see #LS24004081
+     */
+    @Test
+    fun executeMUDRNRAPU00120() {
+        val expected = listOf("99.000000", ".000000")
+        assertEquals(expected, "smeup/MUDRNRAPU00120".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -179,7 +179,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00115() {
-        val expected = listOf("99.000000", "0.000000")
+        val expected = listOf("99.000000", ".000000")
         assertEquals(expected, "smeup/MUDRNRAPU00115".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -172,4 +172,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("*IN36: 0;*IN36: 0;*IN36: 1;*IN36: 0;*IN36: 1;*IN36: 0;*IN36: 0.")
         assertEquals(expected, "smeup/MU101019".outputOf())
     }
+
+    /**
+     * Z-ADD to a DS field defined as array and overlay.
+     * @see #LS24004081
+     */
+    @Test
+    fun executeMUDRNRAPU00115() {
+        val expected = listOf("99.000000", "0.000000")
+        assertEquals(expected, "smeup/MUDRNRAPU00115".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00115.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00115.rpgle
@@ -1,0 +1,42 @@
+     V* ==============================================================
+     V* 17/09/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment, with Z-ADD, a value to a DS field defined as
+    O *  array and overlay.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was
+    O *  Issue executing ZAddStmt at line xyz. null..
+     V* ==============================================================
+     D MSG             S             30
+     D CONT            S              3  0 INZ(1)
+     D SUM             S             12  6 INZ(0)
+
+     D D5COSO        E DS                  EXTNAME(D5COSO0F)
+     D  D50                                DIM(99) LIKE(D$C001) INZ
+     D                                             OVERLAY(D5COSO:88)
+
+     C                   Z-ADD     1             D50                            #Issue executing ZAddStmt at line 20
+
+     C                   EXSR      CALCULATE
+
+     C                   EVAL      SUM=0
+     C                   EVAL      CONT=1
+     C                   Z-ADD     0             D50
+     C                   EXSR      CALCULATE
+
+     C                   SETON                                          LR
+
+
+
+     C     CALCULATE     BEGSR
+
+     C     100           DOUEQ     CONT
+     C                   EVAL      SUM+=D50(CONT)
+     C                   EVAL      CONT+=1
+     C                   ENDDO
+     C                   EVAL      MSG=%CHAR(SUM)
+     C     MSG           DSPLY
+
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00115.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00115.rpgle
@@ -19,18 +19,18 @@
 
      C                   Z-ADD     1             D50                            #Issue executing ZAddStmt at line 20
 
-     C                   EXSR      CALCULATE
+     C                   EXSR      CALCULATES
 
      C                   EVAL      SUM=0
      C                   EVAL      COUNT=1
      C                   Z-ADD     0             D50
-     C                   EXSR      CALCULATE
+     C                   EXSR      CALCULATES
 
      C                   SETON                                          LR
 
 
 
-     C     CALCULATE     BEGSR
+     C     CALCULATES    BEGSR
 
      C     100           DOUEQ     COUNT
      C                   EVAL      SUM+=D50(COUNT)

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00115.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00115.rpgle
@@ -10,7 +10,7 @@
     O *  Issue executing ZAddStmt at line xyz. null..
      V* ==============================================================
      D MSG             S             30
-     D CONT            S              3  0 INZ(1)
+     D COUNT           S              3  0 INZ(1)
      D SUM             S             12  6 INZ(0)
 
      D D5COSO        E DS                  EXTNAME(D5COSO0F)
@@ -22,7 +22,7 @@
      C                   EXSR      CALCULATE
 
      C                   EVAL      SUM=0
-     C                   EVAL      CONT=1
+     C                   EVAL      COUNT=1
      C                   Z-ADD     0             D50
      C                   EXSR      CALCULATE
 
@@ -32,9 +32,9 @@
 
      C     CALCULATE     BEGSR
 
-     C     100           DOUEQ     CONT
-     C                   EVAL      SUM+=D50(CONT)
-     C                   EVAL      CONT+=1
+     C     100           DOUEQ     COUNT
+     C                   EVAL      SUM+=D50(COUNT)
+     C                   EVAL      COUNT+=1
      C                   ENDDO
      C                   EVAL      MSG=%CHAR(SUM)
      C     MSG           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00115.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00115.rpgle
@@ -18,20 +18,18 @@
      D                                             OVERLAY(D5COSO:88)
 
      C                   Z-ADD     1             D50                            #Issue executing ZAddStmt at line 20
-
-     C                   EXSR      CALCULATES
-
-     C                   EVAL      SUM=0
-     C                   EVAL      COUNT=1
+     C                   EXSR      SHOW_RES
      C                   Z-ADD     0             D50
-     C                   EXSR      CALCULATES
+     C                   EXSR      SHOW_RES
 
      C                   SETON                                          LR
 
 
 
-     C     CALCULATES    BEGSR
+     C     SHOW_RES      BEGSR
 
+     C                   EVAL      SUM=0
+     C                   EVAL      COUNT=1
      C     100           DOUEQ     COUNT
      C                   EVAL      SUM+=D50(COUNT)
      C                   EVAL      COUNT+=1

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00120.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00120.rpgle
@@ -1,0 +1,36 @@
+     V* ==============================================================
+     V* 19/09/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment, with Z-ADD, a value to a S field defined
+    O *  as array.
+     V* ==============================================================
+     D MSG             S             30
+     D COUNT           S              3  0 INZ(1)
+     D SUM             S             12  6 INZ(0)
+
+
+     D  D50            S              5  0 DIM(99) INZ
+
+     C                   Z-ADD     1             D50
+     C                   EXSR      SHOW_RES
+
+     C                   EVAL      SUM=0
+     C                   EVAL      COUNT=1
+     C                   Z-ADD     0             D50
+     C                   EXSR      SHOW_RES
+
+     C                   SETON                                          LR
+
+
+
+     C     SHOW_RES      BEGSR
+
+     C     100           DOUEQ     COUNT
+     C                   EVAL      SUM+=D50(COUNT)
+     C                   EVAL      COUNT+=1
+     C                   ENDDO
+     C                   EVAL      MSG=%CHAR(SUM)
+     C     MSG           DSPLY
+
+     C                   ENDSR


### PR DESCRIPTION
## Description
This work resolves an assignment of a **scalar value** to an **array** defined as Data Struct's field. For example:
```
     D D5COSO        E DS                  EXTNAME(D5COSO0F)
     D  D50                                DIM(99) LIKE(D$C001) INZ
     D                                             OVERLAY(D5COSO:88)

     C                   Z-ADD     1             D50
```

In addition, was analyzed and fixed an assignment of a **scalar value** to an **array** defined as Standalone. For example:
```
     D  D50            S              5  0 DIM(99) INZ

     C                   Z-ADD     1             D50
```


### Technical notes
To achieve the goal, I improved `InternalInterpreter.set` when `value` (which the source) is a scalar instead an array, under `FieldDefinition`'s branch. 

Related to #LS24004081

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
