### PR TITLE
Feature/ls24005102/read indicators

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1335,21 +1335,29 @@ internal fun CsCHAINContext.toAst(conf: ToAstConfiguration): Statement {
     val position = toPosition(conf.considerPosition)
     val factor1 = this.factor1Context()?.content?.toAst(conf) ?: throw UnsupportedOperationException("CHAIN operation requires factor 1: ${this.text} - ${position.atLine()}")
     val factor2 = this.cspec_fixed_standard_parts().factor2.text ?: throw UnsupportedOperationException("CHAIN operation requires factor 2: ${this.text} - ${position.atLine()}")
-    return ChainStmt(factor1, factor2, position)
+    val hi = this.cspec_fixed_standard_parts().hi.toIndicatorKey()
+    val lo = this.cspec_fixed_standard_parts().lo.toIndicatorKey()
+    return ChainStmt(factor1, factor2, hi, lo, position)
 }
 
 internal fun CsREADContext.toAst(conf: ToAstConfiguration): Statement {
     val position = toPosition(conf.considerPosition)
     // TODO implement DS in result field
     val factor2 = this.cspec_fixed_standard_parts().factor2.text ?: throw UnsupportedOperationException("READ operation requires factor 2: ${this.text} - ${position.atLine()}")
-    return ReadStmt(factor2, position)
+
+    val loIndicator = this.cspec_fixed_standard_parts().lo.toIndicatorKey()
+    val eqIndicator = this.cspec_fixed_standard_parts().eq.toIndicatorKey()
+    return ReadStmt(factor2, loIndicator, eqIndicator, position)
 }
 
 internal fun CsREADPContext.toAst(conf: ToAstConfiguration): Statement {
     val position = toPosition(conf.considerPosition)
     // TODO implement DS in result field
     val factor2 = this.cspec_fixed_standard_parts().factor2.text ?: throw UnsupportedOperationException("READP operation requires factor 2: ${this.text} - ${position.atLine()}")
-    return ReadPreviousStmt(factor2, position)
+
+    val loIndicator = this.cspec_fixed_standard_parts().lo.toIndicatorKey()
+    val eqIndicator = this.cspec_fixed_standard_parts().eq.toIndicatorKey()
+    return ReadPreviousStmt(factor2, loIndicator, eqIndicator, position)
 }
 
 internal fun CsREADEContext.toAst(conf: ToAstConfiguration): Statement {
@@ -1357,7 +1365,10 @@ internal fun CsREADEContext.toAst(conf: ToAstConfiguration): Statement {
     // TODO implement DS in result field
     val factor1 = this.factor1Context()?.content?.toAst(conf)
     val factor2 = this.cspec_fixed_standard_parts().factor2.text ?: throw UnsupportedOperationException("READE operation requires factor 2: ${this.text} - ${position.atLine()}")
-    return ReadEqualStmt(factor1, factor2, position)
+
+    val lo = this.cspec_fixed_standard_parts().lo.toIndicatorKey()
+    val eq = this.cspec_fixed_standard_parts().eq.toIndicatorKey()
+    return ReadEqualStmt(factor1, factor2, lo, eq, position)
 }
 
 internal fun CsREADPEContext.toAst(conf: ToAstConfiguration): Statement {
@@ -1365,7 +1376,10 @@ internal fun CsREADPEContext.toAst(conf: ToAstConfiguration): Statement {
     // TODO implement DS in result field
     val factor1 = this.factor1Context()?.content?.toAst(conf)
     val factor2 = this.cspec_fixed_standard_parts().factor2.text ?: throw UnsupportedOperationException("READPE operation requires factor 2: ${this.text} - ${position.atLine()}")
-    return ReadPreviousEqualStmt(factor1, factor2, position)
+
+    val lo = this.cspec_fixed_standard_parts().lo.toIndicatorKey()
+    val eq = this.cspec_fixed_standard_parts().eq.toIndicatorKey()
+    return ReadPreviousEqualStmt(factor1, factor2, lo, eq, position)
 }
 
 internal fun CsSETLLContext.toAst(conf: ToAstConfiguration): Statement {
@@ -2308,3 +2322,5 @@ private fun Map<FileDefinition, List<DataDefinition>>.processWithSpecifications(
 }
 
 private fun String.isStringLiteral(): Boolean = startsWith('\'') && endsWith('\'')
+
+private fun ResultIndicatorContext.toIndicatorKey() = text.trim().takeIf { it.isNotBlank() }?.toIndicatorKey()

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1,5 +1,6 @@
 package com.smeup.rpgparser.smeup
 
+import com.smeup.rpgparser.smeup.dbmock.C5ADFF9LDbMock
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -411,6 +412,18 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     fun executeMUDRNRAPU00271() {
         val expected = listOf("OK")
         assertEquals(expected, "smeup/MUDRNRAPU00271".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * READE with EQ Indicator
+     * @see #LS24005102
+     */
+    @Test
+    fun executeMUDRNRAPU00272() {
+        val expected = listOf("ok")
+        C5ADFF9LDbMock().usePopulated {
+            assertEquals(expected, "smeup/MUDRNRAPU00272".outputOf(configuration = smeupConfig))
+        }
     }
 
     /**

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -415,12 +415,12 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * READE with EQ Indicator
+     * READ operations with EQ Indicator
      * @see #LS24005102
      */
     @Test
     fun executeMUDRNRAPU00272() {
-        val expected = listOf("ok")
+        val expected = listOf("ok", "ok", "ok", "ok")
         C5ADFF9LDbMock().usePopulated {
             assertEquals(expected, "smeup/MUDRNRAPU00272".outputOf(configuration = smeupConfig))
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/dbmock/C5ADFF9LDbMock.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/dbmock/C5ADFF9LDbMock.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smeup.rpgparser.smeup.dbmock
+
+import com.smeup.rpgparser.interpreter.FileMetadata
+import java.io.File
+
+class C5ADFF9LDbMock : DbMock {
+    override val metadata =
+        FileMetadata.createInstance(File("src/test/resources/smeup/metadata/C5ADFF9L.json").inputStream())
+}

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/dbmock/DbMock.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/dbmock/DbMock.kt
@@ -61,7 +61,9 @@ interface DbMock : AutoCloseable {
                 is NumberType -> buildString {
                     append("\"${it.fieldName}\"")
                     val defaultValue = if ((it.type as NumberType).decimal) {
-                        " DECIMAL(${(it.type as NumberType).entireDigits}, ${(it.type as NumberType).decimalDigits}) DEFAULT 0.0"
+                        val type = it.type as NumberType
+                        val totalSize = type.entireDigits + type.decimalDigits
+                        " DECIMAL($totalSize, ${type.decimalDigits}) DEFAULT 0.0"
                     } else {
                         " BIGINT DEFAULT 0"
                     }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00272.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00272.rpgle
@@ -2,16 +2,46 @@
      V* 26/11/2024 APU002 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Perform READE operation with EQ indicator
+    O * Perform READ operations with EQ indicator
      V* ==============================================================
     O * JARIKO ANOMALY
-    O * Before the fix, indicators on READE operations were ignored
+    O * Before the fix, indicators on READ operations were ignored
      V* ==============================================================
      FC5ADFF9L  IF   E           K DISK    RENAME(C5ADFFR:C5ADFF9)
+     C* READE with eof indicator
      C     TAG1          TAG
      C     KSCEN         READE     C5ADFF9L                               50
      C  N50              IF        *ON
+     C     'ko'          DSPLY
      C                   GOTO      TAG1
      C                   ENDIF
      C     'ok'          DSPLY
+     C* READPE bof indicator
+     C     *LOVAL        SETLL     C5ADFF9L
+     C     TAG2          TAG
+     C     KSCEN         READPE    C5ADFF9L                               50
+     C  N50              IF        *ON
+     C     'ko'          DSPLY
+     C                   GOTO      TAG2
+     C                   ENDIF
+     C     'ok'          DSPLY
+     C* READ eof indicator
+     C     *HIVAL        SETLL     C5ADFF9L
+     C     TAG3          TAG
+     C     KSCEN         READ      C5ADFF9L                               50
+     C  N50              IF        *ON
+     C     'ko'          DSPLY
+     C                   GOTO      TAG3
+     C                   ENDIF
+     C     'ok'          DSPLY
+     C* READP bof indicator
+     C     *LOVAL        SETLL     C5ADFF9L
+     C     TAG4          TAG
+     C     KSCEN         READP     C5ADFF9L                               50
+     C  N50              IF        *ON
+     C     'ko'          DSPLY
+     C                   GOTO      TAG4
+     C                   ENDIF
+     C     'ok'          DSPLY
+     C*
      C     *LIKE         DEFINE    D5SCEN        KSCEN

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00272.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00272.rpgle
@@ -1,0 +1,17 @@
+     V* ==============================================================
+     V* 26/11/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Perform READE operation with EQ indicator
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, indicators on READE operations were ignored
+     V* ==============================================================
+     FC5ADFF9L  IF   E           K DISK    RENAME(C5ADFFR:C5ADFF9)
+     C     TAG1          TAG
+     C     KSCEN         READE     C5ADFF9L                               50
+     C  N50              IF        *ON
+     C                   GOTO      TAG1
+     C                   ENDIF
+     C     'ok'          DSPLY
+     C     *LIKE         DEFINE    D5SCEN        KSCEN

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/metadata/C5ADFF9L.json
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/metadata/C5ADFF9L.json
@@ -1,0 +1,153 @@
+{"name": "C5ADFF9L",
+  "tableName": "C5ADFF0F",
+  "recordFormat": "C5ADFFR",
+  "fields": [
+    { "fieldName": "D5AZIE",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":2, "varying":false}}
+  , { "fieldName": "D5DEAZ",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":35, "varying":false}}
+  , { "fieldName": "D5SCEN",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "D5DESC",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":35, "varying":false}}
+  , { "fieldName": "D5IDOJ",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "D5LIVE",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5STAT",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":2, "varying":false}}
+  , { "fieldName": "D5TPOG",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":12, "varying":false}}
+  , { "fieldName": "D5CDOG",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":15, "varying":false}}
+  , { "fieldName": "D5DEOG",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":35, "varying":false}}
+  , { "fieldName": "D5TPOR",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":12, "varying":false}}
+  , { "fieldName": "D5CDOR",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":15, "varying":false}}
+  , { "fieldName": "D5DEOR",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":35, "varying":false}}
+  , { "fieldName": "D5TPOC",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":12, "varying":false}}
+  , { "fieldName": "D5CDOC",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":15, "varying":false}}
+  , { "fieldName": "D5DEOC",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":35, "varying":false}}
+  , { "fieldName": "D5TPFO",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":12, "varying":false}}
+  , { "fieldName": "D5CDFO",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":15, "varying":false}}
+  , { "fieldName": "D5DEFO",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":35, "varying":false}}
+  , { "fieldName": "D5ORDF",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5RICL",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5ORDR",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5DATA",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5SEGN",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5VALU",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":4, "varying":false}}
+  , { "fieldName": "D5CAMB",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":6, "decimalDigits":6, "rpgType":"P"}}
+  , { "fieldName": "D5IMPO",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":15, "decimalDigits":6, "rpgType":"P"}}
+  , { "fieldName": "D5IMVA",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":15, "decimalDigits":6, "rpgType":"P"}}
+  , { "fieldName": "D5CD01",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":30, "varying":false}}
+  , { "fieldName": "D5DEC1",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":50, "varying":false}}
+  , { "fieldName": "D5CD02",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":30, "varying":false}}
+  , { "fieldName": "D5DEC2",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":50, "varying":false}}
+  , { "fieldName": "D5CD03",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":30, "varying":false}}
+  , { "fieldName": "D5DEC3",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":50, "varying":false}}
+  , { "fieldName": "D5CD04",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":30, "varying":false}}
+  , { "fieldName": "D5DEC4",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":50, "varying":false}}
+  , { "fieldName": "D5CD05",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":30, "varying":false}}
+  , { "fieldName": "D5DEC5",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":50, "varying":false}}
+  , { "fieldName": "D5DT01",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5DT02",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5DT03",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5DT04",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5DT05",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5QT01",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":15, "decimalDigits":6, "rpgType":"P"}}
+  , { "fieldName": "D5QT02",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":15, "decimalDigits":6, "rpgType":"P"}}
+  , { "fieldName": "D5QT03",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":15, "decimalDigits":6, "rpgType":"P"}}
+  , { "fieldName": "D5QT04",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":15, "decimalDigits":6, "rpgType":"P"}}
+  , { "fieldName": "D5QT05",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":15, "decimalDigits":6, "rpgType":"P"}}
+  , { "fieldName": "D5FL01",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL02",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL03",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL04",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL05",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL06",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL07",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL08",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL09",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL10",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL11",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL12",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL13",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL14",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL15",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL16",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL17",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL18",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL19",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5FL20",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1, "varying":false}}
+  , { "fieldName": "D5DTIN",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5ORIN",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":6, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5USIN",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "D5DTAG",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5ORAG",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":6, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "D5USAG",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  ], "accessFields": [ "D5SCEN", "D5DATA", "D5AZIE", "D5TPOG", "D5CDOG", "D5TPFO", "D5CDFO"]}


### PR DESCRIPTION
## Description

Add support for indicators on READ op codes (`READ`, `READP`, `READE`, `READPE`, `CHAIN`).

Related to:
- LS24005102

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
