### PR TITLE
Feature/ls24004723/telemetry callbacks

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -287,7 +287,39 @@ data class JarikoCallback(
      * @return true if the feature flag is on, false otherwise - default implementation returns the feature flag default value
      * @see FeatureFlag.on
      * */
-    var featureFlagIsOn: ((featureFlag: FeatureFlag) -> Boolean) = { featureFlag -> featureFlag.on }
+    var featureFlagIsOn: ((featureFlag: FeatureFlag) -> Boolean) = { featureFlag -> featureFlag.on },
+
+    /**
+     * It is invoked whenever we start a telemetry trace.
+     * @param trace The object containing all the information about this trace.
+     */
+    var startJarikoTrace: ((trace: JarikoTrace) -> Unit) = {
+        // Defaults to a no-op
+    },
+
+    /**
+     * It is invoked whenever we finish a telemetry trace.
+     * @param trace The object containing all the information about this trace.
+     */
+    var finishJarikoTrace: ((trace: JarikoTrace) -> Unit) = {
+        // Defaults to a no-op
+    },
+
+    /**
+     * It is invoked whenever we start a telemetry trace defined as annotation in an RPG program.
+     * @param trace The object containing all the information about this trace.
+     */
+    var startRpgTrace: ((trace: RpgTrace) -> Unit) = {
+        // Defaults to a no-op
+    },
+
+    /**
+     * It is invoked whenever we finish a telemetry trace defined as annotation in an RPG program.
+     * @param trace The object containing all the information about this trace.
+     */
+    var finishRpgTrace: ((trace: RpgTrace) -> Unit) = {
+        // Defaults to a no-op
+    }
 )
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -299,7 +299,6 @@ data class JarikoCallback(
 
     /**
      * It is invoked whenever we finish a telemetry trace.
-     * @param trace The object containing all the information about this trace.
      */
     var finishJarikoTrace: (() -> Unit) = {
         // Defaults to a no-op
@@ -315,7 +314,6 @@ data class JarikoCallback(
 
     /**
      * It is invoked whenever we finish a telemetry trace defined as annotation in an RPG program.
-     * @param trace The object containing all the information about this trace.
      */
     var finishRpgTrace: (() -> Unit) = {
         // Defaults to a no-op

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -301,7 +301,7 @@ data class JarikoCallback(
      * It is invoked whenever we finish a telemetry trace.
      * @param trace The object containing all the information about this trace.
      */
-    var finishJarikoTrace: ((trace: JarikoTrace) -> Unit) = {
+    var finishJarikoTrace: (() -> Unit) = {
         // Defaults to a no-op
     },
 
@@ -317,7 +317,7 @@ data class JarikoCallback(
      * It is invoked whenever we finish a telemetry trace defined as annotation in an RPG program.
      * @param trace The object containing all the information about this trace.
      */
-    var finishRpgTrace: ((trace: RpgTrace) -> Unit) = {
+    var finishRpgTrace: (() -> Unit) = {
         // Defaults to a no-op
     }
 )

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
@@ -89,15 +89,8 @@ object MainExecutionContext {
                 val ctx = context.get()
                 val callback = ctx.configuration.jarikoCallback
                 val trace = JarikoTrace(JarikoTraceKind.MainExecutionContext)
-                callback.startJarikoTrace(trace)
-
-                // We need to finish the trace even if the program throws
-                try {
+                callback.traceBlock(trace) {
                     invoke(ctx)
-                } catch (e: Exception) {
-                    throw e
-                } finally {
-                    callback.finishJarikoTrace()
                 }
             }.onFailure {
                 if (isRootContext) memorySliceMgr?.afterMainProgramInterpretation(false)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
@@ -86,7 +86,19 @@ object MainExecutionContext {
                 )
             }
             return mainProgram.runCatching {
-                invoke(context.get())
+                val ctx = context.get()
+                val callback = ctx.configuration.jarikoCallback
+                val trace = JarikoTrace(JarikoTraceKind.MainExecutionContext)
+                callback.startJarikoTrace(trace)
+
+                // We need to finish the trace even if the program throws
+                try {
+                    invoke(ctx)
+                } catch (e: Exception) {
+                    throw e
+                } finally {
+                    callback.finishJarikoTrace()
+                }
             }.onFailure {
                 if (isRootContext) memorySliceMgr?.afterMainProgramInterpretation(false)
             }.onSuccess {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -535,20 +535,19 @@ class ExpressionEvaluation(
         val functionToCall = expression.function.name
         val callback = MainExecutionContext.getConfiguration().jarikoCallback
         val trace = JarikoTrace(JarikoTraceKind.FunctionCall, functionToCall)
-        callback.startJarikoTrace(trace)
-        val function = systemInterface.findFunction(interpreterStatus.symbolTable, functionToCall)
-            ?: throw RuntimeException("Function $functionToCall cannot be found (${expression.position.line()})")
-        val functionWrapper = FunctionWrapper(function = function, functionName = functionToCall, expression)
-        val paramsValues = expression.args.map {
-            if (it is DataRefExpr) {
-                FunctionValue(variableName = it.variable.name, value = it.evalWith(this))
-            } else {
-                FunctionValue(value = it.evalWith(this))
+        callback.traceBlock(trace) {
+            val function = systemInterface.findFunction(interpreterStatus.symbolTable, functionToCall)
+                ?: throw RuntimeException("Function $functionToCall cannot be found (${expression.position.line()})")
+            val functionWrapper = FunctionWrapper(function = function, functionName = functionToCall, expression)
+            val paramsValues = expression.args.map {
+                if (it is DataRefExpr) {
+                    FunctionValue(variableName = it.variable.name, value = it.evalWith(this))
+                } else {
+                    FunctionValue(value = it.evalWith(this))
+                }
             }
+            functionWrapper.execute(systemInterface, paramsValues, interpreterStatus.symbolTable)
         }
-        val returnValue = functionWrapper.execute(systemInterface, paramsValues, interpreterStatus.symbolTable)
-        callback.finishJarikoTrace()
-        returnValue
     }
 
     override fun eval(expression: TimeStampExpr): Value = proxyLogging(expression) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -1346,11 +1346,11 @@ open class InternalInterpreter(
         val callback = configuration.jarikoCallback
         val trace = when (statement) {
             is CallStmt -> JarikoTrace(
-                kind = JarikoTraceKind.Program,
+                kind = JarikoTraceKind.CallStmt,
                 description = eval(statement.expression).asString().value.trim()
             )
             is ExecuteSubroutine -> JarikoTrace(
-                kind = JarikoTraceKind.Subroutine,
+                kind = JarikoTraceKind.ExecuteSubroutine,
                 description = statement.subroutine.name
 
             )

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -1329,6 +1329,11 @@ open class InternalInterpreter(
                 kind = JarikoTraceKind.Program,
                 description = eval(statement.expression).asString().value.trim()
             )
+            is ExecuteSubroutine -> JarikoTrace(
+                kind = JarikoTraceKind.Subroutine,
+                description = statement.subroutine.name
+
+            )
             is CompositeStatement -> JarikoTrace(
                 kind = JarikoTraceKind.CompositeStatement,
                 description = statement.loggableEntityName

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -88,9 +88,7 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
     override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
         val callback = configuration.jarikoCallback
         val trace = JarikoTrace(JarikoTraceKind.RpgProgram, this.name)
-        callback.startJarikoTrace(trace)
-
-        return try {
+        return callback.traceBlock(trace) {
             val expectedKeys = params().asSequence().map { it.name }.toSet()
 
             // Original params passed from the caller
@@ -203,10 +201,6 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
                 )
             }
             changedInitialValues
-        } catch (e: Exception) {
-            throw e
-        } finally {
-            callback.finishJarikoTrace()
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
@@ -17,6 +17,8 @@
 
 package com.smeup.rpgparser.interpreter
 
+import com.smeup.rpgparser.execution.JarikoCallback
+
 /**
  * Kind of a trace
  */
@@ -46,3 +48,14 @@ data class RpgTrace(
     val program: String,
     val description: String? = null
 )
+
+internal fun <T> JarikoCallback.traceBlock(trace: JarikoTrace, block: () -> T): T {
+    startJarikoTrace(trace)
+    try {
+        return block()
+    } catch (e: Exception) {
+        throw e
+    } finally {
+        finishJarikoTrace()
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * imitations under the License.
+ *
+ */
+
+package com.smeup.rpgparser.interpreter
+
+/**
+ * Kind of a trace
+ */
+enum class JarikoTraceKind {
+    Parsing,
+    SymbolTable,
+    CompositeStatement,
+    Program
+}
+
+/**
+ * A trace emitted by Jariko for telemetry purposes
+ */
+data class JarikoTrace(
+    val kind: JarikoTraceKind,
+    val description: String? = null
+)
+
+/**
+ * A trace emitted by an RPG program for telemetry purposes
+ */
+data class RpgTrace(
+    val program: String,
+    val description: String? = null
+)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
@@ -24,7 +24,8 @@ enum class JarikoTraceKind {
     Parsing,
     SymbolTable,
     CompositeStatement,
-    Program
+    Program,
+    Subroutine
 }
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
@@ -24,8 +24,9 @@ enum class JarikoTraceKind {
     Parsing,
     SymbolTable,
     CompositeStatement,
-    Program,
-    Subroutine
+    CallStmt,
+    ExecuteSubroutine,
+    FunctionCall
 }
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
@@ -26,7 +26,9 @@ enum class JarikoTraceKind {
     CompositeStatement,
     CallStmt,
     ExecuteSubroutine,
-    FunctionCall
+    FunctionCall,
+    MainExecutionContext,
+    RpgProgram
 }
 
 /**
@@ -34,7 +36,7 @@ enum class JarikoTraceKind {
  */
 data class JarikoTrace(
     val kind: JarikoTraceKind,
-    val description: String? = null
+    val description: String = ""
 )
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
@@ -188,97 +188,155 @@ class RpgParserFacade {
     }
 
     fun createParser(inputStream: InputStream, errors: MutableList<Error>, longLines: Boolean): RpgParser {
+        val logSource = { LogSourceData(executionProgramName, "") }
         val callback = MainExecutionContext.getConfiguration().jarikoCallback
         val rpgLoadTrace = JarikoTrace(JarikoTraceKind.Parsing, "RPGLOAD")
-        callback.startJarikoTrace(rpgLoadTrace)
+        var charInput: CharStream? = null
+        callback.traceBlock(rpgLoadTrace) {
+            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "RPGLOAD", "START"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "RPGLOAD"))
+            val elapsedLoad = measureNanoTime {
+                charInput =
+                    if (longLines) inputStreamWithLongLines(inputStream) else CharStreams.fromStream(inputStream)
+            }.nanoseconds
 
-        val logSource = { LogSourceData(executionProgramName, "") }
-        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "RPGLOAD", "START"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "RPGLOAD"))
-        val charInput: CharStream?
-        val elapsedLoad = measureNanoTime {
-            charInput = if (longLines) inputStreamWithLongLines(inputStream) else CharStreams.fromStream(inputStream)
-        }.nanoseconds
+            val lines = charInput?.toString()?.split(Pattern.compile("\\r\\n|\\r|\\n"))?.size ?: 0
+            val endLogSource = { LogSourceData(executionProgramName, lines.toString()) }
 
-        val lines = charInput?.toString()?.split(Pattern.compile("\\r\\n|\\r|\\n"))?.size ?: 0
-        val endLogSource = { LogSourceData(executionProgramName, lines.toString()) }
-
-        MainExecutionContext.log(LazyLogEntry.produceStatement(endLogSource, "RPGLOAD", "END"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingEnd(endLogSource, "RPGLOAD", elapsedLoad))
-        MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(endLogSource, ProgramUsageType.Parsing, "RPGLOAD", elapsedLoad))
-        callback.finishJarikoTrace()
+            MainExecutionContext.log(LazyLogEntry.produceStatement(endLogSource, "RPGLOAD", "END"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingEnd(endLogSource, "RPGLOAD", elapsedLoad))
+            MainExecutionContext.log(
+                LazyLogEntry.producePerformanceAndUpdateAnalytics(
+                    endLogSource,
+                    ProgramUsageType.Parsing,
+                    "RPGLOAD",
+                    elapsedLoad
+                )
+            )
+        }
 
         val lexerTrace = JarikoTrace(JarikoTraceKind.Parsing, "LEXER")
-        callback.startJarikoTrace(lexerTrace)
-        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "LEXER", "START"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "LEXER"))
+        val lexer = callback.traceBlock(lexerTrace) {
+            val lexer: Lexer
+            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "LEXER", "START"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "LEXER"))
 
-        val lexer: RpgLexer
-        val elapsedLexer = measureNanoTime {
-            lexer = RpgLexer(charInput)
-            lexer.removeErrorListeners()
-            lexer.addErrorListener(object : BaseErrorListener() {
-                override fun syntaxError(p0: Recognizer<*, *>?, p1: Any?, line: Int, charPositionInLine: Int, errorMessage: String?, p5: RecognitionException?) {
-                    errors.add(Error(ErrorType.LEXICAL, errorMessage
-                        ?: "unspecified", position = Point(line, charPositionInLine).asPosition))
-                }
-            })
-        }.nanoseconds
+            val elapsedLexer = measureNanoTime {
+                lexer = RpgLexer(charInput)
+                lexer.removeErrorListeners()
+                lexer.addErrorListener(object : BaseErrorListener() {
+                    override fun syntaxError(
+                        p0: Recognizer<*, *>?,
+                        p1: Any?,
+                        line: Int,
+                        charPositionInLine: Int,
+                        errorMessage: String?,
+                        p5: RecognitionException?
+                    ) {
+                        errors.add(
+                            Error(
+                                ErrorType.LEXICAL, errorMessage
+                                    ?: "unspecified", position = Point(line, charPositionInLine).asPosition
+                            )
+                        )
+                    }
+                })
+            }.nanoseconds
 
-        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "LEXER", "END"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "LEXER", elapsedLexer))
-        MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "LEXER", elapsedLexer))
-        callback.finishJarikoTrace()
+            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "LEXER", "END"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "LEXER", elapsedLexer))
+            MainExecutionContext.log(
+                LazyLogEntry.producePerformanceAndUpdateAnalytics(
+                    logSource,
+                    ProgramUsageType.Parsing,
+                    "LEXER",
+                    elapsedLexer
+                )
+            )
+            lexer
+        }
 
         val parserTrace = JarikoTrace(JarikoTraceKind.Parsing, "PARSER")
-        callback.startJarikoTrace(parserTrace)
-        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "PARSER", "START"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "PARSER"))
-        val parser: RpgParser
-        val elapsedParser = measureNanoTime {
-            val commonTokenStream = CommonTokenStream(lexer)
-            parser = RpgParser(commonTokenStream)
-            parser.removeErrorListeners()
-            parser.addErrorListener(object : BaseErrorListener() {
-                override fun syntaxError(p0: Recognizer<*, *>?, p1: Any?, line: Int, charPositionInLine: Int, errorMessage: String?, p5: RecognitionException?) {
-                    errors.add(Error(ErrorType.SYNTACTIC, errorMessage
-                        ?: "unspecified", position = Point(line, charPositionInLine).asPosition))
-                }
-            })
-        }.nanoseconds
-        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "PARSER", "END"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "PARSER", elapsedParser))
-        MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "PARSER", elapsedParser))
-        callback.finishJarikoTrace()
+        val parser = callback.traceBlock(parserTrace) {
+            val parser: RpgParser
+            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "PARSER", "START"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "PARSER"))
+            val elapsedParser = measureNanoTime {
+                val commonTokenStream = CommonTokenStream(lexer)
+                parser = RpgParser(commonTokenStream)
+                parser.removeErrorListeners()
+                parser.addErrorListener(object : BaseErrorListener() {
+                    override fun syntaxError(
+                        p0: Recognizer<*, *>?,
+                        p1: Any?,
+                        line: Int,
+                        charPositionInLine: Int,
+                        errorMessage: String?,
+                        p5: RecognitionException?
+                    ) {
+                        errors.add(
+                            Error(
+                                ErrorType.SYNTACTIC, errorMessage
+                                    ?: "unspecified", position = Point(line, charPositionInLine).asPosition
+                            )
+                        )
+                    }
+                })
+            }.nanoseconds
+            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "PARSER", "END"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "PARSER", elapsedParser))
+            MainExecutionContext.log(
+                LazyLogEntry.producePerformanceAndUpdateAnalytics(
+                    logSource,
+                    ProgramUsageType.Parsing,
+                    "PARSER",
+                    elapsedParser
+                )
+            )
+            parser
+        }
         return parser
     }
 
     private fun verifyParseTree(parser: Parser, errors: MutableList<Error>, root: ParserRuleContext) {
         val callback = MainExecutionContext.getConfiguration().jarikoCallback
         val trace = JarikoTrace(JarikoTraceKind.Parsing, "CHKPTREE")
-        callback.startJarikoTrace(trace)
-        val logSource = { LogSourceData(executionProgramName, "") }
-        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "CHKPTREE", "START"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "CHKPTREE"))
-        val elapsed = measureNanoTime {
-            val commonTokenStream = parser.tokenStream as CommonTokenStream
-            val lastToken = commonTokenStream.get(commonTokenStream.index())
-            if (lastToken.type != Token.EOF) {
-                errors.add(Error(ErrorType.SYNTACTIC, "Not whole input consumed", lastToken!!.endPoint.asPosition))
-            }
-
-            root.processDescendantsAndErrors({
-                if (it.exception != null) {
-                    errors.add(Error(ErrorType.SYNTACTIC, "Recognition exception: ${it.exception.message}", it.start.startPoint.asPosition))
+        callback.traceBlock(trace) {
+            val logSource = { LogSourceData(executionProgramName, "") }
+            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "CHKPTREE", "START"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "CHKPTREE"))
+            val elapsed = measureNanoTime {
+                val commonTokenStream = parser.tokenStream as CommonTokenStream
+                val lastToken = commonTokenStream.get(commonTokenStream.index())
+                if (lastToken.type != Token.EOF) {
+                    errors.add(Error(ErrorType.SYNTACTIC, "Not whole input consumed", lastToken!!.endPoint.asPosition))
                 }
-            }, {
-                errors.add(Error(ErrorType.SYNTACTIC, "Error node found", it.toPosition(true)))
-            })
-        }.nanoseconds
-        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "CHKPTREE", "END"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "CHKPTREE", elapsed))
-        MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "CHKPTREE", elapsed))
-        callback.finishJarikoTrace()
+
+                root.processDescendantsAndErrors({
+                    if (it.exception != null) {
+                        errors.add(
+                            Error(
+                                ErrorType.SYNTACTIC,
+                                "Recognition exception: ${it.exception.message}",
+                                it.start.startPoint.asPosition
+                            )
+                        )
+                    }
+                }, {
+                    errors.add(Error(ErrorType.SYNTACTIC, "Error node found", it.toPosition(true)))
+                })
+            }.nanoseconds
+            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "CHKPTREE", "END"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "CHKPTREE", elapsed))
+            MainExecutionContext.log(
+                LazyLogEntry.producePerformanceAndUpdateAnalytics(
+                    logSource,
+                    ProgramUsageType.Parsing,
+                    "CHKPTREE",
+                    elapsed
+                )
+            )
+        }
     }
 
     private fun parseMute(code: String, errors: MutableList<Error>): MuteParser.MuteLineContext {
@@ -369,19 +427,27 @@ class RpgParserFacade {
             MainExecutionContext.getParsingProgramStack().peek().sourceLines = code.split("\\r\\n|\\n".toRegex())
         }
         val parser = createParser(BOMInputStream(code.byteInputStream(Charsets.UTF_8)), errors, longLines = true)
-        val root: RContext
         val callback = MainExecutionContext.getConfiguration().jarikoCallback
         val trace = JarikoTrace(JarikoTraceKind.Parsing, "RCONTEXT")
-        callback.startJarikoTrace(trace)
-        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "RCONTEXT", "START"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "RCONTEXT"))
-        val elapsedRoot = measureNanoTime {
-            root = parser.r()
-        }.nanoseconds
-        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "RCONTEXT", "END"))
-        MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "RCONTEXT", elapsedRoot))
-        MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "RCONTEXT", elapsedRoot))
-        callback.finishJarikoTrace()
+        val root = callback.traceBlock(trace) {
+            val root: RContext
+            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "RCONTEXT", "START"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "RCONTEXT"))
+            val elapsedRoot = measureNanoTime {
+                root = parser.r()
+            }.nanoseconds
+            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "RCONTEXT", "END"))
+            MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "RCONTEXT", elapsedRoot))
+            MainExecutionContext.log(
+                LazyLogEntry.producePerformanceAndUpdateAnalytics(
+                    logSource,
+                    ProgramUsageType.Parsing,
+                    "RCONTEXT",
+                    elapsedRoot
+                )
+            )
+            root
+        }
         var mutes: MutesImmutableMap? = null
         if (muteSupport) {
             mutes = findMutes(code, errors)
@@ -398,16 +464,23 @@ class RpgParserFacade {
             if (compiledFile.exists()) {
                 val callback = MainExecutionContext.getConfiguration().jarikoCallback
                 val trace = JarikoTrace(JarikoTraceKind.Parsing, "AST")
-                callback.startJarikoTrace(trace)
-                val logSource = { LogSourceData(executionProgramName, "") }
-                MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "START"))
-                MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "AST"))
-                compiledFile.readBytes().createCompilationUnit().apply {
-                    val elapsed = (System.nanoTime() - start).nanoseconds
-                    MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "END"))
-                    MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "AST", elapsed))
-                    MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "AST", elapsed))
-                    callback.finishJarikoTrace()
+                callback.traceBlock(trace) {
+                    val logSource = { LogSourceData(executionProgramName, "") }
+                    MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "START"))
+                    MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "AST"))
+                    compiledFile.readBytes().createCompilationUnit().apply {
+                        val elapsed = (System.nanoTime() - start).nanoseconds
+                        MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "END"))
+                        MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "AST", elapsed))
+                        MainExecutionContext.log(
+                            LazyLogEntry.producePerformanceAndUpdateAnalytics(
+                                logSource,
+                                ProgramUsageType.Parsing,
+                                "AST",
+                                elapsed
+                            )
+                        )
+                    }
                 }
             } else {
                 null
@@ -438,39 +511,39 @@ class RpgParserFacade {
             result.dumpError()
         }
         return kotlin.runCatching {
-            val compilationUnit: CompilationUnit
             val logSource = { LogSourceData(executionProgramName, "") }
             val callback = MainExecutionContext.getConfiguration().jarikoCallback
             val trace = JarikoTrace(JarikoTraceKind.Parsing, "AST")
-            callback.startJarikoTrace(trace)
-            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "START"))
-            MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "AST"))
-            val elapsed = measureNanoTime {
-                compilationUnit = result.root!!.rContext.toAst(
-                    conf = MainExecutionContext.getConfiguration().options.toAstConfiguration,
-                    source = if (MainExecutionContext.getConfiguration().options.mustDumpSource()) {
-                        result.src
-                    } else {
-                        null
-                    },
-                    copyBlocks = if (MainExecutionContext.getParsingProgramStack().empty()) null else MainExecutionContext.getParsingProgramStack().peek().copyBlocks
-                ).apply {
-                    if (muteSupport) {
-                        val resolved = this.injectMuteAnnotation(result.root.muteContexts!!)
-                        if (muteVerbose) {
-                            val sorted = resolved.sortedWith(compareBy { it.muteLine })
-                            sorted.forEach {
-                                println("Mute annotation at line ${it.muteLine} attached to statement ${it.statementLine}")
+            callback.traceBlock(trace) {
+                val compilationUnit: CompilationUnit
+                MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "START"))
+                MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "AST"))
+                val elapsed = measureNanoTime {
+                    compilationUnit = result.root!!.rContext.toAst(
+                        conf = MainExecutionContext.getConfiguration().options.toAstConfiguration,
+                        source = if (MainExecutionContext.getConfiguration().options.mustDumpSource()) {
+                            result.src
+                        } else {
+                            null
+                        },
+                        copyBlocks = if (MainExecutionContext.getParsingProgramStack().empty()) null else MainExecutionContext.getParsingProgramStack().peek().copyBlocks
+                    ).apply {
+                        if (muteSupport) {
+                            val resolved = this.injectMuteAnnotation(result.root.muteContexts!!)
+                            if (muteVerbose) {
+                                val sorted = resolved.sortedWith(compareBy { it.muteLine })
+                                sorted.forEach {
+                                    println("Mute annotation at line ${it.muteLine} attached to statement ${it.statementLine}")
+                                }
                             }
                         }
                     }
-                }
-            }.nanoseconds
-            MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "END"))
-            MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "AST", elapsed))
-            MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "AST", elapsed))
-            callback.finishJarikoTrace()
-            compilationUnit
+                }.nanoseconds
+                MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "END"))
+                MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "AST", elapsed))
+                MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "AST", elapsed))
+                compilationUnit
+            }
         }.onFailure {
             throw AstCreatingException(result.src, it)
         }.getOrThrow()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
@@ -206,7 +206,7 @@ class RpgParserFacade {
         MainExecutionContext.log(LazyLogEntry.produceStatement(endLogSource, "RPGLOAD", "END"))
         MainExecutionContext.log(LazyLogEntry.produceParsingEnd(endLogSource, "RPGLOAD", elapsedLoad))
         MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(endLogSource, ProgramUsageType.Parsing, "RPGLOAD", elapsedLoad))
-        callback.finishJarikoTrace(rpgLoadTrace)
+        callback.finishJarikoTrace()
 
         val lexerTrace = JarikoTrace(JarikoTraceKind.Parsing, "LEXER")
         callback.startJarikoTrace(lexerTrace)
@@ -228,7 +228,7 @@ class RpgParserFacade {
         MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "LEXER", "END"))
         MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "LEXER", elapsedLexer))
         MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "LEXER", elapsedLexer))
-        callback.finishJarikoTrace(lexerTrace)
+        callback.finishJarikoTrace()
 
         val parserTrace = JarikoTrace(JarikoTraceKind.Parsing, "PARSER")
         callback.startJarikoTrace(parserTrace)
@@ -249,7 +249,7 @@ class RpgParserFacade {
         MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "PARSER", "END"))
         MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "PARSER", elapsedParser))
         MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "PARSER", elapsedParser))
-        callback.finishJarikoTrace(parserTrace)
+        callback.finishJarikoTrace()
         return parser
     }
 
@@ -278,7 +278,7 @@ class RpgParserFacade {
         MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "CHKPTREE", "END"))
         MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "CHKPTREE", elapsed))
         MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "CHKPTREE", elapsed))
-        callback.finishJarikoTrace(trace)
+        callback.finishJarikoTrace()
     }
 
     private fun parseMute(code: String, errors: MutableList<Error>): MuteParser.MuteLineContext {
@@ -381,7 +381,7 @@ class RpgParserFacade {
         MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "RCONTEXT", "END"))
         MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "RCONTEXT", elapsedRoot))
         MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "RCONTEXT", elapsedRoot))
-        callback.finishJarikoTrace(trace)
+        callback.finishJarikoTrace()
         var mutes: MutesImmutableMap? = null
         if (muteSupport) {
             mutes = findMutes(code, errors)
@@ -407,7 +407,7 @@ class RpgParserFacade {
                     MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "END"))
                     MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "AST", elapsed))
                     MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "AST", elapsed))
-                    callback.finishJarikoTrace(trace)
+                    callback.finishJarikoTrace()
                 }
             } else {
                 null
@@ -469,7 +469,7 @@ class RpgParserFacade {
             MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "END"))
             MainExecutionContext.log(LazyLogEntry.produceParsingEnd(logSource, "AST", elapsed))
             MainExecutionContext.log(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Parsing, "AST", elapsed))
-            callback.finishJarikoTrace(trace)
+            callback.finishJarikoTrace()
             compilationUnit
         }.onFailure {
             throw AstCreatingException(result.src, it)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -926,6 +926,41 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun traceMainExecutionContextTest() {
+        val traces = mutableListOf<JarikoTrace>()
+        val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }
+        val configuration = Configuration().apply {
+            jarikoCallback.startJarikoTrace = { trace ->
+                traces.add(trace)
+            }
+        }
+        executePgm("TRACETST1", configuration = configuration, systemInterface = systemInterface)
+        val mainExecutionTraces = traces.filter { it.kind == JarikoTraceKind.MainExecutionContext }
+
+        // Only one main execution context
+        assertEquals(mainExecutionTraces.size, 1)
+    }
+
+    @Test
+    fun traceRpgProgramTest() {
+        val traces = mutableListOf<JarikoTrace>()
+        val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }
+        val configuration = Configuration().apply {
+            jarikoCallback.startJarikoTrace = { trace ->
+                traces.add(trace)
+            }
+        }
+        executePgm("TRACETST1", configuration = configuration, systemInterface = systemInterface)
+        val rpgProgramTraces = traces.filter { it.kind == JarikoTraceKind.RpgProgram }
+
+        // TRACETST1, TRACETST2
+        assertEquals(rpgProgramTraces.size, 2)
+
+        assertEquals(rpgProgramTraces.filter { it.description == "TRACETST1" }.size, 1)
+        assertEquals(rpgProgramTraces.filter { it.description == "TRACETST2" }.size, 1)
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -73,11 +73,13 @@ class JarikoCallbackTest : AbstractTest() {
         val exitedTimes = mutableMapOf("CAL04" to 0, "CAL02" to 0)
         val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }
         executePgm(systemInterface = systemInterface, programName = "CAL04", configuration = Configuration().apply {
-            jarikoCallback.onEnterPgm = { programName: String, symbolTable: ISymbolTable ->
+            jarikoCallback.onEnterPgm = {
+                    programName: String, symbolTable: ISymbolTable ->
                 println("onEnterPgm - programName: $programName, symbolTable: $symbolTable")
                 enteredTimes[programName] = enteredTimes[programName]!! + 1
             }
-            jarikoCallback.onExitPgm = { programName: String, symbolTable: ISymbolTable, _: Throwable? ->
+            jarikoCallback.onExitPgm = {
+                    programName: String, symbolTable: ISymbolTable, _: Throwable? ->
                 println("onExitPgm - programName: $programName, symbolTable: $symbolTable")
                 exitedTimes[programName] = exitedTimes[programName]!! + 1
             }
@@ -108,12 +110,7 @@ class JarikoCallbackTest : AbstractTest() {
                         println("Program - relativeLineNumber: ${sourceReference.relativeLine}, lineNumber: $lineNumber")
                     }
                     val src = when (sourceReference.sourceReferenceType) {
-                        SourceReferenceType.Copy -> copyDefinitions[CopyId(
-                            member = sourceReference.sourceId.uppercase(
-                                Locale.getDefault()
-                            )
-                        )]
-
+                        SourceReferenceType.Copy -> copyDefinitions[CopyId(member = sourceReference.sourceId.uppercase(Locale.getDefault()))]
                         SourceReferenceType.Program -> pgm
                     }
                     require(src != null)
@@ -245,7 +242,6 @@ class JarikoCallbackTest : AbstractTest() {
             override fun findCopy(copyId: CopyId): Copy? {
                 return copyDefinitions[copyId]?.let { Copy.fromInputStream(it.byteInputStream(charset("UTF-8"))) }
             }
-
             override fun display(value: String) {
                 // println(value)
             }
@@ -259,24 +255,21 @@ class JarikoCallbackTest : AbstractTest() {
         var enteredTimes = 0
         var exitedTimes = 0
         val functionParams = mutableListOf<FunctionValue>()
-        executePgm(
-            systemInterface = systemInterface,
-            programName = "PROCEDURE1",
-            configuration = Configuration().apply {
-                jarikoCallback.onEnterFunction = { functionName: String, params: List<FunctionValue>, _: ISymbolTable ->
-                    enteredTimes++
-                    functionParams.addAll(params)
-                    Assert.assertEquals("CALL1", functionName)
-                    Assert.assertEquals(11, params[0].value.asInt().value)
-                    Assert.assertEquals(22, params[1].value.asInt().value)
-                    Assert.assertEquals(ZeroValue, params[2].value)
-                }
-                jarikoCallback.onExitFunction = { functionName: String, _: Value ->
-                    exitedTimes++
-                    Assert.assertEquals("CALL1", functionName)
-                    Assert.assertEquals(33, functionParams[2].value.asInt().value)
-                }
-            })
+        executePgm(systemInterface = systemInterface, programName = "PROCEDURE1", configuration = Configuration().apply {
+            jarikoCallback.onEnterFunction = { functionName: String, params: List<FunctionValue>, _: ISymbolTable ->
+                enteredTimes++
+                functionParams.addAll(params)
+                Assert.assertEquals("CALL1", functionName)
+                Assert.assertEquals(11, params[0].value.asInt().value)
+                Assert.assertEquals(22, params[1].value.asInt().value)
+                Assert.assertEquals(ZeroValue, params[2].value)
+            }
+            jarikoCallback.onExitFunction = { functionName: String, _: Value ->
+                exitedTimes++
+                Assert.assertEquals("CALL1", functionName)
+                Assert.assertEquals(33, functionParams[2].value.asInt().value)
+            }
+        })
         Assert.assertEquals(enteredTimes, exitedTimes)
     }
 
@@ -286,23 +279,20 @@ class JarikoCallbackTest : AbstractTest() {
         var enteredTimes = 0
         var exitedTimes = 0
         val functionParams = mutableListOf<FunctionValue>()
-        executePgm(
-            systemInterface = systemInterface,
-            programName = "PROCEDURE2",
-            configuration = Configuration().apply {
-                jarikoCallback.onEnterFunction = { functionName: String, params: List<FunctionValue>, _: ISymbolTable ->
-                    enteredTimes++
-                    functionParams.addAll(params)
-                    Assert.assertEquals("CALL1", functionName)
-                    Assert.assertEquals(11, params[0].value.asInt().value)
-                    Assert.assertEquals(22, params[1].value.asInt().value)
-                }
-                jarikoCallback.onExitFunction = { functionName: String, returnValue: Value ->
-                    exitedTimes++
-                    Assert.assertEquals("CALL1", functionName)
-                    Assert.assertEquals(33, returnValue.asInt().value)
-                }
-            })
+        executePgm(systemInterface = systemInterface, programName = "PROCEDURE2", configuration = Configuration().apply {
+            jarikoCallback.onEnterFunction = { functionName: String, params: List<FunctionValue>, _: ISymbolTable ->
+                enteredTimes++
+                functionParams.addAll(params)
+                Assert.assertEquals("CALL1", functionName)
+                Assert.assertEquals(11, params[0].value.asInt().value)
+                Assert.assertEquals(22, params[1].value.asInt().value)
+            }
+            jarikoCallback.onExitFunction = { functionName: String, returnValue: Value ->
+                exitedTimes++
+                Assert.assertEquals("CALL1", functionName)
+                Assert.assertEquals(33, returnValue.asInt().value)
+            }
+        })
         Assert.assertEquals(enteredTimes, exitedTimes)
     }
 
@@ -537,42 +527,34 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR23CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR23", SourceReferenceType.Program, "ERROR23", mapOf(
-                9 to "Factor 2 cannot be null at: Position(start=Line 9, Column 11, end=Line 9, Column 16) com.smeup.rpgparser.RpgParser\$FactorContext",
-                14 to "Factor 1 cannot be null at: Position(start=Line 14, Column 11, end=Line 14, Column 25) com.smeup.rpgparser.RpgParser\$FactorContext"
-            )
-        )
+        executePgmCallBackTest("ERROR23", SourceReferenceType.Program, "ERROR23", mapOf(
+            9 to "Factor 2 cannot be null at: Position(start=Line 9, Column 11, end=Line 9, Column 16) com.smeup.rpgparser.RpgParser\$FactorContext",
+            14 to "Factor 1 cannot be null at: Position(start=Line 14, Column 11, end=Line 14, Column 25) com.smeup.rpgparser.RpgParser\$FactorContext"
+        ))
     }
 
     @Test
     fun executeERROR24CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR24", SourceReferenceType.Program, "ERROR24", mapOf(
-                8 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
-                9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
-            )
-        )
+        executePgmCallBackTest("ERROR24", SourceReferenceType.Program, "ERROR24", mapOf(
+            8 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
+            9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
+        ))
     }
 
     @Test
     fun executeERROR25CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR25", SourceReferenceType.Program, "ERROR25", mapOf(
-                8 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
-                9 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
-            )
-        )
+        executePgmCallBackTest("ERROR25", SourceReferenceType.Program, "ERROR25", mapOf(
+            8 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
+            9 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
+        ))
     }
 
     @Test
     fun executeERROR26CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR26", SourceReferenceType.Program, "ERROR26", mapOf(
-                8 to "For ISO format the date must be between 0001 and 9999 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
-                9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
-            )
-        )
+        executePgmCallBackTest("ERROR26", SourceReferenceType.Program, "ERROR26", mapOf(
+            8 to "For ISO format the date must be between 0001 and 9999 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
+            9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
+        ))
     }
 
     @Test
@@ -582,13 +564,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR27CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR27", SourceReferenceType.Program, "ERROR27", mapOf(
-                10 to "No element of the collection was transformed to a non-null value.",
-                11 to "An operation is not implemented: IN£UDLDA                           \n" +
-                        " at Position(start=Line 11, Column 25, end=Line 11, Column 81) com.smeup.rpgparser.RpgParser\$Cspec_fixed_standardContext"
-            )
-        )
+        executePgmCallBackTest("ERROR27", SourceReferenceType.Program, "ERROR27", mapOf(
+            10 to "No element of the collection was transformed to a non-null value.",
+            11 to "An operation is not implemented: IN£UDLDA                           \n" +
+                    " at Position(start=Line 11, Column 25, end=Line 11, Column 81) com.smeup.rpgparser.RpgParser\$Cspec_fixed_standardContext"
+        ))
     }
 
     @Test
@@ -598,11 +578,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR29CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR29", SourceReferenceType.Program, "ERROR29", mapOf(
-                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-            )
-        )
+        executePgmCallBackTest("ERROR29", SourceReferenceType.Program, "ERROR29", mapOf(
+            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+        ))
     }
 
     @Test
@@ -612,11 +590,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR30CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR30", SourceReferenceType.Program, "ERROR30", mapOf(
-                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-            )
-        )
+        executePgmCallBackTest("ERROR30", SourceReferenceType.Program, "ERROR30", mapOf(
+            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+        ))
     }
 
     @Test
@@ -626,11 +602,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR31CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR31", SourceReferenceType.Program, "ERROR31", mapOf(
-                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-            )
-        )
+        executePgmCallBackTest("ERROR31", SourceReferenceType.Program, "ERROR31", mapOf(
+            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+        ))
     }
 
     @Test
@@ -640,11 +614,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR32CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR32", SourceReferenceType.Program, "ERROR32", mapOf(
-                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-            )
-        )
+        executePgmCallBackTest("ERROR32", SourceReferenceType.Program, "ERROR32", mapOf(
+            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+        ))
     }
 
     @Test
@@ -654,11 +626,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR33CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR33", SourceReferenceType.Program, "ERROR33", mapOf(
-                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-            )
-        )
+        executePgmCallBackTest("ERROR33", SourceReferenceType.Program, "ERROR33", mapOf(
+            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+        ))
     }
 
     @Test
@@ -668,11 +638,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR34CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR34", SourceReferenceType.Program, "ERROR34", mapOf(
-                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-            )
-        )
+        executePgmCallBackTest("ERROR34", SourceReferenceType.Program, "ERROR34", mapOf(
+            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+        ))
     }
 
     @Test
@@ -686,8 +654,7 @@ class JarikoCallbackTest : AbstractTest() {
             pgm = "ERROR35",
             sourceReferenceType = SourceReferenceType.Program,
             sourceId = "ERROR35",
-            lines = listOf(9, 10)
-        )
+            lines = listOf(9, 10))
     }
 
     @Test
@@ -760,11 +727,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR41CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR41", SourceReferenceType.Program, "ERROR41", mapOf(
-                24 to "Cannot coerce sub-string `0052 ` to NumberType(entireDigits=3, decimalDigits=2, rpgType=S)."
-            )
-        )
+        executePgmCallBackTest("ERROR41", SourceReferenceType.Program, "ERROR41", mapOf(
+            24 to "Cannot coerce sub-string `0052 ` to NumberType(entireDigits=3, decimalDigits=2, rpgType=S)."
+        ))
     }
 
     @Test
@@ -774,11 +739,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR42CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR42", SourceReferenceType.Program, "ERROR42", mapOf(
-                24 to "Cannot coerce sub-string `0052 ` to NumberType(entireDigits=3, decimalDigits=2, rpgType=S)."
-            )
-        )
+        executePgmCallBackTest("ERROR42", SourceReferenceType.Program, "ERROR42", mapOf(
+            24 to "Cannot coerce sub-string `0052 ` to NumberType(entireDigits=3, decimalDigits=2, rpgType=S)."
+        ))
     }
 
     @Test
@@ -788,11 +751,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR43CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR43", SourceReferenceType.Program, "ERROR43", mapOf(
-                23 to "Cannot coerce sub-string `0005 ` to NumberType(entireDigits=5, decimalDigits=0, rpgType=S)."
-            )
-        )
+        executePgmCallBackTest("ERROR43", SourceReferenceType.Program, "ERROR43", mapOf(
+            23 to "Cannot coerce sub-string `0005 ` to NumberType(entireDigits=5, decimalDigits=0, rpgType=S)."
+        ))
     }
 
     @Test
@@ -802,11 +763,9 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR44CallBackTest() {
-        executePgmCallBackTest(
-            "ERROR44", SourceReferenceType.Program, "ERROR44", mapOf(
-                8 to "Error calling program or procedure - Could not find program MISSING"
-            )
-        )
+        executePgmCallBackTest("ERROR44", SourceReferenceType.Program, "ERROR44", mapOf(
+            8 to "Error calling program or procedure - Could not find program MISSING"
+        ))
     }
 
     @Test
@@ -1045,10 +1004,8 @@ class JarikoCallbackTest : AbstractTest() {
      * to mock another kind of encoding error
      */
     @Test
-    @Ignore(
-        "This test is not working because the encoding error in ERROR28.rpgle was " +
-                "due to the fact that we will try to compile also ast with errors"
-    )
+    @Ignore("This test is not working because the encoding error in ERROR28.rpgle was " +
+            "due to the fact that we will try to compile also ast with errors")
     fun onCompilationUnitEncodingErrorTest() {
         // Flags to track if callbacks are triggered
         var enteredInOnCompilationUnitEncodingError = false

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -904,6 +904,22 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun traceSubroutineTest() {
+        val traces = mutableListOf<JarikoTrace>()
+        val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }
+        val configuration = Configuration().apply {
+            jarikoCallback.startJarikoTrace = { trace ->
+                traces.add(trace)
+            }
+        }
+        executePgm("TRACETST1", configuration = configuration, systemInterface = systemInterface)
+        val programTraces = traces.filter { it.kind == JarikoTraceKind.Subroutine }
+
+        // 1 subroutine call per program
+        assertEquals(programTraces.size, 2)
+    }
+
+    @Test
     fun traceParsingTest() {
         val traces = mutableListOf<JarikoTrace>()
         val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -73,13 +73,11 @@ class JarikoCallbackTest : AbstractTest() {
         val exitedTimes = mutableMapOf("CAL04" to 0, "CAL02" to 0)
         val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }
         executePgm(systemInterface = systemInterface, programName = "CAL04", configuration = Configuration().apply {
-            jarikoCallback.onEnterPgm = {
-                    programName: String, symbolTable: ISymbolTable ->
+            jarikoCallback.onEnterPgm = { programName: String, symbolTable: ISymbolTable ->
                 println("onEnterPgm - programName: $programName, symbolTable: $symbolTable")
                 enteredTimes[programName] = enteredTimes[programName]!! + 1
             }
-            jarikoCallback.onExitPgm = {
-                    programName: String, symbolTable: ISymbolTable, _: Throwable? ->
+            jarikoCallback.onExitPgm = { programName: String, symbolTable: ISymbolTable, _: Throwable? ->
                 println("onExitPgm - programName: $programName, symbolTable: $symbolTable")
                 exitedTimes[programName] = exitedTimes[programName]!! + 1
             }
@@ -110,7 +108,12 @@ class JarikoCallbackTest : AbstractTest() {
                         println("Program - relativeLineNumber: ${sourceReference.relativeLine}, lineNumber: $lineNumber")
                     }
                     val src = when (sourceReference.sourceReferenceType) {
-                        SourceReferenceType.Copy -> copyDefinitions[CopyId(member = sourceReference.sourceId.uppercase(Locale.getDefault()))]
+                        SourceReferenceType.Copy -> copyDefinitions[CopyId(
+                            member = sourceReference.sourceId.uppercase(
+                                Locale.getDefault()
+                            )
+                        )]
+
                         SourceReferenceType.Program -> pgm
                     }
                     require(src != null)
@@ -242,6 +245,7 @@ class JarikoCallbackTest : AbstractTest() {
             override fun findCopy(copyId: CopyId): Copy? {
                 return copyDefinitions[copyId]?.let { Copy.fromInputStream(it.byteInputStream(charset("UTF-8"))) }
             }
+
             override fun display(value: String) {
                 // println(value)
             }
@@ -255,21 +259,24 @@ class JarikoCallbackTest : AbstractTest() {
         var enteredTimes = 0
         var exitedTimes = 0
         val functionParams = mutableListOf<FunctionValue>()
-        executePgm(systemInterface = systemInterface, programName = "PROCEDURE1", configuration = Configuration().apply {
-            jarikoCallback.onEnterFunction = { functionName: String, params: List<FunctionValue>, _: ISymbolTable ->
-                enteredTimes++
-                functionParams.addAll(params)
-                Assert.assertEquals("CALL1", functionName)
-                Assert.assertEquals(11, params[0].value.asInt().value)
-                Assert.assertEquals(22, params[1].value.asInt().value)
-                Assert.assertEquals(ZeroValue, params[2].value)
-            }
-            jarikoCallback.onExitFunction = { functionName: String, _: Value ->
-                exitedTimes++
-                Assert.assertEquals("CALL1", functionName)
-                Assert.assertEquals(33, functionParams[2].value.asInt().value)
-            }
-        })
+        executePgm(
+            systemInterface = systemInterface,
+            programName = "PROCEDURE1",
+            configuration = Configuration().apply {
+                jarikoCallback.onEnterFunction = { functionName: String, params: List<FunctionValue>, _: ISymbolTable ->
+                    enteredTimes++
+                    functionParams.addAll(params)
+                    Assert.assertEquals("CALL1", functionName)
+                    Assert.assertEquals(11, params[0].value.asInt().value)
+                    Assert.assertEquals(22, params[1].value.asInt().value)
+                    Assert.assertEquals(ZeroValue, params[2].value)
+                }
+                jarikoCallback.onExitFunction = { functionName: String, _: Value ->
+                    exitedTimes++
+                    Assert.assertEquals("CALL1", functionName)
+                    Assert.assertEquals(33, functionParams[2].value.asInt().value)
+                }
+            })
         Assert.assertEquals(enteredTimes, exitedTimes)
     }
 
@@ -279,20 +286,23 @@ class JarikoCallbackTest : AbstractTest() {
         var enteredTimes = 0
         var exitedTimes = 0
         val functionParams = mutableListOf<FunctionValue>()
-        executePgm(systemInterface = systemInterface, programName = "PROCEDURE2", configuration = Configuration().apply {
-            jarikoCallback.onEnterFunction = { functionName: String, params: List<FunctionValue>, _: ISymbolTable ->
-                enteredTimes++
-                functionParams.addAll(params)
-                Assert.assertEquals("CALL1", functionName)
-                Assert.assertEquals(11, params[0].value.asInt().value)
-                Assert.assertEquals(22, params[1].value.asInt().value)
-            }
-            jarikoCallback.onExitFunction = { functionName: String, returnValue: Value ->
-                exitedTimes++
-                Assert.assertEquals("CALL1", functionName)
-                Assert.assertEquals(33, returnValue.asInt().value)
-            }
-        })
+        executePgm(
+            systemInterface = systemInterface,
+            programName = "PROCEDURE2",
+            configuration = Configuration().apply {
+                jarikoCallback.onEnterFunction = { functionName: String, params: List<FunctionValue>, _: ISymbolTable ->
+                    enteredTimes++
+                    functionParams.addAll(params)
+                    Assert.assertEquals("CALL1", functionName)
+                    Assert.assertEquals(11, params[0].value.asInt().value)
+                    Assert.assertEquals(22, params[1].value.asInt().value)
+                }
+                jarikoCallback.onExitFunction = { functionName: String, returnValue: Value ->
+                    exitedTimes++
+                    Assert.assertEquals("CALL1", functionName)
+                    Assert.assertEquals(33, returnValue.asInt().value)
+                }
+            })
         Assert.assertEquals(enteredTimes, exitedTimes)
     }
 
@@ -527,34 +537,42 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR23CallBackTest() {
-        executePgmCallBackTest("ERROR23", SourceReferenceType.Program, "ERROR23", mapOf(
-            9 to "Factor 2 cannot be null at: Position(start=Line 9, Column 11, end=Line 9, Column 16) com.smeup.rpgparser.RpgParser\$FactorContext",
-            14 to "Factor 1 cannot be null at: Position(start=Line 14, Column 11, end=Line 14, Column 25) com.smeup.rpgparser.RpgParser\$FactorContext"
-        ))
+        executePgmCallBackTest(
+            "ERROR23", SourceReferenceType.Program, "ERROR23", mapOf(
+                9 to "Factor 2 cannot be null at: Position(start=Line 9, Column 11, end=Line 9, Column 16) com.smeup.rpgparser.RpgParser\$FactorContext",
+                14 to "Factor 1 cannot be null at: Position(start=Line 14, Column 11, end=Line 14, Column 25) com.smeup.rpgparser.RpgParser\$FactorContext"
+            )
+        )
     }
 
     @Test
     fun executeERROR24CallBackTest() {
-        executePgmCallBackTest("ERROR24", SourceReferenceType.Program, "ERROR24", mapOf(
-            8 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
-            9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
-        ))
+        executePgmCallBackTest(
+            "ERROR24", SourceReferenceType.Program, "ERROR24", mapOf(
+                8 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
+                9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
+            )
+        )
     }
 
     @Test
     fun executeERROR25CallBackTest() {
-        executePgmCallBackTest("ERROR25", SourceReferenceType.Program, "ERROR25", mapOf(
-            8 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
-            9 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
-        ))
+        executePgmCallBackTest(
+            "ERROR25", SourceReferenceType.Program, "ERROR25", mapOf(
+                8 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
+                9 to "For JUL format the date must be between 1940 and 2039 at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
+            )
+        )
     }
 
     @Test
     fun executeERROR26CallBackTest() {
-        executePgmCallBackTest("ERROR26", SourceReferenceType.Program, "ERROR26", mapOf(
-            8 to "For ISO format the date must be between 0001 and 9999 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
-            9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
-        ))
+        executePgmCallBackTest(
+            "ERROR26", SourceReferenceType.Program, "ERROR26", mapOf(
+                8 to "For ISO format the date must be between 0001 and 9999 at: Position(start=Line 8, Column 5, end=Line 8, Column 81) com.smeup.rpgparser.RpgParser\$DspecContext",
+                9 to "Initialization value is incorrect. Must be 'YYYY-MM-DD' at: Position(start=Line 9, Column 5, end=Line 9, Column 85) com.smeup.rpgparser.RpgParser\$DspecContext"
+            )
+        )
     }
 
     @Test
@@ -564,11 +582,13 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR27CallBackTest() {
-        executePgmCallBackTest("ERROR27", SourceReferenceType.Program, "ERROR27", mapOf(
-            10 to "No element of the collection was transformed to a non-null value.",
-            11 to "An operation is not implemented: IN£UDLDA                           \n" +
-                    " at Position(start=Line 11, Column 25, end=Line 11, Column 81) com.smeup.rpgparser.RpgParser\$Cspec_fixed_standardContext"
-        ))
+        executePgmCallBackTest(
+            "ERROR27", SourceReferenceType.Program, "ERROR27", mapOf(
+                10 to "No element of the collection was transformed to a non-null value.",
+                11 to "An operation is not implemented: IN£UDLDA                           \n" +
+                        " at Position(start=Line 11, Column 25, end=Line 11, Column 81) com.smeup.rpgparser.RpgParser\$Cspec_fixed_standardContext"
+            )
+        )
     }
 
     @Test
@@ -578,9 +598,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR29CallBackTest() {
-        executePgmCallBackTest("ERROR29", SourceReferenceType.Program, "ERROR29", mapOf(
-            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-        ))
+        executePgmCallBackTest(
+            "ERROR29", SourceReferenceType.Program, "ERROR29", mapOf(
+                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+            )
+        )
     }
 
     @Test
@@ -590,9 +612,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR30CallBackTest() {
-        executePgmCallBackTest("ERROR30", SourceReferenceType.Program, "ERROR30", mapOf(
-            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-        ))
+        executePgmCallBackTest(
+            "ERROR30", SourceReferenceType.Program, "ERROR30", mapOf(
+                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+            )
+        )
     }
 
     @Test
@@ -602,9 +626,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR31CallBackTest() {
-        executePgmCallBackTest("ERROR31", SourceReferenceType.Program, "ERROR31", mapOf(
-            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-        ))
+        executePgmCallBackTest(
+            "ERROR31", SourceReferenceType.Program, "ERROR31", mapOf(
+                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+            )
+        )
     }
 
     @Test
@@ -614,9 +640,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR32CallBackTest() {
-        executePgmCallBackTest("ERROR32", SourceReferenceType.Program, "ERROR32", mapOf(
-            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-        ))
+        executePgmCallBackTest(
+            "ERROR32", SourceReferenceType.Program, "ERROR32", mapOf(
+                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+            )
+        )
     }
 
     @Test
@@ -626,9 +654,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR33CallBackTest() {
-        executePgmCallBackTest("ERROR33", SourceReferenceType.Program, "ERROR33", mapOf(
-            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-        ))
+        executePgmCallBackTest(
+            "ERROR33", SourceReferenceType.Program, "ERROR33", mapOf(
+                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+            )
+        )
     }
 
     @Test
@@ -638,9 +668,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR34CallBackTest() {
-        executePgmCallBackTest("ERROR34", SourceReferenceType.Program, "ERROR34", mapOf(
-            11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
-        ))
+        executePgmCallBackTest(
+            "ERROR34", SourceReferenceType.Program, "ERROR34", mapOf(
+                11 to "MOVE/MOVEL for BooleanType have to be 0, 1 or blank"
+            )
+        )
     }
 
     @Test
@@ -654,7 +686,8 @@ class JarikoCallbackTest : AbstractTest() {
             pgm = "ERROR35",
             sourceReferenceType = SourceReferenceType.Program,
             sourceId = "ERROR35",
-            lines = listOf(9, 10))
+            lines = listOf(9, 10)
+        )
     }
 
     @Test
@@ -727,9 +760,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR41CallBackTest() {
-        executePgmCallBackTest("ERROR41", SourceReferenceType.Program, "ERROR41", mapOf(
-            24 to "Cannot coerce sub-string `0052 ` to NumberType(entireDigits=3, decimalDigits=2, rpgType=S)."
-        ))
+        executePgmCallBackTest(
+            "ERROR41", SourceReferenceType.Program, "ERROR41", mapOf(
+                24 to "Cannot coerce sub-string `0052 ` to NumberType(entireDigits=3, decimalDigits=2, rpgType=S)."
+            )
+        )
     }
 
     @Test
@@ -739,9 +774,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR42CallBackTest() {
-        executePgmCallBackTest("ERROR42", SourceReferenceType.Program, "ERROR42", mapOf(
-            24 to "Cannot coerce sub-string `0052 ` to NumberType(entireDigits=3, decimalDigits=2, rpgType=S)."
-        ))
+        executePgmCallBackTest(
+            "ERROR42", SourceReferenceType.Program, "ERROR42", mapOf(
+                24 to "Cannot coerce sub-string `0052 ` to NumberType(entireDigits=3, decimalDigits=2, rpgType=S)."
+            )
+        )
     }
 
     @Test
@@ -751,9 +788,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR43CallBackTest() {
-        executePgmCallBackTest("ERROR43", SourceReferenceType.Program, "ERROR43", mapOf(
-            23 to "Cannot coerce sub-string `0005 ` to NumberType(entireDigits=5, decimalDigits=0, rpgType=S)."
-        ))
+        executePgmCallBackTest(
+            "ERROR43", SourceReferenceType.Program, "ERROR43", mapOf(
+                23 to "Cannot coerce sub-string `0005 ` to NumberType(entireDigits=5, decimalDigits=0, rpgType=S)."
+            )
+        )
     }
 
     @Test
@@ -763,9 +802,11 @@ class JarikoCallbackTest : AbstractTest() {
 
     @Test
     fun executeERROR44CallBackTest() {
-        executePgmCallBackTest("ERROR44", SourceReferenceType.Program, "ERROR44", mapOf(
-            8 to "Error calling program or procedure - Could not find program MISSING"
-        ))
+        executePgmCallBackTest(
+            "ERROR44", SourceReferenceType.Program, "ERROR44", mapOf(
+                8 to "Error calling program or procedure - Could not find program MISSING"
+            )
+        )
     }
 
     @Test
@@ -776,40 +817,39 @@ class JarikoCallbackTest : AbstractTest() {
     @Test
     fun traceEmittedTest() {
         val startTraces = mutableListOf<JarikoTrace>()
-        val finishTraces = mutableListOf<JarikoTrace>()
+        var finishCount = 0
 
         val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }
         val configuration = Configuration().apply {
             jarikoCallback.startJarikoTrace = { trace ->
                 startTraces.add(trace)
             }
-            jarikoCallback.finishJarikoTrace = { trace ->
-                finishTraces.add(trace)
+            jarikoCallback.finishJarikoTrace = {
+                finishCount += 1
             }
         }
         executePgm("TRACETST1", configuration = configuration, systemInterface = systemInterface)
 
         assert(startTraces.isNotEmpty())
-        assert(finishTraces.isNotEmpty())
+        assert(finishCount > 0)
     }
 
     @Test
     fun traceOpenedAlsoClosedTest() {
         val startTraces = mutableListOf<JarikoTrace>()
-        val finishTraces = mutableListOf<JarikoTrace>()
+        var finishCount = 0
 
         val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }
         val configuration = Configuration().apply {
             jarikoCallback.startJarikoTrace = { trace ->
                 startTraces.add(trace)
             }
-            jarikoCallback.finishJarikoTrace = { trace ->
-                finishTraces.add(trace)
+            jarikoCallback.finishJarikoTrace = {
+                finishCount += 1
             }
         }
         executePgm("TRACETST1", configuration = configuration, systemInterface = systemInterface)
-        assert(startTraces.containsAll(finishTraces))
-        assert(finishTraces.containsAll(startTraces))
+        assertEquals(startTraces.size, finishCount)
     }
 
     @Test
@@ -989,8 +1029,10 @@ class JarikoCallbackTest : AbstractTest() {
      * to mock another kind of encoding error
      */
     @Test
-    @Ignore("This test is not working because the encoding error in ERROR28.rpgle was " +
-            "due to the fact that we will try to compile also ast with errors")
+    @Ignore(
+        "This test is not working because the encoding error in ERROR28.rpgle was " +
+                "due to the fact that we will try to compile also ast with errors"
+    )
     fun onCompilationUnitEncodingErrorTest() {
         // Flags to track if callbacks are triggered
         var enteredInOnCompilationUnitEncodingError = false

--- a/rpgJavaInterpreter-core/src/test/resources/TRACETST1.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/TRACETST1.rpgle
@@ -5,10 +5,16 @@
     O * Perform tracing
      V* ==============================================================
      D $A              S              2
+     DCALL1            PR
+     Da                               2  0
+     Db                               2  0
+
      C                   EXSR      SR
 
      C     SR            BEGSR
      C     1             IFEQ      1
+     C                   CALLP     CALL1(5:6)
+     C                   EVAL      $A=CALL1(5:6)
      C                   EVAL      $A = '5'
      C                   CALL      'TRACETST2'
      C     0             IFGT      1
@@ -18,3 +24,10 @@
      C                   ENDIF
      C                   ENDSR
      C                   SETON                                          LR
+
+     PCALL1            B
+     DCALL1            PI
+     Da                               2  0
+     Db                               2  0
+     C                   RETURN    a+b
+     PCALL1            E

--- a/rpgJavaInterpreter-core/src/test/resources/TRACETST1.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/TRACETST1.rpgle
@@ -1,0 +1,20 @@
+     V* ==============================================================
+     V* 04/11/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Perform tracing
+     V* ==============================================================
+     D $A              S              2
+     C                   EXSR      SR
+
+     C     SR            BEGSR
+     C     1             IFEQ      1
+     C                   EVAL      $A = '5'
+     C                   CALL      'TRACETST2'
+     C     0             IFGT      1
+     C     $A            DSPLY
+     C                   ENDIF
+     C     '1'           DSPLY
+     C                   ENDIF
+     C                   ENDSR
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/TRACETST2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/TRACETST2.rpgle
@@ -1,0 +1,19 @@
+     V* ==============================================================
+     V* 04/11/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Perform tracing
+     V* ==============================================================
+     D $A              S              2
+     C                   EXSR      SR
+
+     C     SR            BEGSR
+     C     1             IFEQ      1
+     C                   EVAL      $A = '5'
+     C     0             IFGT      1
+     C     $A            DSPLY
+     C                   ENDIF
+     C     '1'           DSPLY
+     C                   ENDIF
+     C                   ENDSR
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description

Add support for telemetry traces emission. Telemetry can be of 2 types:
- Jariko traces: emitted when the interpreter executes specific types of instructions
- RPG traces: emitted when a certain annotation is encountered in an RPG program

Specifically Jariko traces are emitted whenever we execute:
- A parsing step.
- Symbol table initialization.
- A program.
- A subroutine.
- A procedure.
- A composite statement (statements containing other statements, e.g.: IF, FOR, DO and so on).

> At the moment only Jariko traces are fully supported. Rpg traces are only defined conceptually as a planned feature and will be supported in a subsequent release.

### Technical notes

Changes consist in:

- The addition of 4 new callbacks in `JarikoCallback`, namely: `startJarikoTrace`, `finishJarikoTrace`, `startRpgTrace`, `finishRpgTrace`.
- The addition of 3 new models: `JarikoTrace`, `RpgTrace`, `JarikoTraceKind`
- All the logic to emit `JarikoTrace`s with related unit tests

Related to:
- LS24004723

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
