### PR TITLE
Bugfix/LS24004854/Coercing from `UnlimitedString` to `String`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -292,6 +292,12 @@ fun coerce(value: Value, type: Type): Value {
             }
         }
         is BooleanValue -> coerceBoolean(value, type)
+        is UnlimitedStringValue -> {
+            when (type) {
+                is StringType -> coerceString(value.value.asValue(), type)
+                else -> value
+            }
+        }
         else -> value
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -292,12 +292,7 @@ fun coerce(value: Value, type: Type): Value {
             }
         }
         is BooleanValue -> coerceBoolean(value, type)
-        is UnlimitedStringValue -> {
-            when (type) {
-                is StringType -> coerceString(value.value.asValue(), type)
-                else -> value
-            }
-        }
+        is UnlimitedStringValue -> coerceString(value.value.asValue(), type)
         else -> value
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -750,7 +750,7 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00162() {
-        val expected = listOf("TAC5J18", "C5")
-        assertEquals(emptyList(), "smeup/MUDRNRAPU00162".outputOf(configuration = smeupConfig))
+        val expected = listOf("ABCDE", "CDE")
+        assertEquals(expected, "smeup/MUDRNRAPU00162".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -773,4 +773,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ABCDE   FG")
         assertEquals(expected, "smeup/MUDRNRAPU00164".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Assignment of UnlimitedStringValue to a StringValue (VARYING) where the size of first is smaller than second.
+     * @see #LS24004854
+     */
+    @Test
+    fun executeMUDRNRAPU00165() {
+        val expected = listOf("ABCFG")
+        assertEquals(expected, "smeup/MUDRNRAPU00165".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -753,4 +753,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("ABCDE", "CDE")
         assertEquals(expected, "smeup/MUDRNRAPU00162".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Assignment of UnlimitedStringValue to a StringValue where the size of first is greater than second
+     * @see #LS24004854
+     */
+    @Test
+    fun executeMUDRNRAPU00163() {
+        val expected = listOf("ABC")
+        assertEquals(expected, "smeup/MUDRNRAPU00163".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -743,4 +743,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("*SCPAccesso da script             00S")
         assertEquals(expected, "smeup/MUDRNRAPU00154".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * SUBST with a side effect where the factor 2 has changed type in `UnlimitedStringValue`.
+     * @see #LS24004854
+     */
+    @Test
+    fun executeMUDRNRAPU00162() {
+        val expected = listOf("TAC5J18", "C5")
+        assertEquals(emptyList(), "smeup/MUDRNRAPU00162".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -755,12 +755,22 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     }
 
     /**
-     * Assignment of UnlimitedStringValue to a StringValue where the size of first is greater than second
+     * Assignment of UnlimitedStringValue to a StringValue where the size of first is greater than second.
      * @see #LS24004854
      */
     @Test
     fun executeMUDRNRAPU00163() {
         val expected = listOf("ABC")
         assertEquals(expected, "smeup/MUDRNRAPU00163".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * Assignment of UnlimitedStringValue to a StringValue where the size of first is smaller than second.
+     * @see #LS24004854
+     */
+    @Test
+    fun executeMUDRNRAPU00164() {
+        val expected = listOf("ABCDE   FG")
+        assertEquals(expected, "smeup/MUDRNRAPU00164".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00162.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00162.rpgle
@@ -1,0 +1,25 @@
+     V* ==============================================================
+     V* 12/11/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * SUBST with a side effect where the factor 2 has changed type
+    O *  in `UnlimitedStringValue`.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix:
+    O *  `Issue executing SubstStmt at line 22. begin 2, end 10,
+    O *   length 5`
+     V* ==============================================================
+     D £UIBDS          DS
+     D  £UIBME                       10
+     D  £UIBP1                         0
+     D £DECPA          S             10
+     D £G40PA          S             10
+
+     C                   EVAL      £UIBP1='ABCDE'
+     C                   EVAL      £DECPA=£UIBP1
+     C     £DECPA        DSPLY
+     C     8             SUBST     £DECPA:3      £G40PA                         #Issue executing SubstStmt at line 22. begin 2, end 10, length 5
+     C     £G40PA        DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00163.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00163.rpgle
@@ -1,0 +1,17 @@
+     V* ==============================================================
+     V* 12/11/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment of UnlimitedStringValue to a StringValue where
+    O *  the size of first is greater than second.
+     V* ==============================================================
+     D £UIBDS          DS
+     D  £UIBME                       10
+     D  £UIBP1                         0
+     D £DECPA          S              3
+
+     C                   EVAL      £UIBP1='ABCDE'
+     C                   EVAL      £DECPA=£UIBP1
+     C     £DECPA        DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00163.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00163.rpgle
@@ -5,13 +5,11 @@
     O * Assignment of UnlimitedStringValue to a StringValue where
     O *  the size of first is greater than second.
      V* ==============================================================
-     D £UIBDS          DS
-     D  £UIBME                       10
-     D  £UIBP1                         0
-     D £DECPA          S              3
+     D VARUNL          S               0
+     D VARSTD          S              3
 
-     C                   EVAL      £UIBP1='ABCDE'
-     C                   EVAL      £DECPA=£UIBP1
-     C     £DECPA        DSPLY
+     C                   EVAL      VARUNL='ABCDE'
+     C                   EVAL      VARSTD=VARUNL
+     C     VARSTD        DSPLY
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00164.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00164.rpgle
@@ -5,14 +5,12 @@
     O * Assignment of UnlimitedStringValue to a StringValue where
     O *  the size of first is smaller than second.
      V* ==============================================================
-     D £UIBDS          DS
-     D  £UIBME                       10
-     D  £UIBP1                         0
-     D £DECPA          S             10
+     D VARUNL          S               0
+     D VARSTD          S             10
 
-     C                   EVAL      £UIBP1='ABCDE'
-     C                   EVAL      £DECPA=£UIBP1
-     C                   MOVE      'FG'          £DECPA
-     C     £DECPA        DSPLY
+     C                   EVAL      VARUNL='ABCDE'
+     C                   EVAL      VARSTD=VARUNL
+     C                   MOVE      'FG'          VARSTD
+     C     VARSTD        DSPLY
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00164.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00164.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 12/11/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment of UnlimitedStringValue to a StringValue where
+    O *  the size of first is smaller than second.
+     V* ==============================================================
+     D £UIBDS          DS
+     D  £UIBME                       10
+     D  £UIBP1                         0
+     D £DECPA          S             10
+
+     C                   EVAL      £UIBP1='ABCDE'
+     C                   EVAL      £DECPA=£UIBP1
+     C                   MOVE      'FG'          £DECPA
+     C     £DECPA        DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00165.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00165.rpgle
@@ -5,14 +5,12 @@
     O * Assignment of UnlimitedStringValue to a StringValue (VARYING)
     O *  where the size of first is smaller than second.
      V* ==============================================================
-     D £UIBDS          DS
-     D  £UIBME                       10
-     D  £UIBP1                         0
-     D £DECPA          S             10    VARYING
+     D VARUNL          S               0
+     D VARSTD          S             10    VARYING
 
-     C                   EVAL      £UIBP1='ABCDE'
-     C                   EVAL      £DECPA=£UIBP1
-     C                   MOVE      'FG'          £DECPA
-     C     £DECPA        DSPLY
+     C                   EVAL      VARUNL='ABCDE'
+     C                   EVAL      VARSTD=VARUNL
+     C                   MOVE      'FG'          VARSTD
+     C     VARSTD        DSPLY
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00165.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00165.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 12/11/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assignment of UnlimitedStringValue to a StringValue (VARYING)
+    O *  where the size of first is smaller than second.
+     V* ==============================================================
+     D £UIBDS          DS
+     D  £UIBME                       10
+     D  £UIBP1                         0
+     D £DECPA          S             10    VARYING
+
+     C                   EVAL      £UIBP1='ABCDE'
+     C                   EVAL      £DECPA=£UIBP1
+     C                   MOVE      'FG'          £DECPA
+     C     £DECPA        DSPLY
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work is related only for the Jariko feature `UnlimitedString`. This is a special type where is possible to store a string without limit of size. 
The applied fix regards the coercion from  `UnlimitedStringValue` a `StringValue` like this snippet:
```
     D £UIBDS          DS
     ...
     D  £UIBP1                         0
     D £DECPA          S             10

     ...
     C                   EVAL      £UIBP1='ABCDE'
     C                   EVAL      £DECPA=£UIBP1
```

Related to #LS24004854

## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
