### PR TITLE
Bugfix/LS24004104/error-movel-for-input-string

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/movel.kt
@@ -147,6 +147,8 @@ private fun movel(
 ): String {
     return if (valueToApplyMoveType is UnlimitedStringType) {
         valueToMove
+    } else if (valueToMove.isBlank() && valueToApplyMoveType.isNumeric()) {
+        "0"
     } else if (valueToMove.length <= valueToApplyMove.length) {
         var result: String = valueToApplyMove
         if (withClear) {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -604,4 +604,10 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("test", "te", "st")
         assertEquals(expected, "smeup/MUDRNRAPU01102".outputOf(configuration = smeupConfig))
     }
+
+    @Test
+    fun executeMUDRNRAPU01103() {
+        val expected = listOf("1", "0")
+        assertEquals(expected, "smeup/MUDRNRAPU01103".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01103.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01103.rpgle
@@ -1,0 +1,23 @@
+     V* ==============================================================
+     V* 19/09/2024 APU011 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Verifies the conversion of values to a numeric data structure
+    O * when using a blank string and displays the results.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O * Issue executing MoveLStmt at line 2797. For input string: "        "
+     V* ==============================================================
+
+     D PER$DS          DS           100
+     D  T$PERI                19     26
+
+     DK§CF             DS
+     D K$DE                           8  0
+
+     C     K$DE          DSPLY
+
+     C                   MOVEL(P)  T$PERI        K$DE
+
+     C     K$DE          DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01103.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01103.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
      V* 19/09/2024 APU011 Creation
+     V* 25/09/2024 APU011 Edit
      V* ==============================================================
     O * PROGRAM GOAL
     O * Verifies the conversion of values to a numeric data structure
@@ -7,17 +8,18 @@
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, the error occurred was:
-    O * Issue executing MoveLStmt at line 2797. For input string: "        "
+    O *   Issue executing MoveLStmt at line 22. For
+    O *   input string: "        "
      V* ==============================================================
-
      D PER$DS          DS           100
      D  T$PERI                19     26
 
      DK§CF             DS
      D K$DE                           8  0
 
+     C                   EVAL      K$DE=1
+     C     K$DE          DSPLY
+     C                   MOVEL(P)  T$PERI        K$DE                           #MoveLStmt at line 22. For input string: "        "
      C     K$DE          DSPLY
 
-     C                   MOVEL(P)  T$PERI        K$DE
-
-     C     K$DE          DSPLY
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description

This work adds the ability to assign an blank string to a numeric value with movel

Technical notes

To achieve the goal, the movel function was updated in movel.kt to handle a blank string and assign 0 only in case we have a string-to-number assignment

Related to #LS24004104

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
