### PR TITLE
Bugfix/LS24004772/`MOVEA` from `ProjectedArrayValue` to `ConcreteArrayValue`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -250,7 +250,7 @@ fun coerce(value: Value, type: Type): Value {
                 }
                 is ArrayType -> {
                     val coercedValue = coerce(value, type.element)
-                    ConcreteArrayValue(MutableList(type.element.size) { coercedValue }, type.element)
+                    ConcreteArrayValue(MutableList(type.nElements) { coercedValue }, type.element)
                 }
                 else -> TODO("Converting DecimalValue to $type")
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/move_a.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/move_a.kt
@@ -158,24 +158,23 @@ private fun valueFromSourceExpression(interpreterCore: InterpreterCore, valueExp
 }
 
 /**
- * Performs type coercion on the `sourceValue` to match the `targetType` according to specific
- * conversion rules, particularly for numeric types with differing decimal precision. This function
- * handles conversions from decimal to integer and from integer to decimal based on the specified
- * `sourceType` and `targetType`.
+ * Coerces `sourceValue` to match `targetType` based on specified numeric conversion rules, especially
+ * for conversions between decimal and integer types with varying decimal precision. This function
+ * validates that the number of digits between `sourceType` and `targetType` are equal before performing
+ * the conversion.
  *
- * @param sourceValue The initial `Value` to be coerced. Expected to be a numeric type such as
- *        `DecimalValue` or `IntValue`.
- * @param targetType The `Type` representing the desired target type for the coercion. If the
- *        `targetType` is a `NumberType` with zero decimal places, the function may perform a
- *        decimal-to-integer conversion; otherwise, it may perform an integer-to-decimal conversion.
- * @param sourceType The `Type` representing the initial type of `sourceValue`, used to guide
- *        the coercion process and determine the scale of conversion required.
+ * @param sourceValue The `Value` to be coerced, generally a numeric type such as `DecimalValue` or `IntValue`.
+ * @param targetType The target `Type` for the coercion, used to guide the conversion, particularly
+ *                   regarding the number of decimal places.
+ * @param sourceType The `Type` representing the original type of `sourceValue`, assisting in determining
+ *                   the required scale and format for conversion.
  *
- * @return The `Value` resulting from the coercion, with adjustments made to decimal places as
- *         necessary to match the `targetType`.
+ * @return The resulting `Value` after coercion, transformed to align with `targetType`.
  *
- * @throws ClassCastException if `sourceValue` is not a `DecimalValue` or `IntValue`, or if
- *         `targetType` or `sourceType` are not of numeric types.
+ * @throws IllegalStateException if the total number of digits between `sourceType` and `targetType`
+ *                               do not match, indicating incompatible numeric sizes for conversion.
+ * @throws ClassCastException if `sourceValue` is not a `DecimalValue` or `IntValue`, or if `targetType`
+ *                            or `sourceType` are not of numeric types.
  */
 private fun internalCoercing(
     sourceValue: Value,
@@ -183,6 +182,11 @@ private fun internalCoercing(
     sourceType: Type
 ): Value {
     var result = sourceValue
+
+    // Number of digits between source and target must be equals.
+    if (sourceType is NumberType && targetType is NumberType && sourceType.numberOfDigits != targetType.numberOfDigits) {
+        throw IllegalStateException("Factor 2 and Result with different type and size.")
+    }
 
     // Proper conversion between a left side as decimal to right side as integer
     if (sourceValue is DecimalValue && sourceType is NumberType && targetType is NumberType && targetType.decimalDigits == 0) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/move_a.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/move_a.kt
@@ -62,8 +62,8 @@ private fun moveaNumber(
             targetArray.getElement(it + 1)
         } else {
             val newValueIndex = it - startIndex + 1
-            if (newValueIndex < newValue.elements.size) {
-                newValue.elements[newValueIndex]
+            if (newValueIndex < newValue.arrayLength()) {
+                newValue.getElement(newValueIndex + 1)
             } else {
                 if (operationExtenter == null) {
                     targetArray.getElement(it + 1)
@@ -76,7 +76,7 @@ private fun moveaNumber(
     return arrayValue
 }
 
-private fun InterpreterCore.toArray(expression: Expression, targetType: Type): ConcreteArrayValue =
+private fun InterpreterCore.toArray(expression: Expression, targetType: Type): ArrayValue =
     when (expression) {
         is ArrayAccessExpr -> {
             val arrayValueRaw = eval(expression.array)
@@ -90,7 +90,7 @@ private fun InterpreterCore.toArray(expression: Expression, targetType: Type): C
         }
         is DataRefExpr -> {
             if (expression.type() is ArrayType) {
-                eval(expression) as ConcreteArrayValue
+                eval(expression) as ArrayValue
             } else {
                 ConcreteArrayValue(mutableListOf(eval(expression)), expression.type())
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/move_a.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/move_a.kt
@@ -1,7 +1,6 @@
 package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.parsing.ast.*
-import java.math.BigDecimal
 import kotlin.math.pow
 
 fun movea(operationExtenter: String?, target: AssignableExpression, valueExpression: Expression, interpreterCore: InterpreterCore): Value {
@@ -181,19 +180,18 @@ private fun internalCoercing(
     targetType: Type,
     sourceType: Type
 ): Value {
-    var result = sourceValue
-
     // Number of digits between source and target must be equals.
     if (sourceType is NumberType && targetType is NumberType && sourceType.numberOfDigits != targetType.numberOfDigits) {
         throw IllegalStateException("Factor 2 and Result with different type and size.")
     }
 
-    // Proper conversion between a left side as decimal to right side as integer
-    if (sourceValue is DecimalValue && sourceType is NumberType && targetType is NumberType && targetType.decimalDigits == 0) {
-        result = DecimalValue(sourceValue.value * BigDecimal(10.0.pow((targetType.entireDigits - sourceType.entireDigits).toDouble())))
-    // Or integer to decimal
-    } else if (sourceValue is IntValue && targetType is NumberType && targetType.decimalDigits > 0) {
-        result = DecimalValue((sourceValue.value / 10.0.pow((targetType.decimalDigits))).toBigDecimal())
+    return when {
+        // Proper conversion between a left side as decimal to right side as integer
+        sourceValue is DecimalValue && sourceType is NumberType && targetType is NumberType && targetType.decimalDigits == 0 ->
+            DecimalValue(sourceValue.value * 10.0.pow(targetType.entireDigits - sourceType.entireDigits).toBigDecimal())
+        // Or integer to decimal
+        sourceValue is IntValue && targetType is NumberType && targetType.decimalDigits > 0 ->
+            DecimalValue((sourceValue.value / 10.0.pow(targetType.decimalDigits)).toBigDecimal())
+        else -> sourceValue
     }
-    return result
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/move_a.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/move_a.kt
@@ -1,6 +1,9 @@
 package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.parsing.ast.*
+import java.lang.Math.pow
+import java.math.BigDecimal
+import kotlin.math.pow
 
 fun movea(operationExtenter: String?, target: AssignableExpression, valueExpression: Expression, interpreterCore: InterpreterCore): Value {
     return when (target) {
@@ -62,7 +65,7 @@ private fun moveaNumber(
             targetArray.getElement(it + 1)
         } else {
             val newValueIndex = it - startIndex + 1
-            if (newValueIndex < newValue.arrayLength()) {
+            var elementValue = if (newValueIndex < newValue.arrayLength()) {
                 newValue.getElement(newValueIndex + 1)
             } else {
                 if (operationExtenter == null) {
@@ -71,6 +74,11 @@ private fun moveaNumber(
                     IntValue.ZERO
                 }
             }
+            // Proper conversion between a left side decimal to right side integer
+            if (elementValue is DecimalValue && targetArray.elementType is NumberType && (targetArray.elementType as NumberType).decimalDigits == 0) {
+                elementValue = DecimalValue(elementValue.value * BigDecimal(10.0.pow(((targetArray.elementType as NumberType).entireDigits - (newValue.elementType as NumberType).entireDigits).toDouble())))
+            }
+            elementValue
         }
     }
     return arrayValue

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -774,6 +774,18 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR45CallBackTest() {
+        executePgmCallBackTest("ERROR45", SourceReferenceType.Program, "ERROR45", mapOf(
+            8 to "Factor 2 and Result with different type and size."
+        ))
+    }
+
+    @Test
+    fun executeERROR45SourceLineTest() {
+        executeSourceLineTest("ERROR45")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -776,7 +776,7 @@ class JarikoCallbackTest : AbstractTest() {
     @Test
     fun executeERROR45CallBackTest() {
         executePgmCallBackTest("ERROR45", SourceReferenceType.Program, "ERROR45", mapOf(
-            8 to "Factor 2 and Result with different type and size."
+            18 to "Factor 2 and Result with different type and size."
         ))
     }
 
@@ -788,7 +788,7 @@ class JarikoCallbackTest : AbstractTest() {
     @Test
     fun executeERROR46CallBackTest() {
         executePgmCallBackTest("ERROR46", SourceReferenceType.Program, "ERROR46", mapOf(
-            8 to "Factor 2 and Result with different type and size."
+            18 to "Factor 2 and Result with different type and size."
         ))
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -786,6 +786,18 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR46CallBackTest() {
+        executePgmCallBackTest("ERROR46", SourceReferenceType.Program, "ERROR46", mapOf(
+            8 to "Factor 2 and Result with different type and size."
+        ))
+    }
+
+    @Test
+    fun executeERROR46SourceLineTest() {
+        executeSourceLineTest("ERROR46")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -558,4 +558,15 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("2", "2", "2", "2", "2", "1", "1", "1", "1", "1")
         assertEquals(expected, "smeup/MUDRNRAPU00155".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * MOVEA between a DS field declared as array and a standalone array. Both as integer.
+     * Size of DS field as array is lower than standalone.
+     * @see #LS24004772
+     */
+    @Test
+    fun executeMUDRNRAPU00156() {
+        val expected = listOf("2", "2", "2", "2", "2", "1", "1", "1", "0", "0")
+        assertEquals(expected, "smeup/MUDRNRAPU00156".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -548,4 +548,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("1", "1", "1", "1", "1", "1", "2", "2")
         assertEquals(expected, "smeup/MUDRNRAPU00148".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * MOVEA between a DS field declared as array and a standalone array. Both as integer.
+     * @see #LS24004772
+     */
+    @Test
+    fun executeMUDRNRAPU00155() {
+        val expected = listOf("2", "2", "2", "2", "2", "1", "1", "1", "1", "1")
+        assertEquals(expected, "smeup/MUDRNRAPU00155".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -570,8 +570,6 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         assertEquals(expected, "smeup/MUDRNRAPU00156".outputOf(configuration = smeupConfig))
     }
 
-
-
     /**
      * MOVEA between a DS field declared as array and a standalone array. Both as integer.
      * Size of DS field as array is greater than standalone.
@@ -581,5 +579,17 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     fun executeMUDRNRAPU00157() {
         val expected = listOf("2", "2", "2", "1", "1", "1")
         assertEquals(expected, "smeup/MUDRNRAPU00157".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * MOVEA between a DS field declared as array and a standalone array. DS field array is declared as decimal;
+     *  standalone array as integer.
+     * Size of DS field as array is lower than standalone.
+     * @see #LS24004772
+     */
+    @Test
+    fun executeMUDRNRAPU00158() {
+        val expected = listOf("2", "2", "2", "2", "2", "1200", "1200", "1200", "0", "0")
+        assertEquals(expected, "smeup/MUDRNRAPU00158".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -569,4 +569,17 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("2", "2", "2", "2", "2", "1", "1", "1", "0", "0")
         assertEquals(expected, "smeup/MUDRNRAPU00156".outputOf(configuration = smeupConfig))
     }
+
+
+
+    /**
+     * MOVEA between a DS field declared as array and a standalone array. Both as integer.
+     * Size of DS field as array is greater than standalone.
+     * @see #LS24004772
+     */
+    @Test
+    fun executeMUDRNRAPU00157() {
+        val expected = listOf("2", "2", "2", "1", "1", "1")
+        assertEquals(expected, "smeup/MUDRNRAPU00157".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -592,4 +592,16 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("2", "2", "2", "2", "2", "1200", "1200", "1200", "0", "0")
         assertEquals(expected, "smeup/MUDRNRAPU00158".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * MOVEA between a DS field declared as array and a standalone array. DS field array is declared as integer;
+     *  standalone array as decimal.
+     * Size of DS field as array is lower than standalone.
+     * @see #LS24004772
+     */
+    @Test
+    fun executeMUDRNRAPU00159() {
+        val expected = listOf("2.200", "2.200", "2.200", "2.200", "2.200", ".001", ".001", ".001", ".000", ".000")
+        assertEquals(expected, "smeup/MUDRNRAPU00159".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR45.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR45.rpgle
@@ -1,0 +1,25 @@
+     V* ==============================================================
+     D* 05/11/24
+     D* Purpose: Must fire the following errors during execution of
+     D* C                   MOVEA(P)  DS1_ARR1      ARR1
+     D* line 18 - "Factor 2 and Result with different type and size."
+     V* ==============================================================
+     D DS1             DS           100
+     D  DS1_ARR1                      5  3 DIM(3) INZ(12.345)
+     D ARR1            S              3  0 DIM(5) INZ(9)
+     D TMP             S              7
+     D COUNT           S              2  0 INZ(1)
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   MOVEA(P)  DS1_ARR1      ARR1
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR46.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR46.rpgle
@@ -1,0 +1,25 @@
+     V* ==============================================================
+     D* 05/11/24
+     D* Purpose: Must fire the following errors during execution of
+     D* C                   MOVEA(P)  DS1_ARR1      ARR1
+     D* line 18 - "Factor 2 and Result with different type and size."
+     V* ==============================================================
+     D DS1             DS           100
+     D  DS1_ARR1                      3  0 DIM(3) INZ(123)
+     D ARR1            S              5  3 DIM(5) INZ(9.9)
+     D TMP             S              7
+     D COUNT           S              2  0 INZ(1)
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   MOVEA(P)  DS1_ARR1      ARR1
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00155.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00155.rpgle
@@ -21,7 +21,7 @@
      C     TMP           DSPLY
      C                   ENDFOR
 
-     C                   MOVEA(P)  DS1_ARR1      ARR1
+     C                   MOVEA(P)  DS1_ARR1      ARR1                           #ProjectedArrayValue cannot be cast to class ConcreteArrayValue
 
      C                   FOR       COUNT=1 TO %ELEM(ARR1)
      C                   EVAL      TMP=%CHAR(ARR1(COUNT))

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00155.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00155.rpgle
@@ -1,0 +1,31 @@
+     V* ==============================================================
+     V* 05/11/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEA between a DS field declared as array and a standalone
+    O *  array. Both as integer.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix:
+    O *  `ProjectedArrayValue cannot be cast to
+    O *   class ConcreteArrayValue`
+     V* ==============================================================
+     D DS1             DS           100
+     D  DS1_ARR1                      2  0 DIM(5) INZ(1)
+     D ARR1            S              2  0 DIM(5) INZ(2)
+     D TMP             S              2
+     D COUNT           S              2  0 INZ(1)
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   MOVEA(P)  DS1_ARR1      ARR1
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00156.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00156.rpgle
@@ -1,0 +1,32 @@
+     V* ==============================================================
+     V* 05/11/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEA between a DS field declared as array and a standalone
+    O *  array. Both as integer.
+    O * Size of DS field as array is lower than standalone.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix:
+    O *  `ProjectedArrayValue cannot be cast to
+    O *   class ConcreteArrayValue`
+     V* ==============================================================
+     D DS1             DS           100
+     D  DS1_ARR1                      2  0 DIM(3) INZ(1)
+     D ARR1            S              2  0 DIM(5) INZ(2)
+     D TMP             S              2
+     D COUNT           S              2  0 INZ(1)
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   MOVEA(P)  DS1_ARR1      ARR1                           #ProjectedArrayValue cannot be cast to class ConcreteArrayValue
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00157.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00157.rpgle
@@ -1,0 +1,32 @@
+     V* ==============================================================
+     V* 05/11/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEA between a DS field declared as array and a standalone
+    O *  array. Both as integer.
+    O * Size of DS field as array is greater than standalone.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix:
+    O *  `ProjectedArrayValue cannot be cast to
+    O *   class ConcreteArrayValue`
+     V* ==============================================================
+     D DS1             DS           100
+     D  DS1_ARR1                      2  0 DIM(5) INZ(1)
+     D ARR1            S              2  0 DIM(3) INZ(2)
+     D TMP             S              2
+     D COUNT           S              2  0 INZ(1)
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   MOVEA(P)  DS1_ARR1      ARR1                           #ProjectedArrayValue cannot be cast to class ConcreteArrayValue
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00158.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00158.rpgle
@@ -1,0 +1,32 @@
+     V* ==============================================================
+     V* 05/11/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEA between a DS field declared as array and a standalone
+    O *  array. DS field array is declared as decimal;
+    O *  standalone array as integer.
+    O * Size of DS field as array is lower than standalone.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix:
+    O *  `Issue arose while setting field DS1_ARR1`
+     V* ==============================================================
+     D DS1             DS           100
+     D  DS1_ARR1                      5  3 DIM(3) INZ(1.2)
+     D ARR1            S              5  0 DIM(5) INZ(2)
+     D TMP             S              5
+     D COUNT           S              2  0 INZ(1)
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   MOVEA(P)  DS1_ARR1      ARR1                           #Issue arose while setting field DS1_ARR1
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00159.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00159.rpgle
@@ -1,0 +1,33 @@
+     V* ==============================================================
+     V* 05/11/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * MOVEA between a DS field declared as array and a standalone
+    O *  array. DS field array is declared as integer;
+    O *  standalone array as decimal.
+    O * Size of DS field as array is lower than standalone.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix:
+    O *  `ProjectedArrayValue cannot be cast to
+    O *   class ConcreteArrayValue`
+     V* ==============================================================
+     D DS1             DS           100
+     D  DS1_ARR1                      5  0 DIM(3) INZ(1)
+     D ARR1            S              5  3 DIM(5) INZ(2.2)
+     D TMP             S              5
+     D COUNT           S              2  0 INZ(1)
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   MOVEA(P)  DS1_ARR1      ARR1                           #ProjectedArrayValue cannot be cast to class ConcreteArrayValue
+
+     C                   FOR       COUNT=1 TO %ELEM(ARR1)
+     C                   EVAL      TMP=%CHAR(ARR1(COUNT))
+     C     TMP           DSPLY
+     C                   ENDFOR
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work fixes the utilization of `MOVEA` from an array declared as DS field to a standalone array.
```
     D DS1             DS           100
     D  DS1_ARR1                      2  0 DIM(5) INZ(1)
     D ARR1            S              2  0 DIM(5) INZ(2)
     ...
     C                   MOVEA(P)  DS1_ARR1      ARR1
```

### Technical notes
On Jariko this operation caused `ProjectedArrayValue cannot be cast to class ConcreteArrayValue`. The fix has been simple by resolving the wrong casting from a `ConcreteArrayValue` to the `ArrayValue` abstract class. Another consideration is that `MOVEA` has own logic of coercing between different numeric type. So, I have provided an "internal coercing" which, in this case, converts properly an integer to decimal and vice versa. Is not possible to apply this coercion when the total of digits are different between Factor 2 and Result. For example, this snippet:
```
     D DS1             DS           100
     D  DS1_ARR1                      5  3 DIM(3) INZ(12.345)
     D ARR1            S              3  0 DIM(5) INZ(9)
     ...
     C                   MOVEA(P)  DS1_ARR1      ARR1
```
is illegal on AS400 execution.

Related to #LS24004772

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
