### PR TITLE
Bugfix/ls24004434/like api instatement

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -336,7 +336,7 @@ open class BaseCompileTimeInterpreter(
                                 val apiId = apiDirective.toApiId(conf)
                                 val type = apiId.loadAndUse { api ->
                                     api.let {
-                                        it.compilationUnit.dataDefinitions.firstOrNull { def ->
+                                        it.compilationUnit.allDataDefinitions.firstOrNull { def ->
                                             def.name.equals(declName, ignoreCase = true)
                                         }
                                     }?.type

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -642,4 +642,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ORIGINAL", "3", "2", "4", "1", "5", "ORDERED", "3", "1", "2", "4", "5")
         assertEquals(expected, "smeup/MUDRNRAPU01104".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Like on an InStatement definition inside an API
+     * @see #LS24004434
+     */
+    @Test
+    fun executeMUDRNRAPU00264() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00264".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00264.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00264.rpgle
@@ -1,0 +1,5 @@
+     D SDECT1          S                   LIKE(£DECTP)
+
+     C/API QILEGEN,CALLDEC
+     C                   EVAL   SDECT1 = 'ok'
+     C     SDECT1        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00264.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00264.rpgle
@@ -1,5 +1,9 @@
+      * Test declaration
      D SDECT1          S                   LIKE(£DECTP)
 
+      * Using LIKE on a definition that is defined instatement inside an API should resolve correctly (See SDECT1)
      C/API QILEGEN,CALLDEC
+
+      * Test output
      C                   EVAL   SDECT1 = 'ok'
      C     SDECT1        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/QILEGEN/CALLDEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/QILEGEN/CALLDEC.rpgle
@@ -1,0 +1,6 @@
+     C     £DEC          BEGSR
+     C                   IF        0
+     C                   CALL      'ABC'
+     C                   PARM                    £DECTP            2
+     C                   ENDIF
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/QILEGEN/CALLDEC.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/QILEGEN/CALLDEC.rpgle
@@ -1,3 +1,8 @@
+      * This program has the sole purpose of being called from MUDRNRAPU00264.rpgle
+      * It is intended to be slim version of £DEC that replicates a situation where
+      * we have an API with an instatement data definition inside that is referenced
+      * using a LIKE() keyword
+
      C     £DEC          BEGSR
      C                   IF        0
      C                   CALL      'ABC'


### PR DESCRIPTION
## Description

> Note: `/API` directives are a feature of Jariko and are not present in the base RPGLE.

Fix an issue that prevented instatement definition contained in `/API` directives from being resolved when referenced with a `LIKE()` keyword.

Related to:
- LS24004434

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
