### PR TITLE
Bugfix/LS24004528/comparison between number and `*ZEROS`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -320,6 +320,7 @@ data class IntValue(val value: Long) : NumberValue() {
         is IntValue -> value.compareTo(other.value)
         is DecimalValue -> this.asDecimal().compareTo(other)
         is PointerValue -> value.compareTo(other.address)
+        is ZeroValue -> value.compareTo(ZeroValue.asInt().value)
         else -> super.compareTo(other)
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -386,4 +386,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("1")
         assertEquals(expected, "smeup/MUDRNRAPU00266".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Comparing number and `*ZEROS` by using `IFxx`.
+     * @see #LS24004528
+     */
+    @Test
+    fun executeMUDRNRAPU00134() {
+        val expected = listOf("OK")
+        assertEquals(expected, "smeup/MUDRNRAPU00134".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00134.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00134.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 18/10/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Comparing number and `*ZEROS` by using `IFxx`.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was
+    O *  `An operation is not implemented: Cannot compare
+    O *    IntValue(value=4) to ZeroValue`.
+     V* ==============================================================
+     D FOO             S              1  0 INZ(4)
+
+     C     FOO           IFGT      *ZEROS
+     C     'OK'          DSPLY
+     C                   ENDIF
+
+     C                   SETON                                          LR      #An operation is not implemented: Cannot compare IntValue(value=4) to ZeroValue


### PR DESCRIPTION
## Description
This work fixes the comparison between a number and `*ZEROS`. For example:
```
     D FOO             S              1  0 INZ(4)
     C     FOO           IFGT      *ZEROS
     C     'OK'          DSPLY
     C                   ENDIF
```

### Technical notes
On Jariko this operation caused: `An operation is not implemented: Cannot compare IntValue(value=4) to ZeroValue`. To achieve the goal of this PR, for `IntValue.compareTo` I have added the case for `ZeroValue`.

Related to #LS24004528

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
