### PR TITLE
chore: bump other deps

### DIFF
--- a/dspfparser/build.gradle
+++ b/dspfparser/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.1'
 
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion"

--- a/dspfparser/build.gradle
+++ b/dspfparser/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.1'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
 
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion"

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation project(":rpgJavaInterpreter-core")
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.1'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
 }
 
 task javadocJar(type: Jar) {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation project(":rpgJavaInterpreter-core")
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.1'
 }
 
 task javadocJar(type: Jar) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ FlightRecorderOptions=stackdepth=64
 kotlinVersion=2.0.20
 serializationVersion=1.7.3
 jvmVersion=11
+junitVersion=5.11.1
 reloadVersion=develop-SNAPSHOT
 jarikoGroupId=io.github.smeup.jariko
 jarikoVersion=develop-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ kotlinVersion=2.0.20
 serializationVersion=1.7.3
 jvmVersion=11
 junitVersion=5.11.1
+antlrVersion=4.13.2
 reloadVersion=develop-SNAPSHOT
 jarikoGroupId=io.github.smeup.jariko
 jarikoVersion=develop-SNAPSHOT

--- a/kolasu/build.gradle
+++ b/kolasu/build.gradle
@@ -3,7 +3,7 @@
 //-----------------
 buildscript {
 
-    ext.antlr_version = '4.7.2'
+    ext.antlr_version = '4.13.2'
 
     repositories {
         mavenCentral()
@@ -39,10 +39,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.1'
 
-    implementation 'com.fifesoft:rsyntaxtextarea:2.5.8'
-    implementation 'com.fifesoft:autocomplete:2.5.8'
+    implementation 'com.fifesoft:rsyntaxtextarea:3.5.1'
+    implementation 'com.fifesoft:autocomplete:3.3.1'
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion"
 

--- a/kolasu/build.gradle
+++ b/kolasu/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.1'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
 
     implementation 'com.fifesoft:rsyntaxtextarea:3.5.1'
     implementation 'com.fifesoft:autocomplete:3.3.1'

--- a/kolasu/build.gradle
+++ b/kolasu/build.gradle
@@ -3,7 +3,8 @@
 //-----------------
 buildscript {
 
-    ext.antlr_version = '4.13.2'
+    ext.antlrVersion = "${antlrVersion}"
+    ext.junitVersion = "${junitVersion}"
 
     repositories {
         mavenCentral()
@@ -33,8 +34,8 @@ repositories {
 }
 
 dependencies {
-    implementation "org.antlr:antlr4:$antlr_version"
-    implementation "org.antlr:antlr4-runtime:$antlr_version"
+    implementation "org.antlr:antlr4:$antlrVersion"
+    implementation "org.antlr:antlr4-runtime:$antlrVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -22,7 +22,8 @@ import java.text.SimpleDateFormat
 buildscript {
     ext.kotlinVersion = "${kotlinVersion}"
     ext.jvmVersion = "${jvmVersion}"
-    ext.antlr_version = '4.13.2'
+    ext.antlrVersion = "${antlrVersion}"
+    ext.junitVersion = "${junitVersion}"
 
     repositories {
         mavenCentral()
@@ -41,15 +42,16 @@ buildscript {
 
 apply plugin: 'antlr'
 
-def antlrVersion = ext.antlr_version
+def antlrVersion = ext.antlrVersion
+def junitVersion = ext.junitVersion
 def generatedMain = "generated-src/antlr/main"
 def generatedMainFile = file(generatedMain)
 
 def unlimitedStringTypeFlag = "jariko.features.UnlimitedStringTypeFlag"
 
 dependencies {
-    antlr "org.antlr:antlr4:$antlr_version"
-    implementation "org.antlr:antlr4-runtime:$antlr_version"
+    antlr "org.antlr:antlr4:$antlrVersion"
+    implementation "org.antlr:antlr4-runtime:$antlrVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.1'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation 'org.hsqldb:hsqldb:2.7.3'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.4.0'
 }


### PR DESCRIPTION
## Description

- Bump dependencies
- Centralize the JUnit dependency version in `grade.properties` through the new variable `junitVersion`

## Checklist:
- [] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [] There are tests for this feature.
- [] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [] Relevant documentation is included in the `docs` directory.
