### PR TITLE
Move error handling logic to CallStmt

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -154,12 +154,7 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
             // set reinitialization to false because symboltable cleaning currently is handled directly
             // in internal interpreter before exit
             // todo i don't know whether parameter reinitialization has still sense
-            kotlin.runCatching {
-                interpreter.execute(this.cu, params, false, callerParams)
-            }.onFailure {
-                MainExecutionContext.getProgramStack().pop()
-                throw it
-            }
+            interpreter.execute(this.cu, params, false, callerParams)
             MainExecutionContext.getConfiguration().jarikoCallback.onExitPgm(name, interpreter.getGlobalSymbolTable(), null)
             params.keys.forEach { params[it] = interpreter[it] }
             changedInitialValues = params().map { interpreter[it.name] }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -789,6 +789,7 @@ data class CallStmt(
                 }
                 interpreter.getIndicators()[errorIndicator] = BooleanValue.TRUE
                 MainExecutionContext.getConfiguration().jarikoCallback.onCallPgmError.invoke(popRuntimeErrorEvent())
+                MainExecutionContext.getProgramStack().pop()
                 null
             }
         paramValuesAtTheEnd?.forEachIndexed { index, value ->


### PR DESCRIPTION
## Description

> Note: This PR does not need any new RPG code, RPG code documentation or test as it only fixes an internal compiler behaviour that caused regressions when integrated in external components.

Fix an internal regression introduced in #642 that caused unexpected state when Jariko was used in dependent components.

Related to:

- #642 

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
