### PR TITLE
Bugfix: analytics logs no longer shown

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
@@ -5,13 +5,14 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.smeup.rpgparser.interpreter
@@ -67,6 +68,12 @@ interface InterpreterCore {
     fun optimizedIntExpression(expression: Expression): () -> Long
     fun enterCondition(index: Value, end: Value, downward: Boolean): Boolean
     fun increment(dataDefinition: AbstractDataDefinition, amount: Long): Value
+    /***
+     * This method is called when the interpretation of the first program of the stack is ended
+     * There is no warranty that this method is called unless you use:
+     * com.smeup.rpgparser.execution.CommandLineProgram.singleCall
+     * methods
+     */
     fun onInterpretationEnd()
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ProgramInterpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ProgramInterpreter.kt
@@ -37,6 +37,9 @@ class ProgramInterpreter(val systemInterface: SystemInterface) {
             MainExecutionContext.getProgramStack().push(rpgProgram)
             rpgProgram.execute(systemInterface = systemInterface, params = initialValues)
             MainExecutionContext.getProgramStack().pop()
+            if (MainExecutionContext.getProgramStack().isEmpty()) {
+                rpgProgram.intepreterCore.onInterpretationEnd()
+            }
         }
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -5,13 +5,14 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.smeup.rpgparser.interpreter
@@ -176,10 +177,6 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
             logHandlers.renderLog(LazyLogEntry.produceStatement(logSource, "INTERPRETATION", "END"))
             logHandlers.renderLog(LazyLogEntry.producePerformanceAndUpdateAnalytics(logSource, ProgramUsageType.Interpretation, "INTERPRETATION", elapsed))
         }
-        if (MainExecutionContext.getProgramStack().isEmpty()) {
-            interpreter.onInterpretationEnd()
-        }
-
         return changedInitialValues
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/logging/LoggingTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/logging/LoggingTest.kt
@@ -5,13 +5,14 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.smeup.rpgparser.logging
@@ -292,5 +293,22 @@ class LoggingTest : AbstractTest() {
             StringValue(varValue),
             null
         )
+    }
+
+    /**
+     * Test if analytics logs are overwritten through the setting of [com.smeup.rpgparser.execution.JarikoCallback.logInfo]
+     * */
+    @Test
+    fun analyticsChannelLogInfo() {
+        val configuration = Configuration()
+        var logInfCalled = false
+        configuration.jarikoCallback.logInfo = { _, _ ->
+            logInfCalled = true
+        }
+        val systemInterface = JavaSystemInterface(configuration = configuration).apply {
+            loggingConfiguration = consoleLoggingConfiguration(LogChannel.ANALYTICS)
+        }
+        executePgm(programName = "HELLO", configuration = configuration, systemInterface = systemInterface)
+        assertTrue(logInfCalled, "logInfo never called")
     }
 }


### PR DESCRIPTION
## Description

Fixed regression related to #650.  
We moved the `push` and `pop` of the current execution program outside the `RpgProgram.execute` method but overlooked `InternalInterpreter.onInterpreterEnd`.

## Checklist:
- [X] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [X] There are tests for this feature.
- [X] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [X] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [X] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
