### PR TITLE
Add test cases for GOTO to tagged ENDSR

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -1363,6 +1363,18 @@ Test 6
     }
 
     @Test
+    fun executeGOTOTST8() {
+        val expected = listOf("2")
+        assertEquals(expected, outputOf("GOTOTST8"))
+    }
+
+    @Test
+    fun executeGOTOTST9() {
+        val expected = listOf("2")
+        assertEquals(expected, outputOf("GOTOTST9"))
+    }
+
+    @Test
     fun executeGotoENDSR() {
         assertEquals(listOf("1", "2", "3"), outputOf("GOTOENDSR"))
     }

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST8.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST8.rpgle
@@ -1,0 +1,14 @@
+     V* ==============================================================
+     V* 25/10/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a subroutine with a GOTO redirecting to the end
+     V* ==============================================================
+     C                   EXSR      SR1
+     C     '2'           DSPLY
+     C                   SETON                                          LR
+
+     C     SR1           BEGSR
+     C                   GOTO      G9SR1
+     C     '1'           DSPLY
+     C     G9SR1         ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST9.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST9.rpgle
@@ -1,0 +1,16 @@
+     V* ==============================================================
+     V* 25/10/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a subroutine with a nested GOTO redirecting to the end
+     V* ==============================================================
+     C                   EXSR      SR1
+     C     '2'           DSPLY
+     C                   SETON                                          LR
+
+     C     SR1           BEGSR
+     C     1             IFEQ      1
+     C                   GOTO      G9SR1
+     C                   ENDIF
+     C     '1'           DSPLY
+     C     G9SR1         ENDSR


### PR DESCRIPTION
## Description

Add two test cases for instances where `GOTO` points to tagged `ENDSR` in order to improve test coverage.

Related to:
- #643 

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
