### PR TITLE
Bugfix/ls24005012/stackoverflow goto

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
@@ -55,6 +55,7 @@ interface InterpreterCore {
     fun setIndicators(statement: WithRightIndicators, hi: BooleanValue, lo: BooleanValue, eq: BooleanValue)
     fun eval(expression: Expression): Value
     fun execute(statements: List<Statement>)
+    fun executeUnwrappedAt(unwrappedStatements: List<Statement>, offset: Int)
     fun dbFile(name: String, statement: Statement): EnrichedDBFile
     fun toSearchValues(searchArgExpression: Expression, fileMetadata: FileMetadata): List<String>
     fun fillDataFrom(dbFile: EnrichedDBFile, record: Record)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -489,7 +489,7 @@ open class InternalInterpreter(
     private fun GotoTopLevelException.indexOfTaggedStatement(statements: List<Statement>) = statements.indexOfTag(tag)
 
     private fun List<Statement>.indexOfTag(tag: String) = indexOfFirst {
-        it is TagStmt && it.tag == tag
+        it is TagStmt && it.tag.lowercase() == tag.lowercase()
     }
 
     private fun caseInsensitiveMap(aMap: Map<String, Value>): Map<String, Value> {
@@ -518,23 +518,6 @@ open class InternalInterpreter(
             while (i < statements.size) {
                 executeWithMute(statements[i++])
             }
-        } catch (e: GotoException) {
-            val containingCU = statements.firstOrNull()?.getContainingCompilationUnit()
-
-            // If tag is in top level we need to quit subroutine and rollback context to top level
-            val topLevelStatements = containingCU?.main?.stmts?.explode(true)
-            topLevelStatements?.let {
-                val topLevelIndex = e.indexOfTaggedStatement(it)
-                if (0 <= topLevelIndex && topLevelIndex < it.size)
-                    throw GotoTopLevelException(e.tag)
-            }
-
-            // Scope might have been changed in the meanwhile with an EXSR after the previous GOTO
-            val scope = MainExecutionContext.getSubroutineStack().peekOrNull()
-            performJump(
-                scope = scope,
-                goto = e
-            )
         } catch (e: InterpreterProgramStatusErrorException) {
             /**
              * Program status error not caught from MONITOR statements should end up here
@@ -565,48 +548,11 @@ open class InternalInterpreter(
         }
 
         var index = offset
-        try {
-            while (index < offsetAwareStatements.size) {
-                val offsetStatement = offsetAwareStatements[index]
-                executeWithMute(offsetStatement.data)
-                index += offsetStatement.offset + 1
-            }
-        } catch (e: GotoException) {
-            val containingCU = unwrappedStatements.firstOrNull()?.getContainingCompilationUnit()
-
-            // If tag is in top level we need to quit subroutine and rollback context to top level
-            val topLevelStatements = containingCU?.main?.stmts?.explode(true)
-            topLevelStatements?.let {
-                val topLevelIndex = e.indexOfTaggedStatement(it)
-                if (0 <= topLevelIndex && topLevelIndex < it.size)
-                    throw GotoTopLevelException(e.tag)
-            }
-
-            // Scope might have been changed in the meanwhile with an EXSR after the previous GOTO
-            val scope = MainExecutionContext.getSubroutineStack().peekOrNull()
-            performJump(
-                scope = scope,
-                goto = e
-            )
+        while (index < offsetAwareStatements.size) {
+            val offsetStatement = offsetAwareStatements[index]
+            executeWithMute(offsetStatement.data)
+            index += offsetStatement.offset + 1
         }
-    }
-
-    /**
-     * Perform a jump in the provided scope
-     * @param scope The subroutine scope to perform the jump into
-     * @param goto The [GotoException] that caused this jump
-     */
-    private fun performJump(scope: ReferenceByName<Subroutine>?, goto: GotoException) {
-        // In case of something wrong with the goto, we dispatch the goto to the parent flow
-
-        val scopeLevelStatements = scope?.referred?.stmts ?: throw goto
-        val unwrappedStatements = scopeLevelStatements.explode(true)
-
-        val index = goto.indexOfTaggedStatement(unwrappedStatements)
-        val isInRange = 0 <= index && index < unwrappedStatements.size
-        if (!isInRange) throw goto
-
-        executeUnwrappedAt(unwrappedStatements, index)
     }
 
     @Deprecated(message = "No longer used")
@@ -1332,9 +1278,7 @@ open class InternalInterpreter(
         sourceProducer?.let { openLoggingScope(statement, it) }
 
         val internalExecute = {
-            val executionTime = measureNanoTime {
-                statement.execute(this)
-            }.nanoseconds
+            val executionTime = measureNanoTime { executeInternalLogic(statement) }.nanoseconds
             sourceProducer?.let { closeLoggingScope(statement, programName, sourceProducer, executionTime) }
         }
         if (trace != null) {
@@ -1415,6 +1359,69 @@ open class InternalInterpreter(
                 statement.loggableEntityName,
                 executionTime
             )
+        }
+    }
+
+    /**
+     * Execute internal logic of a single statement without telemetry nor additional context.
+     */
+    private fun executeInternalLogic(statement: Statement) {
+        when (statement) {
+            is ExecuteSubroutine -> {
+                // Setup subroutine context
+                MainExecutionContext.getSubroutineStack().push(statement.subroutine)
+
+                // Execute subroutine, we deal with exceptions later
+                var throwable = kotlin.runCatching {
+                    statement.execute(this)
+                }.exceptionOrNull()
+
+                val unwrappedStatements = statement.subroutine.referred!!.stmts.explode(true)
+                val containingCU = unwrappedStatements.firstOrNull()?.getContainingCompilationUnit()
+
+                // Recursive deal with goto
+                var scope: ReferenceByName<Subroutine>? = statement.subroutine
+                while (throwable is GotoException && statement.subroutine == scope) {
+                    // If is a goto to the end, exit SR
+                    if (throwable.tag.equals(scope.referred!!.tag, true)) {
+                        throwable = null
+                        break
+                    }
+
+                    // If tag is in top level we need to quit subroutine and rollback context to top level
+                    val topLevelStatements = containingCU?.main?.stmts?.explode(true)
+                    topLevelStatements?.let {
+                        val goto = throwable as GotoException
+                        val topLevelIndex = goto.indexOfTaggedStatement(it)
+                        if (0 <= topLevelIndex && topLevelIndex < it.size) {
+                            MainExecutionContext.getSubroutineStack().pop()
+                            throw GotoTopLevelException(goto.tag)
+                        }
+                    }
+
+                    // We need to know the statement unwrapped in order to jump directly into a nested tag
+                    val offset = throwable.indexOfTaggedStatement(unwrappedStatements)
+                    require(0 <= offset && offset < unwrappedStatements.size) { "Offset $offset is not valid." }
+                    throwable = kotlin.runCatching {
+                        executeUnwrappedAt(unwrappedStatements, offset)
+                    }.exceptionOrNull()
+                    scope = MainExecutionContext.getSubroutineStack().peekOrNull()
+                }
+
+                // Deal with other types of exceptions
+                throwable?.let {
+                    when (it) {
+                        is LeaveSrException -> {
+                            // Just catch it, do nothing
+                        }
+                        else -> throw it
+                    }
+                }
+
+                // Cleanup subroutine context
+                MainExecutionContext.getSubroutineStack().pop()
+            }
+            else -> statement.execute(this)
         }
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -31,7 +31,6 @@ import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.parsing.parsetreetoast.todo
 import com.smeup.rpgparser.utils.ComparisonOperator.*
 import com.smeup.rpgparser.utils.chunkAs
-import com.smeup.rpgparser.utils.indexOfTaggedStatement
 import com.smeup.rpgparser.utils.resizeTo
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.ReferenceByName

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
@@ -22,6 +22,8 @@ import com.smeup.rpgparser.interpreter.ControlFlowException
 import com.smeup.rpgparser.interpreter.GotoException
 import com.smeup.rpgparser.interpreter.GotoTopLevelException
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
+import com.smeup.rpgparser.parsing.ast.Statement
+import com.smeup.rpgparser.parsing.ast.TagStmt
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.ancestor
 import java.math.BigDecimal
@@ -185,4 +187,12 @@ internal fun produceGotoInCurrentScope(tag: String): ControlFlowException {
     val shouldLookupTopLevel = MainExecutionContext.getSubroutineStack().isEmpty()
     val normalizedTag = tag.lowercase()
     return if (shouldLookupTopLevel) GotoTopLevelException(normalizedTag) else GotoException(normalizedTag)
+}
+
+internal fun GotoException.indexOfTaggedStatement(statements: List<Statement>) = statements.indexOfTag(tag)
+
+internal fun GotoTopLevelException.indexOfTaggedStatement(statements: List<Statement>) = statements.indexOfTag(tag)
+
+internal fun List<Statement>.indexOfTag(tag: String) = indexOfFirst {
+    it is TagStmt && it.tag.lowercase() == tag.lowercase()
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
@@ -16,7 +16,11 @@
 
 package com.smeup.rpgparser.utils
 
+import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.execution.ParsingProgram
+import com.smeup.rpgparser.interpreter.ControlFlowException
+import com.smeup.rpgparser.interpreter.GotoException
+import com.smeup.rpgparser.interpreter.GotoTopLevelException
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.ancestor
@@ -173,3 +177,12 @@ internal fun <T> Stack<T>.peekOrNull(): T? = if (isNotEmpty()) {
  * Get the [CompilationUnit] that contains the current [Node]
  */
 internal fun Node.getContainingCompilationUnit() = ancestor(CompilationUnit::class.java)
+
+/**
+ * Produce a scoped goto exception
+ */
+internal fun produceGotoInCurrentScope(tag: String): ControlFlowException {
+    val shouldLookupTopLevel = MainExecutionContext.getSubroutineStack().isEmpty()
+    val normalizedTag = tag.lowercase()
+    return if (shouldLookupTopLevel) GotoTopLevelException(normalizedTag) else GotoException(normalizedTag)
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
@@ -16,11 +16,7 @@
 
 package com.smeup.rpgparser.utils
 
-import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.execution.ParsingProgram
-import com.smeup.rpgparser.interpreter.ControlFlowException
-import com.smeup.rpgparser.interpreter.GotoException
-import com.smeup.rpgparser.interpreter.GotoTopLevelException
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import com.smeup.rpgparser.parsing.ast.Statement
 import com.smeup.rpgparser.parsing.ast.TagStmt
@@ -179,19 +175,6 @@ internal fun <T> Stack<T>.peekOrNull(): T? = if (isNotEmpty()) {
  * Get the [CompilationUnit] that contains the current [Node]
  */
 internal fun Node.getContainingCompilationUnit() = ancestor(CompilationUnit::class.java)
-
-/**
- * Produce a scoped goto exception
- */
-internal fun produceGotoInCurrentScope(tag: String): ControlFlowException {
-    val shouldLookupTopLevel = MainExecutionContext.getSubroutineStack().isEmpty()
-    val normalizedTag = tag.lowercase()
-    return if (shouldLookupTopLevel) GotoTopLevelException(normalizedTag) else GotoException(normalizedTag)
-}
-
-internal fun GotoException.indexOfTaggedStatement(statements: List<Statement>) = statements.indexOfTag(tag)
-
-internal fun GotoTopLevelException.indexOfTaggedStatement(statements: List<Statement>) = statements.indexOfTag(tag)
 
 internal fun List<Statement>.indexOfTag(tag: String) = indexOfFirst {
     it is TagStmt && it.tag.lowercase() == tag.lowercase()

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -407,6 +407,12 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         assertEquals(expected, "smeup/MUDRNRAPU00269".outputOf(configuration = smeupConfig))
     }
 
+    @Test
+    fun executeMUDRNRAPU00271() {
+        val expected = listOf("OK")
+        assertEquals(expected, "smeup/MUDRNRAPU00271".outputOf(configuration = smeupConfig))
+    }
+
     /**
      * Comparing number and `*ZEROS` by using `IFxx`.
      * @see #LS24004528

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00271.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00271.rpgle
@@ -1,0 +1,17 @@
+     V* ==============================================================
+     D* 19/11/24  nn.mm lanmam
+     V* ==============================================================
+     D COUNTER         S              5  0
+
+     C                   EVAL      COUNTER=0
+
+     C                   EXSR      MEM_DT
+
+     C     MEM_DT        BEGSR
+     C     RILALTRO      TAG
+     C                   IF        COUNTER < 10000
+     C                   EVAL      COUNTER=COUNTER + 1
+     C                   GOTO      RILALTRO
+     C                   ENDIF
+     C     'OK'          DSPLY
+     C                   ENDSR


### PR DESCRIPTION
## Description

Fix a stack overflow occurring when a `GOTO` was repeated a large number of times.

### Technical notes

The stack overflow occurred in specific situations where a `GOTO` was called repeatedly inside a statement which executed the `interpreter.execute` statement on its own in order to execute a subset of statements (like the `IF` statement).

This caused to spawn multiple `interpreter.execute` calls inside each other eventually resulting in a stack overflow.
This issue also caused a multiple execution of statements after the `GOTO` flow due to the fact that each of those `interpreter.execute` call resumed from the same point.

To fix these behaviours:
- The `ExecuteSubroutine` statement execution was refactored to deal with exceptions recursively.
- `GotoTopLevelException`s are now thrown directly when possible instead of being promoted from `GotoException`s. This allows to skip the promotion logic while capturing `GotoException`s simplifying management for both `GotoTopLevelException`s and  `GotoException`s.
- Strengthened tag normalization so to always be case insensitive.

Related to:
- LS24005012

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
