### PR TITLE
Fix error throw logic

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -272,7 +272,5 @@ private fun ReferenceByName<AbstractDataDefinition>.tryToResolveRecursively(posi
         resolved = this.tryToResolve(currentCu.allDataDefinitions, caseInsensitive = true)
         currentCu = currentCu.parent?.let { it as CompilationUnit }
     }
-    require(resolved) {
-        "Data reference not resolved: ${this.name} at $position"
-    }
+    if (!resolved) cu.error("Data reference not resolved: ${this.name} at $position")
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -24,6 +24,7 @@ import com.smeup.rpgparser.interpreter.InStatementDataDefinition
 import com.smeup.rpgparser.interpreter.type
 import com.smeup.rpgparser.parsing.ast.*
 import com.smeup.rpgparser.parsing.facade.AstCreatingException
+import com.smeup.rpgparser.parsing.facade.adaptInFunctionOf
 import com.smeup.rpgparser.parsing.facade.getExecutionProgramNameWithNoExtension
 import com.smeup.rpgparser.parsing.facade.getLastPoppedParsingProgram
 import com.smeup.rpgparser.utils.popIfPresent
@@ -272,5 +273,6 @@ private fun ReferenceByName<AbstractDataDefinition>.tryToResolveRecursively(posi
         resolved = this.tryToResolve(currentCu.allDataDefinitions, caseInsensitive = true)
         currentCu = currentCu.parent?.let { it as CompilationUnit }
     }
-    if (!resolved) cu.error("Data reference not resolved: ${this.name} at $position")
+    val relativePosition = position?.adaptInFunctionOf(getProgramNameToCopyBlocks().second)
+    if (!resolved) cu.error("Data reference not resolved: ${this.name} at $relativePosition")
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2549,4 +2549,19 @@ Test 6
         val expected = listOf("0", "0", "0", "1")
         assertEquals(expected, "PRSLTCALLERDUPLICATE".outputOf())
     }
+
+    @Test
+    fun missingDefinitionOnPListShouldThrowResolutionError() {
+        val systemInterface = JavaSystemInterface()
+
+        val source = """
+|     C                   CALL      'PGM'
+|     C                   PARM                    MISSING
+        """.trimMargin()
+
+        val program = getProgram(source, systemInterface)
+        assertFailsWith(AstResolutionError::class) {
+            program.singleCall(listOf())
+        }
+    }
 }


### PR DESCRIPTION
## Description

> This PR fixes internal Jariko logics. It does not add/alter any RPGLE functionality.

Fix an issue causing `tryToResolveRecursively` to throw an Exception of unexpected type.

This was specially noticeable when it was thrown while parsing an API as it caused to report errors from a `Position` that had nothing to do with the source they originated from, resulting in error reports pointing to wrong lines or out of bounds.

Related to:
- LS24004845

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
