### PR TITLE
Bugfix/ls24004379/take projected array value

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sorta.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sorta.kt
@@ -59,9 +59,6 @@ fun sortA(value: Value, arrayType: ArrayType) {
 
             // return value
             value.container.value = resultList.joinToString("")
-
-            value.startOffset = 0
-            value.arrayLength = value.elements().size
         }
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -984,10 +984,8 @@ class ProjectedArrayValue(
 
     override fun takeFirst(n: Int): Value = takeAll().takeFirst(n)
 
-    override fun take(from: Int, to: Int): ProjectedArrayValue {
-        //todo
-        return ProjectedArrayValue(container, field, startOffset = from * step, step, arrayLength = to)
-    }
+    override fun take(from: Int, to: Int): ProjectedArrayValue =
+        ProjectedArrayValue(container, field, startOffset = from * step, step, arrayLength = to)
 }
 
 fun createArrayValue(elementType: Type, n: Int, creator: (Int) -> Value) = ConcreteArrayValue(Array(n, creator).toMutableList(), elementType)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -918,9 +918,9 @@ object JulValue : Value {
 class ProjectedArrayValue(
     val container: DataStructValue,
     val field: FieldDefinition,
-    val startOffset: Int,
+    var startOffset: Int,
     val step: Int,
-    val arrayLength: Int
+    var arrayLength: Int
 ) : ArrayValue() {
     override val elementType: Type
         get() = (this.field.type as ArrayType).element
@@ -983,6 +983,11 @@ class ProjectedArrayValue(
     override fun takeLast(n: Int): Value = takeAll().takeLast(n)
 
     override fun takeFirst(n: Int): Value = takeAll().takeFirst(n)
+
+    override fun take(from: Int, to: Int): ProjectedArrayValue {
+        //todo
+        return ProjectedArrayValue(container, field, startOffset = from * step, step, arrayLength = to)
+    }
 }
 
 fun createArrayValue(elementType: Type, n: Int, creator: (Int) -> Value) = ConcreteArrayValue(Array(n, creator).toMutableList(), elementType)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -918,9 +918,9 @@ object JulValue : Value {
 class ProjectedArrayValue(
     val container: DataStructValue,
     val field: FieldDefinition,
-    var startOffset: Int,
+    val startOffset: Int,
     val step: Int,
-    var arrayLength: Int
+    val arrayLength: Int
 ) : ArrayValue() {
     override val elementType: Type
         get() = (this.field.type as ArrayType).element

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -2,6 +2,7 @@ package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.db.utilities.DBServer
 import com.smeup.rpgparser.smeup.dbmock.MULANGTLDbMock
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -631,5 +632,15 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     fun executeMUDRNRAPU00263() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00263".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * Verifies the sort of ds array values
+     * @see #LS24004379
+     */
+    @Test
+    fun executeMUDRNRAPU01104() {
+        val expected = listOf("ORIGINAL", "3", "2", "4", "1", "5", "ORDERED", "3", "1", "2", "4", "5")
+        assertEquals(expected, "smeup/MUDRNRAPU01104".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -2,7 +2,6 @@ package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.db.utilities.DBServer
 import com.smeup.rpgparser.smeup.dbmock.MULANGTLDbMock
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01104.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01104.rpgle
@@ -1,0 +1,36 @@
+     V* ==============================================================
+     V* 07/10/2024 APU011 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Verifies the sort of ds array values
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *   Issue executing SortAStmt at line 25.
+    O *   An operation is not implemented: take not yet implemented for ProjectedArrayValue
+     V* ==============================================================
+
+     D INDX            S              2  0
+     D MSG             S              5
+     D                 DS
+     DARR                            10  0 DIM(5)
+
+     C                   EVAL      ARR(1)=3
+     C                   EVAL      ARR(2)=2
+     C                   EVAL      ARR(3)=4
+     C                   EVAL      ARR(4)=1
+     C                   EVAL      ARR(5)=5
+     C     'ORIGINAL'    DSPLY
+     C                   EXSR      SHOW_RES
+     C                   SORTA     %SUBARR(ARR:2:4)
+     C     'ORDERED'     DSPLY
+     C                   EXSR      SHOW_RES
+
+     C                   SETON                                          LR
+
+     C     SHOW_RES      BEGSR
+     C                   FOR       INDX=1 TO %ELEM(ARR)
+     C                   EVAL      MSG=%CHAR(ARR(INDX))
+     C     MSG           DSPLY
+     C                   ENDFOR
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01104.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01104.rpgle
@@ -2,11 +2,12 @@
      V* 07/10/2024 APU011 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Verifies the sort of ds array values
+    O * Verifies the sorting of values in an array in a data structure
+    O * when the factor one is a reference to an array field.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, the error occurred was:
-    O *   Issue executing SortAStmt at line 25.
+    O *   Issue executing SortAStmt at line 26.
     O *   An operation is not implemented: take not yet implemented for ProjectedArrayValue
      V* ==============================================================
 


### PR DESCRIPTION
## Description

This work adds the ability to improve the sorting functionality for arrays, specifically for the case where the first factor is a reference to a field of an array in a data structure.

**Technical notes**
To achieve the goal:
- The Take function has been added to the ProjectedArrayValue class to correctly handle the values of the array.
- The sortA function has been modified to sort values in data structure's field array.

Related to #LS24004379

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
