### PR TITLE
Bugfix/ls24004983/mock log format

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -261,14 +261,28 @@ data class JarikoCallback(
      * Default implementation provides a simple println with the name of the mock statement.
      * @param mockStatement The mock statement
      */
-    var onMockStatement: ((mockStatement: MockStatement) -> Unit) = { System.err.println("Executing mock statement ${it.javaClass.simpleName} ${if (it is Statement) "at absolute position: " + it.position + "." else "." }") },
+    var onMockStatement: ((mockStatement: MockStatement) -> Unit) = {
+        val programName = MainExecutionContext.getExecutionProgramName()
+        val position = if (it is Statement) it.position else null
+        val provider = { LogSourceData(programName, position?.line() ?: "") }
+        val entry = LazyLogEntry.produceInformational(provider, "MOCKSTMT", it.javaClass.simpleName)
+        val rendered = entry.renderScoped()
+        System.err.println(rendered)
+    },
 
     /**
      * If specified, it allows customizing the behavior of the mock statements.
      * Default implementation provides a simple println with the name of the mock expression.
      * @param mockExpression The mock expression
      */
-    var onMockExpression: ((mockExpression: MockExpression) -> Unit) = { System.err.println("Executing mock expression: ${it.javaClass.simpleName}") },
+    var onMockExpression: ((mockExpression: MockExpression) -> Unit) = {
+        val programName = MainExecutionContext.getExecutionProgramName()
+        val position = if (it is Expression) it.position else null
+        val provider = { LogSourceData(programName, position?.line() ?: "") }
+        val entry = LazyLogEntry.produceInformational(provider, "MOCKEXPR", it.javaClass.simpleName)
+        val rendered = entry.renderScoped()
+        System.err.println(rendered)
+    },
 
     /**
      * If specified, it allows overriding the default mechanism of API validation.

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -861,6 +861,7 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: ReallocExpr): Value = proxyLogging(expression) {
+        MainExecutionContext.getConfiguration().jarikoCallback.onMockExpression(expression)
         val pointer = expression.value as? DataRefExpr ?: error("%REALLOC is only allowed for pointers")
         val references = interpreterStatus.getReferences(pointer)
         require(references.all { it.key.type is ArrayType }) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/logs.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/logs.kt
@@ -26,6 +26,9 @@ import com.smeup.rpgparser.utils.asNonNullString
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.Position
 import java.io.PrintStream
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.*
 import kotlin.system.measureNanoTime
 import kotlin.time.Duration
@@ -378,6 +381,15 @@ class LazyLogEntry(val entry: LogEntry, val renderContent: (sep: String) -> Stri
 
         val content = renderContent(sep)
         append(content)
+    }
+
+    fun renderScoped(): String {
+        val rendered = render("\t", withHeader = true, withScope = false)
+        val timestamp = DateTimeFormatter
+            .ofPattern("HH:mm:ss.SSS")
+            .withZone(ZoneId.systemDefault())
+            .format(Instant.now())
+        return "$timestamp\t${entry.scope}\t$rendered"
     }
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/logging/LoggingTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/logging/LoggingTest.kt
@@ -222,7 +222,7 @@ class LoggingTest : AbstractTest() {
             // Files.writeString(Paths.get("c:\\temp\\errorEventsInErrorChannel.txt"), out.toString().trim())
             assertEquals(2, errorLogEntries.size)
             assertTrue(errorLogEntries[0].matches(errorPattern), "Error entry: ${errorLogEntries[0]} does not match $errorPattern")
-            assertTrue(errorLogEntries[1].matches(errorPattern), "Error entry: ${errorLogEntries[0]} does not match $errorPattern")
+            assertTrue(errorLogEntries[1].matches(errorPattern), "Error entry: ${errorLogEntries[1]} does not match $errorPattern")
             System.setOut(defaultOut)
             println("errorEventsInErrorChannel: ${out.toString().trim()}")
         }
@@ -310,5 +310,52 @@ class LoggingTest : AbstractTest() {
         }
         executePgm(programName = "HELLO", configuration = configuration, systemInterface = systemInterface)
         assertTrue(logInfCalled, "logInfo never called")
+    }
+
+    /**
+     * Test if mock statements are printed out in the appropriate format
+     * @see #LS24004983
+     */
+    @Test
+    fun mockStatementFormat() {
+        val defaultErr = System.err
+        val virtualErr = StringOutputStream()
+        System.setErr(PrintStream(virtualErr))
+        val systemInterface = JavaSystemInterface()
+        executePgm(programName = "MOCK01", systemInterface = systemInterface)
+        virtualErr.flush()
+        val logEntries = virtualErr.toString().trim().split(regex = Regex("\\n|\\r\\n"))
+        val stmtLogEntries = logEntries.filter { it.contains("MOCKSTMT") }
+        assertEquals(3, stmtLogEntries.size)
+
+        val logFormatRegexMockStatement = Regex(pattern = "\\d+:\\d+:\\d+\\.\\d+\\s*\\tMOCKSTMT\\tMOCK01.*")
+        assertTrue(stmtLogEntries[0].matches(logFormatRegexMockStatement), "Error entry: ${stmtLogEntries[0]} does not match $logFormatRegexMockStatement")
+        assertTrue(stmtLogEntries[1].matches(logFormatRegexMockStatement), "Error entry: ${stmtLogEntries[1]} does not match $logFormatRegexMockStatement")
+        assertTrue(stmtLogEntries[2].matches(logFormatRegexMockStatement), "Error entry: ${stmtLogEntries[2]} does not match $logFormatRegexMockStatement")
+
+        System.setErr(defaultErr)
+    }
+
+    /**
+     * Test if mock expression are printed out in the appropriate format
+     * @see #LS24004983
+     */
+    @Test
+    fun mockExpressionFormat() {
+        val defaultErr = System.err
+        val virtualErr = StringOutputStream()
+        System.setErr(PrintStream(virtualErr))
+        val systemInterface = JavaSystemInterface()
+        executePgm(programName = "MOCK01", systemInterface = systemInterface)
+        virtualErr.flush()
+        val logEntries = virtualErr.toString().trim().split(regex = Regex("\\n|\\r\\n"))
+        val exprLogEntries = logEntries.filter { it.contains("MOCKEXPR") }
+        assertEquals(2, exprLogEntries.size)
+
+        val logFormatRegexMockExpr = Regex(pattern = "\\d+:\\d+:\\d+\\.\\d+\\s*\\tMOCKEXPR\\tMOCK01.*")
+        assertTrue(exprLogEntries[0].matches(logFormatRegexMockExpr), "Error entry: ${exprLogEntries[0]} does not match $logFormatRegexMockExpr")
+        assertTrue(exprLogEntries[1].matches(logFormatRegexMockExpr), "Error entry: ${exprLogEntries[1]} does not match $logFormatRegexMockExpr")
+
+        System.setErr(defaultErr)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/MOCK01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/MOCK01.rpgle
@@ -1,0 +1,9 @@
+     V* ==============================================================
+     D* This program executes some mock statements and expressions
+     V* ==============================================================
+     D PTR1            S               *   INZ(*Null)
+     C                   BITOFF    '01234567'    $A                1
+     C                   BITON     '27'          $A
+     C                   EVAL      PTR1 = %Alloc(50)
+     C                   EVAL      PTR1 = %ReAlloc(PTR1:100)
+     C                   DEALLOC                 PTR1


### PR DESCRIPTION
## Description

> Note: This PR does not add/alter any RPGLE functionality but rather changes an internal behaviour of the compiler.

Tune mock callbacks output in order to be compliant with the default TSV standard in order not to break logs flow when exported for analysis.

Related to:
- LS24004983

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
