### PR TITLE
Feature/ls24005143/indicators with define

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1302,6 +1302,14 @@ data class DefineStmt(
         get() = "DEFINE"
 
     override fun dataDefinition(): List<InStatementDataDefinition> {
+        // FIXME: If indicator was not priorly SET (SETON or SETOFF), program should error
+        val indicatorPattern = Regex("\\*IN\\d\\d")
+        val isIndicator = originalName.trim().uppercase().matches(indicatorPattern)
+        if (isIndicator) {
+            val newDefinition = InStatementDataDefinition(newVarName, BooleanType, position)
+            return listOf(newDefinition)
+        }
+
         val containingCU = this.ancestor(CompilationUnit::class.java)
             ?: return emptyList()
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1302,16 +1302,23 @@ data class DefineStmt(
         get() = "DEFINE"
 
     override fun dataDefinition(): List<InStatementDataDefinition> {
-        // FIXME: If indicator was not priorly SET (SETON or SETOFF), program should error
+        val containingCU = this.ancestor(CompilationUnit::class.java)
+            ?: return emptyList()
+
         val indicatorPattern = Regex("\\*IN\\d\\d")
-        val isIndicator = originalName.trim().uppercase().matches(indicatorPattern)
+        val normalizedOriginalName = originalName.trim().uppercase()
+        val isIndicator = normalizedOriginalName.matches(indicatorPattern)
         if (isIndicator) {
+            val indicatorKey = normalizedOriginalName.removePrefix("*IN").toIndicatorKey()
+            val setStatements = containingCU.main.stmts.explode(true).filterIsInstance<SetStmt>()
+            val definedIndicators = setStatements.map { it.indicators }.flatten().filterIsInstance<IndicatorExpr>()
+            val isIndicatorDefined = definedIndicators.any { it.index == indicatorKey }
+
+            if (!isIndicatorDefined) throw Error("Data reference $originalName not resolved")
+
             val newDefinition = InStatementDataDefinition(newVarName, BooleanType, position)
             return listOf(newDefinition)
         }
-
-        val containingCU = this.ancestor(CompilationUnit::class.java)
-            ?: return emptyList()
 
         // Search standalone 'D spec' or InStatement definition
         val originalDataDefinition = containingCU.dataDefinitions.find { it.name == originalName }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -1010,6 +1010,18 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR49CallBackTest() {
+        executePgmCallBackTest("ERROR49", SourceReferenceType.Program, "ERROR49", mapOf(
+            6 to "Data reference *IN10 not resolved"
+        ))
+    }
+
+    @Test
+    fun executeERROR49SourceLineTest() {
+        executeSourceLineTest("ERROR49")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -795,6 +795,16 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     }
 
     /**
+     * DEFINE with indicator as original name
+     * @see #LS24005143
+     */
+    @Test
+    fun executeMUDRNRAPU00273() {
+        val expected = listOf("1", "0")
+        assertEquals(expected, "smeup/MUDRNRAPU00273".outputOf(configuration = smeupConfig))
+    }
+
+    /**
      * Truncation of number by using Z-ADD. The source is greater than destination.
      * Source and destination are integer.
      * @see #LS24005040

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR49.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR49.rpgle
@@ -1,0 +1,6 @@
+     V* ==============================================================
+     D* 02/12/24
+     D* Purpose: Must fire the following errors during execution of
+     D* line 6 - Data reference *IN10 not resolved
+     V* ==============================================================
+     C     *LIKE         DEFINE    *IN10         XIN10

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00273.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00273.rpgle
@@ -1,0 +1,15 @@
+     V* ==============================================================
+     V* 28/11/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * DEFINE on an indicator
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, jariko throw a DataReference error
+     V* ==============================================================
+     C                   SETON                                        10
+     C                   EVAL      XIN10=*ON
+     C     XIN10         DSPLY
+     C                   EVAL      XIN10=*OFF
+     C     XIN10         DSPLY
+     C     *LIKE         DEFINE    *IN10         XIN10


### PR DESCRIPTION
## Description

Add support for `DEFINE` based on indicators.

Related to:
- LS24005143

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
