### PR TITLE
Feature/ls24004325/qualified like resolution

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -622,4 +622,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf(".00", "0")
         assertEquals(expected, "smeup/MUDRNRAPU00131".outputOf())
     }
+
+    /**
+     * LIKE on DS field with absolute path
+     * @see #LS24003324
+     */
+    @Test
+    fun executeMUDRNRAPU00263() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00263".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00263.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00263.rpgle
@@ -1,0 +1,14 @@
+      * Test definitions
+     D £C6CIN          DS                                                       INPUT
+     D  £C6CTP                       12                                         Tipo Oggetto
+     D §DI             DS                  LIKEDS(£C6CIN)
+     D XC6CTP          S                   LIKE(§DI.£C6CTP)
+
+      * Test value initialization
+     C                   EVAL      §DI.£C6CTP='ok'
+
+      * LIKE on DS field with absolute path should be defined appropriately
+     C                   EVAL      XC6CTP=§DI.£C6CTP
+
+      * Test output
+     C     XC6CTP        DSPLY


### PR DESCRIPTION
## Description

Add support for declarations using `LIKE` on DS fields like following:

Given a DS `$A` with a field `$B`, declare a standalone definition `$C` using `LIKE($A.$B)`, or in RPGLE code terms

```
     D $C     S LIKE($A.$B)
```

Related to:
- LS24004325

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
