### PR TITLE
Bugfix/LS24004622/EVAL array to array

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -990,10 +990,10 @@ open class InternalInterpreter(
              * If the source (from `value`) and target (from `dataDefinition`) are two array with size of source smaller than target,
              *  copy the last missed values from target to new `coercedValue`.
              */
-            if (value is ConcreteArrayValue && coercedValue is ConcreteArrayValue && dataDefinition.type is ArrayType) {
-                if (value.elements.size < dataDefinition.type.numberOfElements()) {
-                    val targetValue = (globalSymbolTable[dataDefinition] as ConcreteArrayValue)
-                    for (i in (value.elements.size + 1)..targetValue.elements.size) {
+            if (value is ArrayValue && coercedValue is ArrayValue && dataDefinition.type is ArrayType) {
+                if (value.arrayLength() < dataDefinition.type.numberOfElements()) {
+                    val targetValue = (globalSymbolTable[dataDefinition] as ArrayValue)
+                    for (i in (value.arrayLength() + 1)..targetValue.arrayLength()) {
                         coercedValue.setElement(i, targetValue.getElement(i))
                     }
                 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -997,8 +997,8 @@ open class InternalInterpreter(
         } else {
             val coercedValue = coerce(value, dataDefinition.type)
             /*
-             * If the source (from `value`) and target (from `dataDefinition`) are two array with size of source smaller than target,
-             *  copy the last missed values from target to new `coercedValue`.
+             * If the source (from `value`) and target (from `dataDefinition`) are two arrays with size of source smaller than target,
+             *  copies the last missed values from target to new `coercedValue`.
              */
             if (value is ArrayValue && coercedValue is ArrayValue && dataDefinition.type is ArrayType) {
                 if (value.arrayLength() < dataDefinition.type.numberOfElements()) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -986,6 +986,18 @@ open class InternalInterpreter(
             }
         } else {
             val coercedValue = coerce(value, dataDefinition.type)
+            /*
+             * If the source (from `value`) and target (from `dataDefinition`) are two array with size of source smaller than target,
+             *  copy the last missed values from target to new `coercedValue`.
+             */
+            if (value is ConcreteArrayValue && coercedValue is ConcreteArrayValue && dataDefinition.type is ArrayType) {
+                if (value.elements.size < dataDefinition.type.numberOfElements()) {
+                    val targetValue = (globalSymbolTable[dataDefinition] as ConcreteArrayValue)
+                    for (i in (value.elements.size + 1)..targetValue.elements.size) {
+                        coercedValue.setElement(i, targetValue.getElement(i))
+                    }
+                }
+            }
             set(dataDefinition, coercedValue)
             return coercedValue
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -523,7 +523,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00146() {
-        val expected = listOf("123", "123", "123", "123.000", "123.000", "12.300", "9.900", "9.900")
+        val expected = listOf("123", "123", "123", "123.000", "123.000", "123.000", "9.900", "9.900")
         assertEquals(expected, "smeup/MUDRNRAPU00146".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -466,4 +466,64 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("123", "123", "123", "12.300", "12.300", "12.300", "9.900", "9.900")
         assertEquals(expected, "smeup/MUDRNRAPU00140".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * EVAL an integer array to another. The size of first is lower than destination.
+     * @see #LS24004606
+     */
+    @Test
+    fun executeMUDRNRAPU00141() {
+        val expected = listOf("1", "1", "1", "1", "1", "1", "2", "2")
+        assertEquals(expected, "smeup/MUDRNRAPU00141".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * EVAL an integer array to another. The size of first is greater than destination.
+     * @see #LS24004606
+     */
+    @Test
+    fun executeMUDRNRAPU00142() {
+        val expected = listOf("1", "1", "1", "1", "1", "1", "1", "1")
+        assertEquals(expected, "smeup/MUDRNRAPU00142".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * EVAL a decimal array to integer.
+     * @see #LS24004606
+     */
+    @Test
+    fun executeMUDRNRAPU00143() {
+        val expected = listOf("1.200", "1.200", "1.200", "1", "1", "1", "2", "2")
+        assertEquals(expected, "smeup/MUDRNRAPU00143".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * EVAL an integer array to decimal.
+     * @see #LS24004606
+     */
+    @Test
+    fun executeMUDRNRAPU00144() {
+        val expected = listOf("1", "1", "1", "1.000", "1.000", "1.000", "2.200", "2.200")
+        assertEquals(expected, "smeup/MUDRNRAPU00144".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * EVAL a decimal array to integer. The number of digits of first are greater than second.
+     * @see #LS24004606
+     */
+    @Test
+    fun executeMUDRNRAPU00145() {
+        val expected = listOf("12.345", "12.345", "12.345", "12", "12", "12", "9", "9")
+        assertEquals(expected, "smeup/MUDRNRAPU00145".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * EVAL a decimal array to integer. The number of digits of first are greater than second.
+     * @see #LS24004606
+     */
+    @Test
+    fun executeMUDRNRAPU00146() {
+        val expected = listOf("123", "123", "123", "123.000", "123.000", "12.300", "9.900", "9.900")
+        assertEquals(expected, "smeup/MUDRNRAPU00146".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -537,4 +537,15 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("1", "1", "1", "1", "1", "1", "2", "2")
         assertEquals(expected, "smeup/MUDRNRAPU00147".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * EVAL an integer array to another. The size of first is lower than destination. In this case the target
+     *  is a DS array.
+     * @see #LS24004606
+     */
+    @Test
+    fun executeMUDRNRAPU00148() {
+        val expected = listOf("1", "1", "1", "1", "1", "1", "2", "2")
+        assertEquals(expected, "smeup/MUDRNRAPU00148".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00141.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00141.rpgle
@@ -1,0 +1,32 @@
+     V* ==============================================================
+     V* 25/10/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEL an integer array to another. The size of first is lower
+    O *  than destination.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the result of array have latest two
+    O *  elements as 0.
+     V* ==============================================================
+     D ARR_1           S              1  0 DIM(3) INZ(1)
+     D ARR_2           S              1  0 DIM(5) INZ(2)
+     D TMP             S              2
+     D COUNT           S              2  0 INZ(1)
+
+     C     COUNT         DOUEQ     4
+     C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   EVAL      ARR_2=ARR_1
+
+     C                   EVAL      COUNT=1
+     C     COUNT         DOUEQ     6
+     C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00141.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00141.rpgle
@@ -1,9 +1,10 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
      V* 29/10/2024 APU001 Improvements
+     V* 31/10/2024 APU001 Typo
      V* ==============================================================
     O * PROGRAM GOAL
-    O * MOVEL an integer array to another. The size of first is lower
+    O * EVAL an integer array to another. The size of first is lower
     O *  than destination.
      V* ==============================================================
     O * JARIKO ANOMALY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00141.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00141.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
+     V* 29/10/2024 APU001 Improvements
      V* ==============================================================
     O * PROGRAM GOAL
     O * MOVEL an integer array to another. The size of first is lower
@@ -14,19 +15,16 @@
      D TMP             S              2
      D COUNT           S              2  0 INZ(1)
 
-     C     COUNT         DOUEQ     4
+     C                   FOR       COUNT=1 TO %ELEM(ARR_1)
      C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   EVAL      ARR_2=ARR_1
 
-     C                   EVAL      COUNT=1
-     C     COUNT         DOUEQ     6
+     C                   FOR       COUNT=1 TO %ELEM(ARR_2)
      C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00142.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00142.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
+     V* 29/10/2024 APU001 Improvements
      V* ==============================================================
     O * PROGRAM GOAL
     O * MOVEL an integer array to another. The size of first is
@@ -10,19 +11,16 @@
      D TMP             S              2
      D COUNT           S              2  0 INZ(1)
 
-     C     COUNT         DOUEQ     6
+     C                   FOR       COUNT=1 TO %ELEM(ARR_1)
      C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   EVAL      ARR_2=ARR_1
 
-     C                   EVAL      COUNT=1
-     C     COUNT         DOUEQ     4
+     C                   FOR       COUNT=1 TO %ELEM(ARR_2)
      C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00142.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00142.rpgle
@@ -1,9 +1,10 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
      V* 29/10/2024 APU001 Improvements
+     V* 31/10/2024 APU001 Typo
      V* ==============================================================
     O * PROGRAM GOAL
-    O * MOVEL an integer array to another. The size of first is
+    O * EVAL an integer array to another. The size of first is
     O *  greater than destination.
      V* ==============================================================
      D ARR_1           S              1  0 DIM(5) INZ(1)

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00142.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00142.rpgle
@@ -1,0 +1,28 @@
+     V* ==============================================================
+     V* 25/10/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEL an integer array to another. The size of first is
+    O *  greater than destination.
+     V* ==============================================================
+     D ARR_1           S              1  0 DIM(5) INZ(1)
+     D ARR_2           S              1  0 DIM(3) INZ(2)
+     D TMP             S              2
+     D COUNT           S              2  0 INZ(1)
+
+     C     COUNT         DOUEQ     6
+     C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   EVAL      ARR_2=ARR_1
+
+     C                   EVAL      COUNT=1
+     C     COUNT         DOUEQ     4
+     C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00143.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00143.rpgle
@@ -1,0 +1,31 @@
+     V* ==============================================================
+     V* 25/10/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEL a decimal array to integer.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the result of array have latest two
+    O *  elements as 0.
+     V* ==============================================================
+     D ARR_1           S              5  3 DIM(3) INZ(1.2)
+     D ARR_2           S              5  0 DIM(5) INZ(2)
+     D TMP             S              5
+     D COUNT           S              2  0 INZ(1)
+
+     C     COUNT         DOUEQ     4
+     C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   EVAL      ARR_2=ARR_1
+
+     C                   EVAL      COUNT=1
+     C     COUNT         DOUEQ     6
+     C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00143.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00143.rpgle
@@ -1,9 +1,10 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
      V* 29/10/2024 APU001 Improvements
+     V* 31/10/2024 APU001 Typo
      V* ==============================================================
     O * PROGRAM GOAL
-    O * MOVEL a decimal array to integer.
+    O * EVAL a decimal array to integer.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, the result of array have latest two

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00143.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00143.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
+     V* 29/10/2024 APU001 Improvements
      V* ==============================================================
     O * PROGRAM GOAL
     O * MOVEL a decimal array to integer.
@@ -13,19 +14,16 @@
      D TMP             S              5
      D COUNT           S              2  0 INZ(1)
 
-     C     COUNT         DOUEQ     4
+     C                   FOR       COUNT=1 TO %ELEM(ARR_1)
      C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   EVAL      ARR_2=ARR_1
 
-     C                   EVAL      COUNT=1
-     C     COUNT         DOUEQ     6
+     C                   FOR       COUNT=1 TO %ELEM(ARR_2)
      C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00144.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00144.rpgle
@@ -1,0 +1,31 @@
+     V* ==============================================================
+     V* 25/10/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEL a decimal array to integer.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the result of array have latest two
+    O *  elements as 0.
+     V* ==============================================================
+     D ARR_1           S              5  0 DIM(3) INZ(1)
+     D ARR_2           S              5  3 DIM(5) INZ(2.2)
+     D TMP             S              5
+     D COUNT           S              2  0 INZ(1)
+
+     C     COUNT         DOUEQ     4
+     C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   EVAL      ARR_2=ARR_1
+
+     C                   EVAL      COUNT=1
+     C     COUNT         DOUEQ     6
+     C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00144.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00144.rpgle
@@ -1,9 +1,10 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
      V* 29/10/2024 APU001 Improvements
+     V* 31/10/2024 APU001 Typo
      V* ==============================================================
     O * PROGRAM GOAL
-    O * MOVEL a decimal array to integer.
+    O * EVAL a decimal array to integer.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, the result of array have latest two

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00144.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00144.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
+     V* 29/10/2024 APU001 Improvements
      V* ==============================================================
     O * PROGRAM GOAL
     O * MOVEL a decimal array to integer.
@@ -13,19 +14,16 @@
      D TMP             S              5
      D COUNT           S              2  0 INZ(1)
 
-     C     COUNT         DOUEQ     4
+     C                   FOR       COUNT=1 TO %ELEM(ARR_1)
      C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   EVAL      ARR_2=ARR_1
 
-     C                   EVAL      COUNT=1
-     C     COUNT         DOUEQ     6
+     C                   FOR       COUNT=1 TO %ELEM(ARR_2)
      C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00145.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00145.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
+     V* 29/10/2024 APU001 Improvements
      V* ==============================================================
     O * PROGRAM GOAL
     O * MOVEL a decimal array to integer. The number of digits
@@ -14,19 +15,16 @@
      D TMP             S              7
      D COUNT           S              2  0 INZ(1)
 
-     C     COUNT         DOUEQ     4
+     C                   FOR       COUNT=1 TO %ELEM(ARR_1)
      C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   EVAL      ARR_2=ARR_1
 
-     C                   EVAL      COUNT=1
-     C     COUNT         DOUEQ     6
+     C                   FOR       COUNT=1 TO %ELEM(ARR_2)
      C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00145.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00145.rpgle
@@ -1,0 +1,32 @@
+     V* ==============================================================
+     V* 25/10/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEL a decimal array to integer. The number of digits
+    O *  of first are greater than second.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the result of array have latest two
+    O *  elements as 0.
+     V* ==============================================================
+     D ARR_1           S              5  3 DIM(3) INZ(12.345)
+     D ARR_2           S              3  0 DIM(5) INZ(9)
+     D TMP             S              7
+     D COUNT           S              2  0 INZ(1)
+
+     C     COUNT         DOUEQ     4
+     C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   EVAL      ARR_2=ARR_1
+
+     C                   EVAL      COUNT=1
+     C     COUNT         DOUEQ     6
+     C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00145.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00145.rpgle
@@ -1,9 +1,10 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
      V* 29/10/2024 APU001 Improvements
+     V* 31/10/2024 APU001 Typo
      V* ==============================================================
     O * PROGRAM GOAL
-    O * MOVEL a decimal array to integer. The number of digits
+    O * EVAL a decimal array to integer. The number of digits
     O *  of first are greater than second.
      V* ==============================================================
     O * JARIKO ANOMALY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
@@ -1,9 +1,10 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
      V* 29/10/2024 APU001 Improvements
+     V* 31/10/2024 APU001 Typo
      V* ==============================================================
     O * PROGRAM GOAL
-    O * MOVEL a integer array to decimal. The number of digits
+    O * EVAL a integer array to decimal. The number of digits
     O *  of first are lower than second.
      V* ==============================================================
     O * JARIKO ANOMALY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
@@ -21,7 +21,7 @@
      C                   EVAL      COUNT=COUNT+1
      C                   ENDDO
 
-     C                   EVAL      ARR_2=ARR_1                                  #Value ConcreteArrayValue cannot be assigned to data: DataDefinition
+     C                   EVAL      ARR_2=ARR_1
 
      C                   EVAL      COUNT=1
      C     COUNT         DOUEQ     6

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
@@ -11,7 +11,7 @@
     O *  to data: DataDefinition'
      V* ==============================================================
      D ARR_1           S              3  0 DIM(3) INZ(123)
-     D ARR_2           S              5  3 DIM(5) INZ(9.9)
+     D ARR_2           S              6  3 DIM(5) INZ(9.9)
      D TMP             S              7
      D COUNT           S              2  0 INZ(1)
 

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
      V* 25/10/2024 APU001 Creation
+     V* 29/10/2024 APU001 Improvements
      V* ==============================================================
     O * PROGRAM GOAL
     O * MOVEL a integer array to decimal. The number of digits
@@ -14,19 +15,16 @@
      D TMP             S              7
      D COUNT           S              2  0 INZ(1)
 
-     C     COUNT         DOUEQ     4
+     C                   FOR       COUNT=1 TO %ELEM(ARR_1)
      C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   EVAL      ARR_2=ARR_1
 
-     C                   EVAL      COUNT=1
-     C     COUNT         DOUEQ     6
+     C                   FOR       COUNT=1 TO %ELEM(ARR_2)
      C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
@@ -1,0 +1,33 @@
+     V* ==============================================================
+     V* 25/10/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEL a integer array to decimal. The number of digits
+    O *  of first are lower than second.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was
+    O *  `Value ConcreteArrayValue cannot be assigned
+    O *  to data: DataDefinition'
+     V* ==============================================================
+     D ARR_1           S              3  0 DIM(3) INZ(123)
+     D ARR_2           S              5  3 DIM(5) INZ(9.9)
+     D TMP             S              7
+     D COUNT           S              2  0 INZ(1)
+
+     C     COUNT         DOUEQ     4
+     C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   EVAL      ARR_2=ARR_1                                  #Value ConcreteArrayValue cannot be assigned to data: DataDefinition
+
+     C                   EVAL      COUNT=1
+     C     COUNT         DOUEQ     6
+     C                   EVAL      TMP=%CHAR(ARR_2(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00146.rpgle
@@ -6,9 +6,8 @@
     O *  of first are lower than second.
      V* ==============================================================
     O * JARIKO ANOMALY
-    O * Before the fix, the error occurred was
-    O *  `Value ConcreteArrayValue cannot be assigned
-    O *  to data: DataDefinition'
+    O * Before the fix, the result of array have latest two
+    O *  elements as 0.
      V* ==============================================================
      D ARR_1           S              3  0 DIM(3) INZ(123)
      D ARR_2           S              6  3 DIM(5) INZ(9.9)

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00148.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00148.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
-     V* 25/10/2024 APU001 Creation
+     V* 28/10/2024 APU001 Creation
+     V* 29/10/2024 APU001 Improvements
      V* ==============================================================
     O * PROGRAM GOAL
     O * WVAL an integer array to another. The size of first is lower
@@ -16,19 +17,16 @@
      D TMP             S              7
      D COUNT           S              2  0 INZ(1)
 
-     C     COUNT         DOUEQ     4
+     C                   FOR       COUNT=1 TO %ELEM(ARR_1)
      C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   EVAL      DS_ARR_1=ARR_1
 
-     C                   EVAL      COUNT=1
-     C     COUNT         DOUEQ     6
+     C                   FOR       COUNT=1 TO %ELEM(DS_ARR_1)
      C                   EVAL      TMP=%CHAR(DS_ARR_1(COUNT))
      C     TMP           DSPLY
-     C                   EVAL      COUNT=COUNT+1
-     C                   ENDDO
+     C                   ENDFOR
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00148.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00148.rpgle
@@ -1,9 +1,10 @@
      V* ==============================================================
      V* 28/10/2024 APU001 Creation
      V* 29/10/2024 APU001 Improvements
+     V* 31/10/2024 APU001 Typo
      V* ==============================================================
     O * PROGRAM GOAL
-    O * WVAL an integer array to another. The size of first is lower
+    O * EVAL an integer array to another. The size of first is lower
     O *  than destination, and the target is ana array of DS.
      V* ==============================================================
     O * JARIKO ANOMALY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00148.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00148.rpgle
@@ -1,0 +1,34 @@
+     V* ==============================================================
+     V* 25/10/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * WVAL an integer array to another. The size of first is lower
+    O *  than destination, and the target is ana array of DS.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the result of array have latest two
+    O *  elements as 0.
+     V* ==============================================================
+     D ARR_1           S              1  0 DIM(3) INZ(1)
+     D DS_1            DS
+     D DS_ARR_1                       1  0 DIM(5) INZ(2)
+
+     D TMP             S              7
+     D COUNT           S              2  0 INZ(1)
+
+     C     COUNT         DOUEQ     4
+     C                   EVAL      TMP=%CHAR(ARR_1(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   EVAL      DS_ARR_1=ARR_1
+
+     C                   EVAL      COUNT=1
+     C     COUNT         DOUEQ     6
+     C                   EVAL      TMP=%CHAR(DS_ARR_1(COUNT))
+     C     TMP           DSPLY
+     C                   EVAL      COUNT=COUNT+1
+     C                   ENDDO
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work is like #647 but for `EVAL` statement. For example:
```
     D ARR_1           S              1  0 DIM(3) INZ(1)
     D ARR_2           S              1  0 DIM(5) INZ(2)
     ...
     C                   EVAL      ARR_2=ARR_1
```

### Technical notes
On Jariko, for this operation, the result of array for latest two elements was `0`. So, I have applied the fix on `internal_interpreter` by checking the size of array and adding the missed elements to last positions.

Related to #LS24004622

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
