### PR TITLE
Bugfix/ls24004450/Fix `DecimalValue` to `StringType`

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -652,4 +652,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00264".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Assignment of integer value to a DS decimal subfield
+     * @see #LS24004450
+     */
+    @Test
+    fun executeMUDRNRAPU00132() {
+        val expected = listOf("10.000000")
+        assertEquals(expected, "smeup/MUDRNRAPU00132".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00132.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00132.rpgle
@@ -1,0 +1,23 @@
+     V* ==============================================================
+     V* 14/10/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment of integer value to a DS decimal subfield.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was
+    O *  `An operation is not implemented: Converting DecimalValue
+    O *   to StringType(length=21, varying=false)`.
+     V* ==============================================================
+     D INX             S              3  0 INZ(5)
+     D RES             S             10
+
+     D                 DS
+     DDS_FL1                        300    DIM(10)
+     D DS_FL1SUB1                    21  6 OVERLAY(DS_FL1:1)
+
+     C                   EVAL      DS_FL1SUB1(INX)=10                           #An operation is not implemented: Converting DecimalValue to StringType(length=21, varying=false)
+     C                   EVAL      RES=%CHAR(DS_FL1SUB1(INX))
+     C     RES           DSPLY
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work fixes the assignment of a integer value to a DS subfield declared as decimal and with overlay to its parent, declared as array. For example:
```
     D                 DS
     DDS_FL1                        300    DIM(10)
     D DS_FL1SUB1                    21  6 OVERLAY(DS_FL1:1)
     ...
     C                   EVAL      DS_FL1SUB1(5)=10
```
### Technical notes
On Jariko this operation caused: `An operation is not implemented: Converting DecimalValue to StringType(length=xx, varying=yyyy)`.
So, to achieve the goal of this PR, instead to coerce the _"source"_ value as String, is better to coerce it into destination type (the field/subfield of DS) and then by calling a special `toString` which remove comma if the coerced value is `DecimalValue`.

Related to #LS24004450

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
