### PR TITLE
Bugfix/ls24004538/call error indicator program stack

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -154,7 +154,12 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
             // set reinitialization to false because symboltable cleaning currently is handled directly
             // in internal interpreter before exit
             // todo i don't know whether parameter reinitialization has still sense
-            interpreter.execute(this.cu, params, false, callerParams)
+            kotlin.runCatching {
+                interpreter.execute(this.cu, params, false, callerParams)
+            }.onFailure {
+                MainExecutionContext.getProgramStack().pop()
+                throw it
+            }
             MainExecutionContext.getConfiguration().jarikoCallback.onExitPgm(name, interpreter.getGlobalSymbolTable(), null)
             params.keys.forEach { params[it] = interpreter[it] }
             changedInitialValues = params().map { interpreter[it.name] }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -386,4 +386,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("1")
         assertEquals(expected, "smeup/MUDRNRAPU00266".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * State of context after a CALL failed setting an error indicator
+     * @see #LS24004538
+     */
+    @Test
+    fun executeMUDRNRAPU00268() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00268".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/ERRORPGM.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/ERRORPGM.rpgle
@@ -1,0 +1,5 @@
+      * This program has the sole purpose of throwing a runtime exception
+     D $A              S              2    DIM(10)
+     D $B              S              2
+     D $C              S              2
+     C                   EVAL      $C=$A($B)

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00268.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00268.rpgle
@@ -1,0 +1,24 @@
+      * Test declarations
+     D £TESTDS         DS
+     D  £TESTPA                      10
+
+      * Call of a program that throws an error and setting the error indicator
+     C                   CALL        'ERRORPGM'                         35
+
+      * If call failed but the error indicator was set
+      * Execution should continue and the context should reference the correct program
+      * Note: We can test the context state is correct by calling a procedure
+     C                   IF        P_Test(£TESTPA:'EmiMsg(':'')='Y'
+     C     'ok'          DSPLY
+     C                   ENDIF
+
+      * Test procedure
+     PP_Test           B
+     D P_Test          Pi         30000    VARYING
+     D  $A                           15    CONST
+     D  $B                            1N   OPTIONS(*NOPASS)
+     D  $C                            1    OPTIONS(*NOPASS)
+     C                   RETURN    'Y'
+     P                 E
+
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Fix a very specific corner case on `CALL` statements with error indicators that caused the compiler to think we never exited the erroring program. 

### Technical notes

It appears that when we threw a runtime error in `interpreter.execute(this.cu, params, false, callerParams)` in `program.kt` we caught the thrown error in `CallStmt`, skipping the program exiting logic. For this reason the interpreter was stuck thinking we never exited that program.

Fixed by adding an intermediate catch logic that performs a cleanup before throwing again.

Related to:
- LS24004538

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
