### PR TITLE
Fix handling TAG when is in composed statements

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -439,10 +439,13 @@ open class InternalInterpreter(
         }
     }
 
-    private fun GotoException.indexOfTaggedStatement(statements: List<Statement>): Int =
-        statements.indexOfFirst {
+    private fun GotoException.indexOfTaggedStatement(statements: List<Statement>): Int {
+        val flatStatements = statements.explode()
+
+        return flatStatements.indexOfFirst {
             it is TagStmt && it.tag == tag
         }
+    }
 
     private fun caseInsensitiveMap(aMap: Map<String, Value>): Map<String, Value> {
         val result = TreeMap<String, Value>(String.CASE_INSENSITIVE_ORDER)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -440,9 +440,7 @@ open class InternalInterpreter(
     }
 
     private fun GotoException.indexOfTaggedStatement(statements: List<Statement>): Int {
-        val flatStatements = statements.explode()
-
-        return flatStatements.indexOfFirst {
+        return statements.explode().indexOfFirst {
             it is TagStmt && it.tag == tag
         }
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -439,10 +439,8 @@ open class InternalInterpreter(
         }
     }
 
-    private fun GotoException.indexOfTaggedStatement(statements: List<Statement>): Int {
-        return statements.explode().indexOfFirst {
-            it is TagStmt && it.tag == tag
-        }
+    private fun GotoException.indexOfTaggedStatement(statements: List<Statement>): Int = statements.explode().indexOfFirst {
+        it is TagStmt && it.tag == tag
     }
 
     private fun caseInsensitiveMap(aMap: Map<String, Value>): Map<String, Value> {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -654,11 +654,13 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     }
 
     /**
+     * Allows for the correct handling of composed (nested) statements during execution, ensuring that `TagStmts`
+     *  can be found even within complex structures.
      * @see #LS24004437
      */
     @Test
     fun executeMUDRNRAPU01105() {
-        val expected = listOf("FFALSE", "FGA", "FTRUE")
+        val expected = listOf("FLG-FALSE", "EMPTY", "FLG-TRUE")
         assertEquals(expected, "smeup/MUDRNRAPU01105".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -652,4 +652,13 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00264".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * @see #LS24004437
+     */
+    @Test
+    fun executeMUDRNRAPU01105() {
+        val expected = listOf("FFALSE", "FGA", "FTRUE")
+        assertEquals(expected, "smeup/MUDRNRAPU01105".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01105.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01105.rpgle
@@ -1,0 +1,46 @@
+     V* ==============================================================
+     V* 11/10/2024 APU011 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Allows for the correct handling of composed (nested) statements during execution,
+    O * ensuring that TagStmts can be found even within complex structures.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *   Internal Server Error
+    O *   Cannot invoke "String.length()" because "str" is null
+     V* ==============================================================
+
+     D  FLAG           S             10  0 INZ(0)
+     C                   EXSR      SIN_SR
+     C                   SETON                                        LR
+
+     C     SIN_SR        BEGSR
+     C                   EXSR      SIN_GR
+     C                   ENDSR
+
+     C     SIN_GR        BEGSR
+     C                   EXSR      MEM_DT
+     C                   ENDSR
+
+     C     MEM_DT        BEGSR
+     C                   CLEAR                   $GA              15
+     C                   EVAL      *IN38=*OFF
+
+     C     1             IFEQ      1
+     C     RILALTRO1     TAG
+     C                   ENDIF
+     C     FLAG          IFEQ      0
+     C     RILALTRO      TAG
+     C     'FFALSE'      DSPLY
+     C                   EVAL      $GA=' '
+     C                   EVAL      FLAG=1
+     C                   ELSE
+     C     'FTRUE'       DSPLY
+     C                   EVAL      $GA='FOO'
+     C                   ENDIF
+     C  N38              IF        $GA=' '
+     C     'FGA'         DSPLY
+     C                   GOTO      RILALTRO1
+     C                   ENDIF
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01105.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU01105.rpgle
@@ -1,46 +1,35 @@
      V* ==============================================================
      V* 11/10/2024 APU011 Creation
+     V* 15/10/2024 APU001 Improvements
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Allows for the correct handling of composed (nested) statements during execution,
-    O * ensuring that TagStmts can be found even within complex structures.
+    O * Allows for the correct handling of composed (nested)
+    O *  statements during execution, ensuring that `TagStmts`
+    O *  can be found even within complex structures.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, the error occurred was:
     O *   Internal Server Error
     O *   Cannot invoke "String.length()" because "str" is null
      V* ==============================================================
-
      D  FLAG           S             10  0 INZ(0)
-     C                   EXSR      SIN_SR
-     C                   SETON                                        LR
 
-     C     SIN_SR        BEGSR
-     C                   EXSR      SIN_GR
-     C                   ENDSR
-
-     C     SIN_GR        BEGSR
-     C                   EXSR      MEM_DT
-     C                   ENDSR
-
-     C     MEM_DT        BEGSR
-     C                   CLEAR                   $GA              15
+     C                   CLEAR                   STR              15
      C                   EVAL      *IN38=*OFF
 
      C     1             IFEQ      1
-     C     RILALTRO1     TAG
+     C     JUMP1         TAG
      C                   ENDIF
      C     FLAG          IFEQ      0
-     C     RILALTRO      TAG
-     C     'FFALSE'      DSPLY
-     C                   EVAL      $GA=' '
+     C     JUMP          TAG
+     C     'FLG-FALSE'   DSPLY
+     C                   EVAL      STR=' '
      C                   EVAL      FLAG=1
      C                   ELSE
-     C     'FTRUE'       DSPLY
-     C                   EVAL      $GA='FOO'
+     C     'FLG-TRUE'    DSPLY
+     C                   EVAL      STR='FOO'
      C                   ENDIF
-     C  N38              IF        $GA=' '
-     C     'FGA'         DSPLY
-     C                   GOTO      RILALTRO1
+     C  N38              IF        STR=' '
+     C     'EMPTY'       DSPLY
+     C                   GOTO      JUMP1                                        #Cannot invoke "String.length()" because "str" is null
      C                   ENDIF
-     C                   ENDSR


### PR DESCRIPTION
## Description
This work fixes the `GOTO` to a `TAG` declared under nested body. For example:
```
     C     FOO           IFEQ      BAR
     C     ... 
     C     JUMP          TAG
     C     ...
     C                   ENDIF     
     ...
     C                   GOTO      JUMP
     ...
```
### Technical notes
In Jariko, that `GOTO` causes `#Cannot invoke "String.length()" because "str" is null` with a `com.smeup.rpgparser.interpreter.GotoException`. To achieve the purpose of this PR, I have made the change on `internal_interpreter` by making an _explosion_ of statements for the individuation of desired `TAG`.

Related to #LS24004437

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
