### PR TITLE
Feature/ls24004559/improve goto support

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
@@ -20,7 +20,9 @@ import com.smeup.dbnative.manager.DBFileFactory
 import com.smeup.rpgparser.experimental.ExperimentalFeaturesFactory
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.logging.AnalyticsLoggingContext
+import com.smeup.rpgparser.parsing.ast.Subroutine
 import com.smeup.rpgparser.parsing.facade.CopyBlocks
+import com.strumenta.kolasu.model.ReferenceByName
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -39,6 +41,7 @@ object MainExecutionContext {
     private val noConfiguration: Configuration by lazy { Configuration() }
     private val noProgramStack: Stack<RpgProgram> by lazy { Stack<RpgProgram>() }
     private val noParsingProgramStack: Stack<ParsingProgram> by lazy { Stack<ParsingProgram>() }
+    private val noProgramSubroutineStack: Stack<ReferenceByName<Subroutine>> by lazy { Stack<ReferenceByName<Subroutine>>() }
     //
 
     // If for some reason we have problems in MainExecutionContext.execute set this variable to true
@@ -169,6 +172,11 @@ object MainExecutionContext {
     }
 
     /**
+     * @return The subroutine stack. This is an execution stack.
+     */
+    fun getSubroutineStack() = context.get()?.subroutineStack ?: noProgramSubroutineStack
+
+    /**
      * Logs entries
      */
     fun log(renderer: LazyLogEntry) {
@@ -218,6 +226,7 @@ data class Context(
     val logging: AnalyticsLoggingContext = AnalyticsLoggingContext(),
     val memorySliceMgr: MemorySliceMgr? = null,
     val programStack: Stack<RpgProgram> = Stack<RpgProgram>(),
+    val subroutineStack: Stack<ReferenceByName<Subroutine>> = Stack<ReferenceByName<Subroutine>>(),
     val systemInterface: SystemInterface,
     var executionProgramName: String? = null,
     var executionFunctionName: String? = null,

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/control_flow_exceptions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/control_flow_exceptions.kt
@@ -11,9 +11,25 @@ class LeaveSrException : ControlFlowException()
 class LeaveException : ControlFlowException()
 class IterException : ControlFlowException()
 
+/**
+ * Exception similar to [GotoException] but thrown when we are trying to goto a TAG
+ * at top level.
+ *
+ * The distinction is needed in order to allow catching it in different places and therefore
+ * executing different logic in different execution flows.
+ *
+ * @param tag The tag of the destination label
+ */
+class GotoTopLevelException(val tag: String) : ControlFlowException()
+
 // Useful to interrupt infinite cycles in tests
 class InterruptForDebuggingPurposes : ControlFlowException()
 class ReturnException(val returnValue: Value?) : ControlFlowException()
+
+/**
+ * Exception thrown whenever we execute a GOTO-like instruction
+ * @param tag The tag of the destination label
+ */
 class GotoException private constructor(val tag: String) : ControlFlowException() {
     companion object {
         operator fun invoke(tag: String): GotoException = GotoException(tag.toUpperCase())

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -33,6 +33,8 @@ import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.parsing.parsetreetoast.todo
 import com.smeup.rpgparser.utils.ComparisonOperator.*
 import com.smeup.rpgparser.utils.chunkAs
+import com.smeup.rpgparser.utils.getContainingCompilationUnit
+import com.smeup.rpgparser.utils.peekOrNull
 import com.smeup.rpgparser.utils.resizeTo
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.ReferenceByName
@@ -395,6 +397,32 @@ open class InternalInterpreter(
         logHandlers = systemInterface.getAllLogHandlers()
     }
 
+    /**
+     * Execute a [MainBody]
+     * @param main The [MainBody]
+     */
+    private fun execute(main: MainBody) {
+        // Execute the main body
+        var throwable = kotlin.runCatching {
+            execute(main.stmts)
+        }.exceptionOrNull()
+
+        val unwrappedStatement = main.stmts.explode(true)
+
+        // Recursive deal with top level goto flow
+        while (throwable is GotoTopLevelException) {
+            // We need to know the statement unwrapped in order to jump directly into a nested tag
+            val offset = throwable.indexOfTaggedStatement(unwrappedStatement)
+            require(0 <= offset && offset < unwrappedStatement.size) { "Offset $offset is not valid." }
+            throwable = kotlin.runCatching {
+                executeUnwrappedAt(unwrappedStatement, offset)
+            }.exceptionOrNull()
+        }
+
+        // If the GOTO-flow threw a different exception, dispatch it to the parent flow
+        throwable?.let { throw it }
+    }
+
     fun execute(
         compilationUnit: CompilationUnit,
         initialValues: Map<String, Value>,
@@ -410,10 +438,10 @@ open class InternalInterpreter(
             initialize(compilationUnit, caseInsensitiveMap(initialValues), reinitialization)
             execINZSR(compilationUnit)
             if (compilationUnit.minTimeOut == null) {
-                execute(compilationUnit.main.stmts)
+                execute(compilationUnit.main)
             } else {
                 val elapsed = measureNanoTime {
-                    execute(compilationUnit.main.stmts)
+                    execute(compilationUnit.main)
                 }.nanoseconds
 
                 if (elapsed.inWholeMilliseconds > compilationUnit.minTimeOut!!) {
@@ -439,7 +467,11 @@ open class InternalInterpreter(
         }
     }
 
-    private fun GotoException.indexOfTaggedStatement(statements: List<Statement>): Int = statements.explode().indexOfFirst {
+    private fun GotoException.indexOfTaggedStatement(statements: List<Statement>) = statements.indexOfTag(tag)
+
+    private fun GotoTopLevelException.indexOfTaggedStatement(statements: List<Statement>) = statements.indexOfTag(tag)
+
+    private fun List<Statement>.indexOfTag(tag: String) = indexOfFirst {
         it is TagStmt && it.tag == tag
     }
 
@@ -449,16 +481,109 @@ open class InternalInterpreter(
         return result
     }
 
-    override fun execute(statements: List<Statement>) {
-        var i = 0
-        while (i < statements.size) {
-            try {
+    override fun execute(statements: List<Statement>) = executeAt(statements, 0)
+
+    /**
+     * Execute a list of statements starting for an arbitrary offset.
+     * @param statements The list of statements to execute.
+     * @param offset The starting offset.
+     */
+    private fun executeAt(statements: List<Statement>, offset: Int) {
+        /*
+         * FIXME:
+         * This method has a lot of code duplicated with [executeUnwrappedAt] because it can be called
+         * passing only a part of statement to execute (like when executing statement bodies).
+         * if you manage to refactor this, please also remove this comment.
+         */
+
+        var i = offset
+        try {
+            while (i < statements.size) {
                 executeWithMute(statements[i++])
-            } catch (e: GotoException) {
-                i = e.indexOfTaggedStatement(statements)
-                if (i < 0 || i >= statements.size) throw e
             }
+        } catch (e: GotoException) {
+            val containingCU = statements.firstOrNull()?.getContainingCompilationUnit()
+
+            // If tag is in top level we need to quit subroutine and rollback context to top level
+            val topLevelStatements = containingCU?.main?.stmts?.explode(true)
+            topLevelStatements?.let {
+                val topLevelIndex = e.indexOfTaggedStatement(it)
+                if (0 <= topLevelIndex && topLevelIndex < it.size)
+                    throw GotoTopLevelException(e.tag)
+            }
+
+            // Scope might have been changed in the meanwhile with an EXSR after the previous GOTO
+            val scope = MainExecutionContext.getSubroutineStack().peekOrNull()
+            performJump(
+                scope = scope,
+                goto = e
+            )
         }
+    }
+
+    /**
+     * Execute an unwrapped list of statement.
+     * @param unwrappedStatements The unwrapped list of statements. It is up to the caller to ensure statements are unwrapped.
+     * @param offset Offset to start the execution from.
+     */
+    private fun executeUnwrappedAt(unwrappedStatements: List<Statement>, offset: Int) {
+        /**
+         * As we execute composite statements recursively, trying to sequentially execute
+         * the unwrapped statement list would result in executing every statement multiple times.
+         *
+         * The following instruction associates to each statement the offset to add in order to find
+         * the real next statement to execute in the list.
+         */
+        val offsetAwareStatements = unwrappedStatements.map {
+            WithOffset(
+                data = it,
+                offset = if (it is CompositeStatement) it.body.size else 0
+            )
+        }
+
+        var index = offset
+        try {
+            while (index < offsetAwareStatements.size) {
+                val offsetStatement = offsetAwareStatements[index]
+                executeWithMute(offsetStatement.data)
+                index += offsetStatement.offset + 1
+            }
+        } catch (e: GotoException) {
+            val containingCU = unwrappedStatements.firstOrNull()?.getContainingCompilationUnit()
+
+            // If tag is in top level we need to quit subroutine and rollback context to top level
+            val topLevelStatements = containingCU?.main?.stmts?.explode(true)
+            topLevelStatements?.let {
+                val topLevelIndex = e.indexOfTaggedStatement(it)
+                if (0 <= topLevelIndex && topLevelIndex < it.size)
+                    throw GotoTopLevelException(e.tag)
+            }
+
+            // Scope might have been changed in the meanwhile with an EXSR after the previous GOTO
+            val scope = MainExecutionContext.getSubroutineStack().peekOrNull()
+            performJump(
+                scope = scope,
+                goto = e
+            )
+        }
+    }
+
+    /**
+     * Perform a jump in the provided scope
+     * @param scope The subroutine scope to perform the jump into
+     * @param goto The [GotoException] that caused this jump
+     */
+    private fun performJump(scope: ReferenceByName<Subroutine>?, goto: GotoException) {
+        // In case of something wrong with the goto, we dispatch the goto to the parent flow
+
+        val scopeLevelStatements = scope?.referred?.stmts ?: throw goto
+        val unwrappedStatements = scopeLevelStatements.explode(true)
+
+        val index = goto.indexOfTaggedStatement(unwrappedStatements)
+        val isInRange = 0 <= index && index < unwrappedStatements.size
+        if (!isInRange) throw goto
+
+        executeUnwrappedAt(unwrappedStatements, index)
     }
 
     @Deprecated(message = "No longer used")

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/interpretation_utils.kt
@@ -20,6 +20,11 @@ import com.smeup.rpgparser.parsing.ast.*
 import java.time.format.DateTimeFormatter
 import java.util.*
 
+data class WithOffset<T>(
+    val data: T,
+    val offset: Int
+)
+
 fun Value.stringRepresentation(format: String? = null): String {
     return when (this) {
         is StringValue -> value

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -135,6 +135,7 @@ data class ExecuteSubroutine(var subroutine: ReferenceByName<Subroutine>, overri
     override fun execute(interpreter: InterpreterCore) {
         val programName = interpreter.getInterpretationContext().currentProgramName
         val logSource = { LogSourceData(programName, subroutine.referred!!.position.line()) }
+        MainExecutionContext.getSubroutineStack().push(subroutine)
         interpreter.renderLog { LazyLogEntry.produceSubroutineStart(logSource, subroutine.referred!!) }
         try {
             interpreter.execute(subroutine.referred!!.stmts)
@@ -142,6 +143,10 @@ data class ExecuteSubroutine(var subroutine: ReferenceByName<Subroutine>, overri
             // Nothing to do here
         } catch (e: GotoException) {
             if (!e.tag.equals(subroutine.referred!!.tag, true)) throw e
+        } finally {
+            // NOTE: The next instruction should never throw. If it does, there is something wrong in how the stack is used.
+            // Investigate where and how it is used and manipulated.
+            MainExecutionContext.getSubroutineStack().pop()
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
@@ -17,6 +17,9 @@
 package com.smeup.rpgparser.utils
 
 import com.smeup.rpgparser.execution.ParsingProgram
+import com.smeup.rpgparser.parsing.ast.CompilationUnit
+import com.strumenta.kolasu.model.Node
+import com.strumenta.kolasu.model.ancestor
 import java.math.BigDecimal
 import java.util.*
 import kotlin.system.measureTimeMillis
@@ -147,13 +150,26 @@ internal fun Stack<ParsingProgram>.pushIfNotAlreadyPresent(parsingProgram: Parsi
 }
 
 /**
- * Pop a ParsingProgram from a stack if it is present
+ * Pop a value from a stack if it is present
  * @return The element popped or null if the stack is empty
  * */
-internal fun Stack<ParsingProgram>.popIfPresent(): ParsingProgram? {
+internal fun <T> Stack<T>.popIfPresent(): T? {
     return if (this.isNotEmpty()) {
         this.pop()
     } else {
         null
     }
 }
+
+/**
+ * Peek a value from a [Stack] if it is present
+ * @return The element peeked or null if the stack is empty
+ */
+internal fun <T> Stack<T>.peekOrNull(): T? = if (isNotEmpty()) {
+    this.peek()
+} else null
+
+/**
+ * Get the [CompilationUnit] that contains the current [Node]
+ */
+internal fun Node.getContainingCompilationUnit() = ancestor(CompilationUnit::class.java)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -1321,6 +1321,48 @@ Test 6
     }
 
     @Test
+    fun executeGOTOTST1() {
+        val expected = listOf("2")
+        assertEquals(expected, outputOf("GOTOTST1"))
+    }
+
+    @Test
+    fun executeGOTOTST2() {
+        val expected = listOf("3")
+        assertEquals(expected, outputOf("GOTOTST2"))
+    }
+
+    @Test
+    fun executeGOTOTST3() {
+        val expected = listOf("1")
+        assertEquals(expected, outputOf("GOTOTST3"))
+    }
+
+    @Test
+    fun executeGOTOTST4() {
+        val expected = listOf("1")
+        assertEquals(expected, outputOf("GOTOTST4"))
+    }
+
+    @Test
+    fun executeGOTOTST5() {
+        val expected = listOf("1", "3")
+        assertEquals(expected, outputOf("GOTOTST5"))
+    }
+
+    @Test
+    fun executeGOTOTST6() {
+        val expected = listOf("1", "4", "3")
+        assertEquals(expected, outputOf("GOTOTST6"))
+    }
+
+    @Test
+    fun executeGOTOTST7() {
+        val expected = listOf("1", "4", "2")
+        assertEquals(expected, outputOf("GOTOTST7"))
+    }
+
+    @Test
     fun executeGotoENDSR() {
         assertEquals(listOf("1", "2", "3"), outputOf("GOTOENDSR"))
     }

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST1.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST1.rpgle
@@ -1,3 +1,11 @@
+     V* ==============================================================
+     V* 23/10/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a GOTO in a subroutine redirecting to a TAG nested
+    O * in the same subroutine
+     V* ==============================================================
+
      C                   EXSR      SR
      C                   SETON                                          LR
 

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST1.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST1.rpgle
@@ -1,0 +1,11 @@
+     C                   EXSR      SR
+     C                   SETON                                          LR
+
+     C     SR            BEGSR
+     C                   GOTO      TAG_1
+     C     1             IFEQ      1
+     C     '1'           DSPLY
+     C     TAG_1         TAG
+     C     '2'           DSPLY
+     C                   ENDIF
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST2.rpgle
@@ -1,3 +1,10 @@
+     V* ==============================================================
+     V* 23/10/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a GOTO in a subroutine redirecting to a TAG in top level
+     V* ==============================================================
+
      C                   EXSR      SR
      C     TAG_1         TAG
      C     '3'           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST2.rpgle
@@ -1,0 +1,12 @@
+     C                   EXSR      SR
+     C     TAG_1         TAG
+     C     '3'           DSPLY
+     C                   SETON                                          LR
+
+     C     SR            BEGSR
+     C                   GOTO      TAG_1
+     C     1             IFEQ      1
+     C     '1'           DSPLY
+     C     '2'           DSPLY
+     C                   ENDIF
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST3.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST3.rpgle
@@ -1,3 +1,11 @@
+     V* ==============================================================
+     V* 23/10/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a nested GOTO in a subroutine redirecting to a TAG
+    O * in top level
+     V* ==============================================================
+
      C                   EXSR      SR
      C     TAG_1         TAG
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST3.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST3.rpgle
@@ -1,0 +1,11 @@
+     C                   EXSR      SR
+     C     TAG_1         TAG
+     C                   SETON                                          LR
+
+     C     SR            BEGSR
+     C     1             IFEQ      1
+     C     '1'           DSPLY
+     C                   GOTO      TAG_1
+     C     '2'           DSPLY
+     C                   ENDIF
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST4.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST4.rpgle
@@ -1,0 +1,11 @@
+     C                   EXSR      SR
+     C                   SETON                                          LR
+
+     C     SR            BEGSR
+     C     1             IFEQ      1
+     C     '1'           DSPLY
+     C                   GOTO      TAG_1
+     C     '2'           DSPLY
+     C                   ENDIF
+     C     TAG_1         TAG
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST4.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST4.rpgle
@@ -1,3 +1,11 @@
+     V* ==============================================================
+     V* 23/10/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a nested GOTO in a subroutine redirecting to a TAG at
+    O * the end of the same subroutine
+     V* ==============================================================
+
      C                   EXSR      SR
      C                   SETON                                          LR
 

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST5.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST5.rpgle
@@ -1,0 +1,14 @@
+     C                   EXSR      SR
+     C     1             IFEQ      0
+     C     TAG_1         TAG
+     C     '3'           DSPLY
+     C                   ENDIF
+     C                   SETON                                          LR
+
+     C     SR            BEGSR
+     C     1             IFEQ      1
+     C     '1'           DSPLY
+     C                   GOTO      TAG_1
+     C     '2'           DSPLY
+     C                   ENDIF
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST5.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST5.rpgle
@@ -1,3 +1,11 @@
+     V* ==============================================================
+     V* 23/10/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a nested GOTO in a subroutine redirecting to a nested
+    O * TAG in top level
+     V* ==============================================================
+
      C                   EXSR      SR
      C     1             IFEQ      0
      C     TAG_1         TAG

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST6.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST6.rpgle
@@ -1,0 +1,22 @@
+     C                   EXSR      SR1
+     C     1             IFEQ      0
+     C     TAG_1         TAG
+     C     '3'           DSPLY
+     C                   ENDIF
+     C                   SETON                                          LR
+
+     C     SR1           BEGSR
+     C     1             IFEQ      1
+     C     '1'           DSPLY
+     C                   EXSR      SR2
+     C     '2'           DSPLY
+     C                   ENDIF
+     C                   ENDSR
+
+     C     SR2           BEGSR
+     C     1             IFEQ      1
+     C     '4'           DSPLY
+     C                   GOTO      TAG_1
+     C     '5'           DSPLY
+     C                   ENDIF
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST6.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST6.rpgle
@@ -1,3 +1,11 @@
+     V* ==============================================================
+     V* 23/10/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a subroutine that calls another subroutine and executes
+    O * a GOTO redirecting to a nested TAG in top level
+     V* ==============================================================
+
      C                   EXSR      SR1
      C     1             IFEQ      0
      C     TAG_1         TAG

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST7.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST7.rpgle
@@ -1,0 +1,22 @@
+     C                   EXSR      SR1
+     C     1             IFEQ      0
+     C     '3'           DSPLY
+     C                   ENDIF
+     C                   SETON                                          LR
+
+     C     SR1           BEGSR
+     C     1             IFEQ      1
+     C     '1'           DSPLY
+     C                   EXSR      SR2
+     C     '2'           DSPLY
+     C                   ENDIF
+     C                   ENDSR
+
+     C     SR2           BEGSR
+     C     1             IFEQ      1
+     C     '4'           DSPLY
+     C                   GOTO      TAG_1
+     C     '5'           DSPLY
+     C                   ENDIF
+     C     TAG_1         TAG
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST7.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST7.rpgle
@@ -6,6 +6,17 @@
     O * a GOTO redirecting to a TAG in the latter subroutine
      V* ==============================================================
 
+     C                   EXSR      SR1
+     C     1             IFEQ      0
+     C     '3'           DSPLY
+     C                   ENDIF
+     C                   SETON                                          LR
+
+     C     SR1           BEGSR
+     C     1             IFEQ      1
+     C     '1'           DSPLY
+     C                   EXSR      SR2
+     C     '2'           DSPLY
      C                   ENDIF
      C                   ENDSR
 

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST7.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST7.rpgle
@@ -1,14 +1,11 @@
-     C                   EXSR      SR1
-     C     1             IFEQ      0
-     C     '3'           DSPLY
-     C                   ENDIF
-     C                   SETON                                          LR
+     V* ==============================================================
+     V* 23/10/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a subroutine that calls another subroutine and executes
+    O * a GOTO redirecting to a TAG in the latter subroutine
+     V* ==============================================================
 
-     C     SR1           BEGSR
-     C     1             IFEQ      1
-     C     '1'           DSPLY
-     C                   EXSR      SR2
-     C     '2'           DSPLY
      C                   ENDIF
      C                   ENDSR
 


### PR DESCRIPTION
## Description

This is a rework of the `GOTO` system which affects `TAG`, `GOTO` and `CABxx` statements.

This rework has two objectives:
- Improve the test coverage for `GOTO` statements
- Allow for the execution of some `GOTO` corner cases not previously supported that araised wrong exceptions at runtime

Previously non working cases are related to the interaction of `GOTO` with its `TAG` in cases where one or the other is deeply nested (for instance when they are contained in `IF`s, `DO`s, `FOR`s and so on).

### Technical notes

This is intended as a redesign of `GOTO` execution that aims to remain as compliant as possible with the previous system.

The reworked system supports all the previous functionalities with the addition of the new corner cases.

**What has not been changed**:
- We still throw `GotoException`s to control the flow
- We still catch those `GotoException`s in the same execution contexts
- We dispatch uncaught `GotoException`s in the same way as before

**What has been changed**:
- Added a subroutine stack in the `MainExecutionContext`, similar to the already present program context, in order to keep track of the subroutine being executed at any specific moment
- Added some execution related methods to allow for sequential execution starting from an arbitrary point (needed to support nested jumps)
- Isolated the actual jump logic in its own (potentially reusable) method
- Added a mechanism to differentiate jumps in the same scope (from a point of the subroutine to a different point in the same subroutine) from those redirecting to the top level using `GotoTopLevelException`. This allows for easier managing and cleanup of the execution context after a jump.

Related to:
- LS24004559

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
