### PR TITLE
Re-exported MUTE10_xx that caused recursive call loop

### DIFF
--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_05.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_05.rpgle
@@ -1,4 +1,9 @@
-   COP* *NOUI
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_05
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_05)
+      * Esportato il        : 20241004 155649
+      *====================================================================
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
      V* gg/mm/aa  nn.mm i xx Breve descrizione
@@ -6,12 +11,21 @@
      V* 05/12/19  001345  BERNI Creato
      V* 09/12/19  001345  BMA   Alcune modifiche
      V* 09/12/19  V5R1    BMA   Check-out 001345 in SMEUP_TST
-     V* 11/12/19  001362  BERNI Inseriti commenti
+     V* 11/12/19  001362  BERNI Aggiunti commenti
      V* 11/12/19  V5R1    BMA   Check-out 001362 in SMEUP_TST
+     V* 13/12/19  001378  BMA   Tolta annotation
+     V* 16/12/19  001378  BMA   Adeguamenti
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001345 001362 001378 in SMEDEV
+     V* 04/03/21  002673 BMA Tolte annotation NOXMI e variati timeout
+     V*  5/03/21  V5R1    BERNIC Check-out 002673 in SMEDEV
+     V* 07/09/23  005098  BERNI Rinominato partendo da MUTE10_05A per correggere nomenclatura
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
+     V*=====================================================================
      V*=====================================================================
      D* OBIETTIVO
      D*  Programma finalizzato ai test performance sulla CALL
-     V*---------------------------------------------------------------------
+     D*---------------------------------------------------------------------
       * Considerare i seguenti codici operativi
       *+----------+--+---------!--+
       *!RPGLE     !ST!BUILT-IN !ST!
@@ -36,7 +50,7 @@
       * Variable for loop
      C                   EVAL      $CICL=10000
       * Call
-     C                   CALL      'WAIT4BENETTI'
+     C                   CALL      'MUTE10_05A'
      C                   PARM                    $CICL
       * End time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_05A.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_05A.rpgle
@@ -1,3 +1,9 @@
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_05A
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_05A)
+      * Esportato il        : 20241004 155649
+      *====================================================================
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
      V* gg/mm/aa  nn.mm i xx Breve descrizione
@@ -5,12 +11,19 @@
      V* 05/12/19  001345  BERNI Creato
      V* 09/12/19  001345  BMA   Alcune modifiche
      V* 09/12/19  V5R1    BMA   Check-out 001345 in SMEUP_TST
-     V* 11/12/19  001362  BERNI Aggiunti commenti
+     V* 11/12/19  001362  BERNI Inseriti commenti
      V* 11/12/19  V5R1    BMA   Check-out 001362 in SMEUP_TST
+     V* 13/12/19  001378  BMA   Corretta annotation
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001345 001362 001378 in SMEDEV
+     V* 04/03/21  002673 BMA Tolte annotation NOXMI e variati timeout
+     V*  5/03/21  V5R1    BERNIC Check-out 002673 in SMEDEV
+     V* 07/09/23  005098  BERNI Rinominato pertendo dal MUTE10_05 per correggere la nomenclatura
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
      D* OBIETTIVO
      D*  Programma finalizzato ai test performance su Statement vari
-     V*---------------------------------------------------------------------
+     D*---------------------------------------------------------------------
       * Considerare i seguenti codici operativi
       *+----------+--+---------!--+
       *!RPGLE     !ST!BUILT-IN !ST!
@@ -24,7 +37,7 @@
      D $N3             S             19  6
      D $CICL           S              7  0
      D V1              S          30000
-     D S1              S            100    INZ('TEST performance')
+     D S1              S            100    INZ('TEST performance')              COSTANTE
      D V2              S          30000    Varying
      D TXT             S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
      D RES             S            100    DIM(10)

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_06.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_06.rpgle
@@ -1,9 +1,21 @@
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_06
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_06)
+      * Esportato il        : 20241004 155649
+      *====================================================================
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
      V* gg/mm/aa  nn.mm i xx Breve descrizione
      V*=====================================================================
-     V* 11/12/19  001362  BERNI Creato
+     V* 11/12/19  001362  BERNI  Creato
      V* 11/12/19  V5R1    BMA   Check-out 001362 in SMEUP_TST
+     V* 13/12/19  001378  BMA   Tolta annotation
+     V* 16/12/19  001378  BMA   Adeguamenti
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001362 001378 in SMEDEV
+     V* 06/09/23  005098  BERNI  Ridenominato partendo da MUTE10_06A per nomenclatura sbagliata
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
      D*  Pgm testing performance with big array
      V*---------------------------------------------------------------------
@@ -32,7 +44,7 @@
       * Loop on PGM
      C                   DO        500
      C                   EVAL      XXRET='1'
-     C                   CALL      'WAIT4BENETTI'
+     C                   CALL      'MUTE10_06A'
      C                   PARM                    ARRAY
      C                   PARM                    XXRET
      C

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_06A.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_06A.rpgle
@@ -1,10 +1,23 @@
-   COP* *NOUI
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_06A
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_06A)
+      * Esportato il        : 20241004 155649
+      *====================================================================
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
      V* gg/mm/aa  nn.mm i xx Breve descrizione
      V*=====================================================================
-     V* 11/12/19  001362  BERNI  Creato
+     V* 11/12/19  001362  BERNI Creato
      V* 11/12/19  V5R1    BMA   Check-out 001362 in SMEUP_TST
+     V* 11/12/19  001368  BMA   Workaround for PARM syntax
+     V* 11/12/19  V5R1    BERNI Check-out 001368 in SMEUP_TST
+     V* 13/12/19  001378  BMA   Corretta annotation
+     V* 16/12/19  001378  BMA   Adeguamenti
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001362 001368 001378 in SMEDEV
+     V* 06/09/23  005098  BERNI  Ridenominato partendo da MUTE10_06 per nomenclatura sbagliata
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
      D*  Pgm testing performance with big array
      V*---------------------------------------------------------------------
@@ -14,7 +27,6 @@
      D XXRET           S              1
       * Main
      C                   EXSR      F_EXEC
-      *
       *
       * Test entry parameter XXRET: 1=RT, Anything else=LR
      C                   IF        XXRET='1'

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_08.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_08.rpgle
@@ -1,13 +1,24 @@
-   COP* *NOUI
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_08
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_08)
+      * Esportato il        : 20241004 155649
+      *====================================================================
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
      V* gg/mm/aa  nn.mm i xx Breve descrizione
      V*=====================================================================
      V* 16/12/19  001378  BMA   Creato
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001378 in SMEDEV
+     V* 04/03/21  002673 BMA Tolte annotation NOXMI e variati timeout
+     V*  5/03/21  V5R1    BERNIC Check-out 002673 in SMEDEV
+     V* 07/09/23  005098  BERNI Rinominato partendo da MUTE10_08A per errore nomenclatura
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
      D* OBIETTIVO
      D*  Programma finalizzato ai test performance sulla CALL
-     V*---------------------------------------------------------------------
+     D*---------------------------------------------------------------------
       * Considerare i seguenti codici operativi
       *+----------+--+---------!--+
       *!RPGLE     !ST!BUILT-IN !ST!
@@ -32,7 +43,7 @@
       * Variable for loop
      C                   EVAL      $CICL=10000
       * Call
-     C                   CALL      'WAIT4BENETTI'
+     C                   CALL      'MUTE10_08A'
      C                   PARM                    $CICL
       * End time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_08A.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_08A.rpgle
@@ -1,12 +1,24 @@
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_08A
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_08A)
+      * Esportato il        : 20241004 155649
+      *====================================================================
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
      V* gg/mm/aa  nn.mm i xx Breve descrizione
      V*=====================================================================
      V* 16/12/19  001378  BMA   Creato
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001378 in SMEDEV
+     V* 04/03/21  002673 BMA Tolte annotation NOXMI e variati timeout
+     V*  5/03/21  V5R1    BERNIC Check-out 002673 in SMEDEV
+     V* 07/09/23  005098  BERNI Rinominato da MUTE10_08 per errore nella nomenclatura
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
      D* OBIETTIVO
      D*  Programma finalizzato ai test performance su Statement vari
-     V*---------------------------------------------------------------------
+     D*---------------------------------------------------------------------
       * Considerare i seguenti codici operativi
       *+----------+--+---------!--+
       *!RPGLE     !ST!BUILT-IN !ST!
@@ -16,7 +28,7 @@
      D $N1             S              5I 0
      D $V              S              5I 0
      D V1              S          30000
-     D S1              S            100    INZ('TEST performance')
+     D S1              S            100    INZ('TEST performance')              COSTANTE
      D V2              S          30000    Varying
      D TXT             S            100    DIM(10) PERRCD(1) CTDATA             _NOTXT
      D RES             S            100    DIM(10)

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_82.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_82.rpgle
@@ -1,10 +1,17 @@
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_82
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_82)
+      * Esportato il        : 20241004 155649
+      *====================================================================
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
      V* gg/mm/aa  nn.mm i xx Breve descrizione
      V*=====================================================================
-     V* 11/12/19  001362  BERNI Creato
-     V* 11/12/19  V5R1    BMA   Check-out 001362 in SMEUP_TST
+     V* 06/09/23  005098  BERNI Creato a partire dal MUTE10_06B
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
+     D*  OBIETTIVO
      D*  Pgm testing performance with big array
      V*---------------------------------------------------------------------
      D $TIMST          S               Z   INZ
@@ -32,7 +39,7 @@
       * Loop on PGM
      C                   DO        500
      C                   EVAL      XXRET=' '
-     C                   CALL      'WAIT4BENETTI'
+     C                   CALL      'MUTE10_06A'
      C                   PARM                    ARRAY
      C                   PARM                    XXRET
      C

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_84.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_84.rpgle
@@ -1,3 +1,9 @@
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_84
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_84)
+      * Esportato il        : 20241004 155649
+      *====================================================================
    COP* *NOUI
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
@@ -8,10 +14,17 @@
      V* 09/12/19  V5R1    BMA   Check-out 001345 in SMEUP_TST
      V* 11/12/19  001362  BERNI Aggiunti commenti
      V* 11/12/19  V5R1    BMA   Check-out 001362 in SMEUP_TST
+     V* 13/12/19  001378  BMA   Corretta annotation
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001345 001362 001378 in SMEDEV
+     V* 04/03/21  002673 BMA Tolte annotation NOXMI e variati timeout
+     V*  5/03/21  V5R1    BERNIC Check-out 002673 in SMEDEV
+     V* 07/09/23  005098  BERNI Rinominato partendo da MUTE10_05B
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
      D* OBIETTIVO
      D*  Programma finalizzato ai test performance sulla CALL
-     V*---------------------------------------------------------------------
+     D*---------------------------------------------------------------------
       * Considerare i seguenti codici operativi
       *+----------+--+---------!--+
       *!RPGLE     !ST!BUILT-IN !ST!
@@ -25,7 +38,7 @@
       * Main
      C                   EXSR      F_CALL
       *
-    MU* TIMEOUT(900)
+    MU* TIMEOUT(0900)
      C                   SETON                                        LR
       *---------------------------------------------------------------------
     RD* Routine test SORTA
@@ -36,7 +49,7 @@
       * Varable for loop
      C                   EVAL      $CICL=100000
       * Call
-     C                   CALL      'WAIT4BENETTI'
+     C                   CALL      'MUTE10_05A'
      C                   PARM                    $CICL
       * End time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_85.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_85.rpgle
@@ -1,3 +1,9 @@
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_85
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_85)
+      * Esportato il        : 20241004 155649
+      *====================================================================
    COP* *NOUI
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
@@ -8,10 +14,17 @@
      V* 09/12/19  V5R1    BMA   Check-out 001345 in SMEUP_TST
      V* 11/12/19  001362  BERNI Aggiunti commenti
      V* 11/12/19  V5R1    BMA   Check-out 001362 in SMEUP_TST
+     V* 13/12/19  001378  BMA   Corretta annotation
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001345 001362 001378 in SMEDEV
+     V* 04/03/21  002673 BMA Tolte annotation NOXMI e variati timeout
+     V*  5/03/21  V5R1    BERNIC Check-out 002673 in SMEDEV
+     V* 07/09/23  005098  BERNI Rinominato partendo da MUTE10_05C per errore nomenclatura
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
      D* OBIETTIVO
      D*  Programma finalizzato ai test performance sulla CALL
-     V*---------------------------------------------------------------------
+     D*---------------------------------------------------------------------
       * Considerare i seguenti codici operativi
       *+----------+--+---------!--+
       *!RPGLE     !ST!BUILT-IN !ST!
@@ -36,7 +49,7 @@
       * Variable for loop
      C                   EVAL      $CICL=1000000
       * Call
-     C                   CALL      'WAIT4BENETTI'
+     C                   CALL      'MUTE10_05A'
      C                   PARM                    $CICL
       * end time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_86.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_86.rpgle
@@ -1,13 +1,25 @@
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_86
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_86)
+      * Esportato il        : 20241004 155649
+      *====================================================================
    COP* *NOUI
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
      V* gg/mm/aa  nn.mm i xx Breve descrizione
      V*=====================================================================
      V* 16/12/19  001378  BMA   Creato
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001378 in SMEDEV
+     V* 04/03/21  002673 BMA Tolte annotation NOXMI e variati timeout
+     V*  5/03/21  V5R1    BERNIC Check-out 002673 in SMEDEV
+     V* 07/09/23  005098  BERNI  Rinominato partendo dal MUTE10_86 per errata nomenclatura
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
      D* OBIETTIVO
      D*  Programma finalizzato ai test performance sulla CALL
-     V*---------------------------------------------------------------------
+     D*---------------------------------------------------------------------
       * Considerare i seguenti codici operativi
       *+----------+--+---------!--+
       *!RPGLE     !ST!BUILT-IN !ST!
@@ -32,7 +44,7 @@
       * Varable for loop
      C                   EVAL      $CICL=100000
       * Call
-     C                   CALL      'WAIT4BENETTI'
+     C                   CALL      'MUTE10_08A'
      C                   PARM                    $CICL
       * End time
      C                   TIME                    $TIMEN

--- a/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_87.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/performance/MUTE10_87.rpgle
@@ -1,13 +1,24 @@
-   COP* *NOUI
+      *====================================================================
+      * smeup V6R1.025DV
+      * Nome sorgente       : MUTE10_87
+      * Sorgente di origine : QTEMP/MUSRC(MUTE10_87)
+      * Esportato il        : 20241004 155649
+      *====================================================================
      V*=====================================================================
      V* MODIFICHE Ril.  T Au Descrizione
      V* gg/mm/aa  nn.mm i xx Breve descrizione
      V*=====================================================================
      V* 16/12/19  001378  BMA   Creato
+     V* 17/12/19  V5R1    PEDSTE Check-out 001378 in SMEUP_TST
+     V* 23/12/19  V5R1    PEDSTE Check-out 001378 in SMEDEV
+     V* 04/03/21  002673 BMA Tolte annotation NOXMI e variati timeout
+     V*  5/03/21  V5R1    BERNIC Check-out 002673 in SMEDEV
+     V* 07/09/23  005098  BERNIC Rinominato da MUTE10_08C per errata nomenclatura
+     V* 07/09/23  V6R1    BMA Check-out 005098 in SMEDEV
      V*=====================================================================
      D* OBIETTIVO
      D*  Programma finalizzato ai test performance sulla CALL
-     V*---------------------------------------------------------------------
+     D*---------------------------------------------------------------------
       * Considerare i seguenti codici operativi
       *+----------+--+---------!--+
       *!RPGLE     !ST!BUILT-IN !ST!
@@ -32,7 +43,7 @@
       * Variable for loop
      C                   EVAL      $CICL=1000000
       * Call
-     C                   CALL      'WAIT4BENETTI'
+     C                   CALL      'MUTE10_08A'
      C                   PARM                    $CICL
       * end time
      C                   TIME                    $TIMEN


### PR DESCRIPTION
## Description
Re-exported the following programs that caused a recursive call loop:

- MUTE10_05
- MUTE10_06
- MUTE10_08
- MUTE10_82
- MUTE10_84
- MUTE10_85
- MUTE10_86
- MUTE10_87

Additionally, re-exported the programs called by the above pgm:

- MUTE10_05A
- MUTE10_06A
- MUTE10_08A


## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [ ] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [ ] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
