### PR TITLE
Bugfix/ls24004538/nested call error stack

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ProgramInterpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ProgramInterpreter.kt
@@ -1,8 +1,15 @@
 package com.smeup.rpgparser.interpreter
 
+import com.smeup.rpgparser.execution.MainExecutionContext
+
 class ProgramInterpreter(val systemInterface: SystemInterface) {
 
     fun execute(rpgProgram: RpgProgram, initialValues: LinkedHashMap<String, Value>) {
-        rpgProgram.execute(systemInterface = systemInterface, params = initialValues)
+        MainExecutionContext.getProgramStack().push(rpgProgram)
+        try {
+            rpgProgram.execute(systemInterface = systemInterface, params = initialValues)
+        } finally {
+            MainExecutionContext.getProgramStack().pop()
+        }
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -128,8 +128,8 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
             }
             if (!initialized) {
                 initialized = true
-                val caller = if (MainExecutionContext.getProgramStack().isNotEmpty()) {
-                    MainExecutionContext.getProgramStack().peek()
+                val caller = if (MainExecutionContext.getProgramStack().size > 1) {
+                    MainExecutionContext.getProgramStack()[MainExecutionContext.getProgramStack().size - 2]
                 } else {
                     null
                 }
@@ -149,7 +149,6 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
 
                 activationGroup = ActivationGroup(activationGroupType, activationGroupType.assignedName(caller))
             }
-            MainExecutionContext.getProgramStack().push(this)
             MainExecutionContext.getConfiguration().jarikoCallback.onEnterPgm(name, interpreter.getGlobalSymbolTable())
             // set reinitialization to false because symboltable cleaning currently is handled directly
             // in internal interpreter before exit
@@ -160,7 +159,6 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
             changedInitialValues = params().map { interpreter[it.name] }
             // here clear symbol table if needed
             interpreter.doSomethingAfterExecution()
-            MainExecutionContext.getProgramStack().pop()
         }.nanoseconds
         if (MainExecutionContext.isLoggingEnabled) {
             logHandlers.renderLog(LazyLogEntry.produceStatement(logSource, "INTERPRETATION", "END"))

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -128,8 +128,20 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
             }
             if (!initialized) {
                 initialized = true
-                val caller = if (MainExecutionContext.getProgramStack().size > 1) {
-                    MainExecutionContext.getProgramStack()[MainExecutionContext.getProgramStack().size - 2]
+
+                /**
+                 * As the RPG program stack is managed outside of this method, it is up to the caller of this method
+                 * to ensure it is in the correct state, that is:
+                 * - `lastIndex` is this RpgProgram
+                 * - `lastIndex - 1` is the RpgProgram that calls this RpgProgram
+                 *
+                 * Note: If these two rules are not followed at this point, do not expect RpgPrograms to behave correctly.
+                 * that means something is wrong with `MainExecutionContext.getProgramStack()` push and pop logic.
+                 */
+                val programStack = MainExecutionContext.getProgramStack()
+                val caller = if (programStack.size > 1) {
+                    val parentProgramIndex = programStack.lastIndex - 1
+                    programStack[parentProgramIndex]
                 } else {
                     null
                 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
@@ -17,6 +17,7 @@
 package com.smeup.rpgparser.utils
 
 import com.smeup.rpgparser.execution.ParsingProgram
+import com.smeup.rpgparser.interpreter.RpgProgram
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.ancestor
@@ -168,6 +169,20 @@ internal fun <T> Stack<T>.popIfPresent(): T? {
 internal fun <T> Stack<T>.peekOrNull(): T? = if (isNotEmpty()) {
     this.peek()
 } else null
+
+/**
+ * Rollback the stack state to the state it was prior of the specified program was called.
+ * @param name The name of the program
+ * @return `true` if the program was actually found in the stack and `false` else-wise
+ */
+internal fun Stack<RpgProgram>.rollbackBefore(name: String): Boolean {
+    while (true) {
+        val previous = this.popIfPresent() ?: break
+        if (previous.name == name) return true
+    }
+
+    return false
+}
 
 /**
  * Get the [CompilationUnit] that contains the current [Node]

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
@@ -17,7 +17,6 @@
 package com.smeup.rpgparser.utils
 
 import com.smeup.rpgparser.execution.ParsingProgram
-import com.smeup.rpgparser.interpreter.RpgProgram
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.ancestor
@@ -169,20 +168,6 @@ internal fun <T> Stack<T>.popIfPresent(): T? {
 internal fun <T> Stack<T>.peekOrNull(): T? = if (isNotEmpty()) {
     this.peek()
 } else null
-
-/**
- * Rollback the stack state to the state it was prior of the specified program was called.
- * @param name The name of the program
- * @return `true` if the program was actually found in the stack and `false` else-wise
- */
-internal fun Stack<RpgProgram>.rollbackBefore(name: String): Boolean {
-    while (true) {
-        val previous = this.popIfPresent() ?: break
-        if (previous.name == name) return true
-    }
-
-    return false
-}
 
 /**
  * Get the [CompilationUnit] that contains the current [Node]

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -398,6 +398,16 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
+     * State of context after a CALL stack failed setting an error indicator
+     * @see #LS24004538
+     */
+    @Test
+    fun executeMUDRNRAPU00269() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00269".outputOf(configuration = smeupConfig))
+    }
+
+    /**
      * Comparing number and `*ZEROS` by using `IFxx`.
      * @see #LS24004528
      */

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/ERRORPGM2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/ERRORPGM2.rpgle
@@ -1,0 +1,2 @@
+      *  This program has the sole purpose of calling a program that throws a runtime exception
+     C                   CALL        'ERRORPGM'

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00269.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00269.rpgle
@@ -1,21 +1,16 @@
      V* ==============================================================
-     V* 21/10/2024 APU002 Creation
+     V* 30/10/2024 APU002 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Call a program that throws an error with an error indicator and ensure the execution context is appropriate
+    O * Call a program with an error indicator that calls another program
+    O * that throws an error and ensure the execution context is appropriate
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, the error was about the caller not resolving
     O * symbols in the correct compilation unit
     O *
-    O * Note: The following test resembles the structure of the program where the issue was discovered
-    O * The original behavior was the following:
-    O * - Call a program with an error indicator
-    O * - Callee errors and execution falls back to the caller
-    O * - The internal context was not cleaned up
-    O * - The caller thinks to be the callee
-    O * - Execute a procedure defined in the caller
-    O * - The procedure is not found because we search for it in the callee CU instead of the caller one
+    O * Note: see MUDRNRAPU00268.rpgle for a deeper explanation
+    O * on how the error was reproduced
      V* ==============================================================
 
       * Test declarations
@@ -23,7 +18,7 @@
      D  £TESTPA                      10
 
       * Call of a program that throws an error and sets the error indicator
-     C                   CALL        'ERRORPGM'                         35
+     C                   CALL        'ERRORPGM2'                        35
 
       * If call failed but the error indicator was set
       * Execution should continue and the context should reference the correct program


### PR DESCRIPTION
## Description

> Note: This PR does not introduce/fix any RPGLE functionality but rather fixes a regression introduced in a precedent PR.

Fix a regression introduced with changes in #644 that caused errors thrown deeply in the program stack to not cleanup the stack state similarly to what we had in #642.

Related to:
- LS24004538
- #642 
- #644 

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
