### PR TITLE
Bugfix/ls24004474/dowxx factor1 indicators

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/statements.kt
@@ -224,11 +224,12 @@ internal fun RpgParser.CsDOWxxContext.toAst(blockContext: BlockContext, conf: To
         else -> todo(conf = conf)
     }
 
+    val factor1Ast = this.factor1.toAstIfSymbolicConstant() ?: this.factor1.content.toAst(conf = conf)
     val factor2Ast = factor2.toAstIfSymbolicConstant() ?: factor2.content.toAst(conf)
 
     return DOWxxStmt(
         comparisonOperator = comparison,
-        factor1 = this.factor1.content.toAst(conf = conf),
+        factor1 = factor1Ast,
         factor2 = factor2Ast,
         position = toPosition(conf.considerPosition),
         body = blockContext.statement().map { it.toAst(conf) }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -376,4 +376,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("123")
         assertEquals(expected, "smeup/MUDRNRAPU00262".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * DOWxx with indicator as factor 1
+     * @see #LS24004474
+     */
+    @Test
+    fun executeMUDRNRAPU00266() {
+        val expected = listOf("1")
+        assertEquals(expected, "smeup/MUDRNRAPU00266".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00266.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00266.rpgle
@@ -1,0 +1,7 @@
+      * DOWxx with indicator in factor 1 should work as expected
+     C     *IN35         DOWEQ     *OFF
+     C                   EVAL *IN35 = *ON
+     C                   ENDDO
+
+      * Test output
+     C     *IN35         DSPLY


### PR DESCRIPTION
## Description

Add support for indicators in `DOWxx` statements factor 1.

Related to:
- LS24004474

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
