### PR TITLE
Bugfix/ls24004911/ds fields on existing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ bin/
 .project
 .settings/
 .idea/
+.kotlin/
 **/.DS_Store
 rpgJavaInterpreter-core/generated-src/
 rpgJavaInterpreter-core/src/main/gen/

--- a/.kotlin/errors/errors-1732010706098.log
+++ b/.kotlin/errors/errors-1732010706098.log
@@ -1,4 +1,0 @@
-kotlin version: 2.0.20
-error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
-    1. Kotlin compile daemon is ready
-

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -286,6 +286,21 @@ open class BaseCompileTimeInterpreter(
         return findType(rContext.getStatements(procedureName), declName, conf, false)!!
     }
 
+    /**
+     * Find type of declaration by specifically look for it in DEFINE statements.
+     */
+    open fun evaluateTypeOfDefine(rContext: RContext, declName: String, conf: ToAstConfiguration, procedureName: String?): Type? {
+        val statements = rContext.getStatements(procedureName)
+        val define = statements
+            .mapNotNull { it.cspec_fixed() }
+            .mapNotNull { it.cspec_fixed_standard() }
+            .mapNotNull { it.csDEFINE() }
+            .map { it.toAst(conf) }
+        val match = define.firstOrNull { it.newVarName.equals(declName, ignoreCase = true) } ?: return null
+
+        return findType(statements, match.originalName, conf)
+    }
+
     private fun findType(statements: List<RpgParser.StatementContext>, declName: String, conf: ToAstConfiguration, innerBlock: Boolean = true): Type? {
         statements
             .forEach { it ->

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -1110,7 +1110,6 @@ open class InternalInterpreter(
             is QualifiedAccessExpr -> {
                 when (val container = eval(target.container)) {
                     is DataStructValue -> {
-                        container[target.field.referred!!]
                         container.set(target.field.referred!!, coerce(value, target.field.referred!!.type))
                     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -750,7 +750,7 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00270() {
-        val expected = listOf("ok")
+        val expected = listOf("OK", "OK")
         assertEquals(expected, "smeup/MUDRNRAPU00270".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -743,4 +743,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("*SCPAccesso da script             00S")
         assertEquals(expected, "smeup/MUDRNRAPU00154".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Fields in a DS based on existing definitions
+     * @see #LS24004911
+     */
+    @Test
+    fun executeMUDRNRAPU00270() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00270".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00270.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00270.rpgle
@@ -1,0 +1,26 @@
+     V* ==============================================================
+     V* 13/11/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Define a DS with fields based on existing definitions
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error was about the CKEY not being resolved
+     V* ==============================================================
+
+     D CKEY            DS
+     D  §OAVT1
+     D  §OAVP1
+     D  §OAVT2
+     D  §OAVP2
+     D  §OAVAT
+
+     D  §OAVT1         S              2
+     D  §OAVP1         S             10
+     D  §OAVT2         S              2
+     D  §OAVP2         S             10
+     D  §OAVAT         S             15
+
+     C                   EVAL §OAVT1='ok'
+     C     CKEY.§OAVT1   DSPLY
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00270.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00270.rpgle
@@ -7,7 +7,6 @@
     O * JARIKO ANOMALY
     O * Before the fix, the error was about the CKEY not being resolved
      V* ==============================================================
-
      D CKEY            DS
      D  §OAVT1
      D  §OAVP1
@@ -15,12 +14,21 @@
      D  §OAVP2
      D  §OAVAT
 
-     D  §OAVT1         S              2
-     D  §OAVP1         S             10
-     D  §OAVT2         S              2
-     D  §OAVP2         S             10
-     D  §OAVAT         S             15
+     D  £OAVT1         S              2
+     D  £OAVP1         S             10
+     D  £OAVT2         S              2
+     D  £OAVP2         S             10
+     D  £OAVAT         S             15
 
-     C                   EVAL §OAVT1='ok'
-     C     CKEY.§OAVT1   DSPLY
+     C                   EVAL      £OAVT1='OK'
+     C                   EVAL      §OAVT1='OK'
+     C     £OAVT1        DSPLY
+     C     §OAVT1        DSPLY
+
+     C     *LIKE         DEFINE    £OAVT1        §OAVT1
+     C     *LIKE         DEFINE    £OAVP1        §OAVP1
+     C     *LIKE         DEFINE    £OAVT2        §OAVT2
+     C     *LIKE         DEFINE    £OAVP2        §OAVP2
+     C     *LIKE         DEFINE    £OAVAT        §OAVAT
+
      C                   SETON                                          LR


### PR DESCRIPTION
## Description

Add support for DS containing references to data definitions that already exist.

Related to:
- LS24004911

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
