### PR TITLE
Bugfix/ls24005170/goto branching quit

### DIFF
--- a/docs/goto.md
+++ b/docs/goto.md
@@ -128,3 +128,8 @@ already execute their child on their own. Increasing the index by one instead of
 
 Eventually each `CompositeStatement` calls the base `execute(statements: List<Statement>)` method, therefore this method has to be
 imagined like a middleware to keep the context of `GOTO` calls sane and consistent called only when a `GOTO` exception is caught.
+
+## Next steps
+
+This implementation is very complex and has many nuances that are very hard to understand. 
+It would be ideal to further refactor it to make it simpler maybe by making it function like an assembly `JMP` call.

--- a/docs/goto.md
+++ b/docs/goto.md
@@ -1,0 +1,130 @@
+# `GOTO` Statement
+
+In this document we are going to discuss the implementation of the `GOTO` statement 
+from a technical standpoint.
+
+This can be useful to understand why specific design choices were made or help as a guide-line to better
+understand the execution flow and how to detect and approach `GOTO` issues during maintenance.
+
+## Assumptions
+
+To properly understand this document we assume:
+- You have technical knowledge of Jariko
+- You know the base Jariko structure and execution logic 
+- You know how GOTOs usually work in programming
+- You are familiar with Jariko and RPG common terminology
+
+This document will not go in the specific merit of what is mentioned in the list above.
+
+## How it works
+
+Let's start by describing how the `GOTO` works from a high-level standpoint as defined by the language.
+In RPG a `GOTO` works by moving the execution flow to a corresponding `TAG`, 
+just like you would intuitively expect in any other common programming language.
+
+Syntax-wise `GOTO`s can redirect to `TAG`s defined:
+- with the corresponding `TAG` statement.
+- at the end of a subroutine.
+
+`TAG` statements can be defined at any nesting level in `CompositeStatement`s.
+
+### Difference from other languages
+
+There is a limitation in behaviour from other common programming language. 
+
+In RPG a `GOTO` can only redirect to a `TAG`:
+- defined in the same subroutine or procedure.
+- defined at the top level.
+
+This actually simplifies our design allowing us to only look for `TAG`s in two "scopes" at most.
+
+## Understanding Jariko's execution logic
+
+Jariko executes statements by calling the interpreter method `execute(statements: List<Statement>)`. 
+
+This method knows the list of statements to execute and has the duty of keeping track of the order of the execution 
+of statements by their index and dispatch the `statement.execute()` for each of them.
+
+It is invoked mainly in two cases:
+- When trying to run the main body (see the method `execute(main: MainBody)`)
+- When a `CompositeStatement` needs to execute a subset of statements (for instance, its body).
+
+Therefore, the execution of Jariko statements works by tree-walking. The tree is composed by the ordered list of statements
+which, when composite, contain one or more child list of statement.
+
+### The execution state in the call stack
+
+For the above reason calls to `execute(statements: List<Statement>)` appear to be recursive.
+
+For instance in a real scenario, we might call a `DO -> IF -> SELECT` statement stack. 
+This would resolve multiple recursive calls making up something that looks like the following:
+
+```
+.
+└── MainBody
+    └── DO
+        ├── IF
+        ├── IF
+        ├── IF
+        │   └── SELECT
+        ├── IF
+        │   └── SELECT
+        ├── IF
+        └── ...
+```
+
+## Problems with the `GOTO` logic
+
+The logic we described arises several problems with the implementation of `GOTO`s.
+Here are the main ones:
+- `GOTO` can redirect to tags defined at any `CompositeStatement` nesting level.
+- `GOTO` execution start where the tag is defined and continues from there, not from the start of its containing scope as common.
+- After a `GOTO` ends we must be able to redirect the execution to the calling subroutine.
+- When the `TAG` is defined at top level we must redirect the flow there and never fall back to the subroutine containing the `GOTO`. We also must be able to intercept following exceptions in top level.
+- A `GOTO` must only redirect the execution without spawning a new call to `execute(statements: List<Statement>)`. Doing this would result in a stack overflow and multiple execution when the same GOTO is called multiple times sequentially.
+- If the `TAG` was defined in a `CompositeStatement`, after its execution ends, we must be able to restart execution from the next statement in its parent body.
+
+## The implementation 
+
+The implementation is constrained by the above requirements, solving all of them.
+
+### The control flow
+
+The flow of `GOTO`s is controlled by throwing two different kind of `ControlFlowException`s:
+- `GotoException`: the base exception thrown in case of a `GOTO` operation
+- `GotoTopLevelException`: the exception thrown when we specifically want to go to a `TAG` defined at top level.
+
+The distinction is needed in order to redirect to the correct scope and setup proper exception flows.
+
+### Exception catching
+
+These two exceptions are caught in two different points:
+- In `execute(main: MainBody)` we catch `GotoTopLevelException` recursively. The `GOTO` is executed in CU scope.
+- In `ExecuteSubroutine.execute()` we catch `GotoException`s recursively and promote them to `GotoTopLevelException` when needed. The `GOTO` is executed in subroutine scope or dispatched at top level.
+
+### The concept of "unwrapping"
+
+To bypass the limitations of `execute(statements: List<Statement>)` the concept of statement unwrapping has been introduced.
+It consists in taking the list of statements and exploding it while keeping track of the offset to the next statement to 
+execute and the parent `CompositeStatement` of each statement in the list.
+
+This has many benefit:
+- It allows us to find deeply nested `TAG`s.
+- It allows us to start execution from an arbitrary index in this list (that basically is the index of the `TAG`).
+- It gives us all the information about what are the statements before the `GOTO`. Needed to find `TAG`s defined before the `GOTO`.
+- It gives us all the information about the `CompositeStatement` tree containing the `GOTO`. Needed to resume the execution in the parent after the `CompositeStatement` containing the tag finishes its execution.
+- It allows us to only spawn a single `execute()` in the interpreter call stack to prevent stack overflows as discussed prior.
+
+Unwrapping is performed only once every time a `GOTO` throws its exception and gets caught.
+
+### Execution of unwrapped statements
+
+Unwrapped statements are executed in the interpreter method `executeUnwrappedAt(unwrappedStatements: List<UnwrappedStatementData>, offset: Int)`.
+
+It has a logic very similar to the `execute(statements: List<Statement>)` but after each statement gets executed it increases the execution index by the offset to the next statement associated with each unwrapped statement.
+
+This is because the list of unwrapped statements contains the reference of each statement in a linear fashion but `CompositeStatement`s
+already execute their child on their own. Increasing the index by one instead of the offset would result in duplicate execution.
+
+Eventually each `CompositeStatement` calls the base `execute(statements: List<Statement>)` method, therefore this method has to be
+imagined like a middleware to keep the context of `GOTO` calls sane and consistent called only when a `GOTO` exception is caught.

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
@@ -55,7 +55,7 @@ interface InterpreterCore {
     fun setIndicators(statement: WithRightIndicators, hi: BooleanValue, lo: BooleanValue, eq: BooleanValue)
     fun eval(expression: Expression): Value
     fun execute(statements: List<Statement>)
-    fun executeUnwrappedAt(unwrappedStatements: List<Statement>, offset: Int)
+    fun executeUnwrappedAt(unwrappedStatements: List<UnwrappedStatementData>, offset: Int)
     fun dbFile(name: String, statement: Statement): EnrichedDBFile
     fun toSearchValues(searchArgExpression: Expression, fileMetadata: FileMetadata): List<String>
     fun fillDataFrom(dbFile: EnrichedDBFile, record: Record)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/control_flow_exceptions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/control_flow_exceptions.kt
@@ -1,6 +1,6 @@
 package com.smeup.rpgparser.interpreter
 
-import com.smeup.rpgparser.parsing.ast.Statement
+import com.smeup.rpgparser.parsing.ast.UnwrappedStatementData
 import com.smeup.rpgparser.utils.indexOfTag
 import com.smeup.rpgparser.utils.runIfNotEmpty
 import java.io.File
@@ -24,7 +24,7 @@ class IterException : ControlFlowException()
  * @param tag The tag of the destination label
  */
 class GotoTopLevelException(val tag: String) : ControlFlowException() {
-    internal fun indexOfTaggedStatement(statements: List<Statement>) = statements.indexOfTag(tag)
+    internal fun indexOfTaggedStatement(statements: List<UnwrappedStatementData>) = statements.indexOfTag(tag)
 }
 
 // Useful to interrupt infinite cycles in tests
@@ -40,7 +40,7 @@ class GotoException private constructor(val tag: String) : ControlFlowException(
         operator fun invoke(tag: String): GotoException = GotoException(tag.uppercase(Locale.getDefault()))
     }
 
-    internal fun indexOfTaggedStatement(statements: List<Statement>) = statements.indexOfTag(tag)
+    internal fun indexOfTaggedStatement(statements: List<UnwrappedStatementData>) = statements.indexOfTag(tag)
 }
 
 class InterpreterTimeoutException(val programName: String, val elapsed: Long, val expected: Long) : ControlFlowException() {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -425,7 +425,7 @@ open class InternalInterpreter(
             execute(main.stmts)
         }.exceptionOrNull()
 
-        val unwrappedStatement = main.stmts.explode(true)
+        val unwrappedStatement = main.stmts.unwrap()
 
         // Recursive deal with top level goto flow
         while (throwable is GotoTopLevelException || throwable is GotoException) {
@@ -533,26 +533,12 @@ open class InternalInterpreter(
      * @param unwrappedStatements The unwrapped list of statements. It is up to the caller to ensure statements are unwrapped.
      * @param offset Offset to start the execution from.
      */
-    override fun executeUnwrappedAt(unwrappedStatements: List<Statement>, offset: Int) {
-        /**
-         * As we execute composite statements recursively, trying to sequentially execute
-         * the unwrapped statement list would result in executing every statement multiple times.
-         *
-         * The following instruction associates to each statement the offset to add in order to find
-         * the real next statement to execute in the list.
-         */
-        val offsetAwareStatements = unwrappedStatements.map {
-            WithOffset(
-                data = it,
-                offset = if (it is CompositeStatement) it.body.size else 0
-            )
-        }
-
+    override fun executeUnwrappedAt(unwrappedStatements: List<UnwrappedStatementData>, offset: Int) {
         var index = offset
-        while (index < offsetAwareStatements.size) {
-            val offsetStatement = offsetAwareStatements[index]
-            executeWithMute(offsetStatement.data)
-            index += offsetStatement.offset + 1
+        while (index < unwrappedStatements.size) {
+            val data = unwrappedStatements[index]
+            executeWithMute(data.statement)
+            index += data.nextOperationOffset + 1
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -111,6 +111,50 @@ interface CompositeStatement {
     val body: List<Statement>
 }
 
+data class UnwrappedStatementData(
+    var statement: Statement,
+    var nextOperationOffset: Int,
+    var parent: UnwrappedStatementData?
+)
+
+interface CustomStatementUnwrap {
+    fun unwrap(parent: UnwrappedStatementData? = null): List<UnwrappedStatementData>
+}
+
+/**
+ * Unwrap statements while keeping their structural data
+ * @see [InterpreterCore.executeUnwrappedAt]
+ */
+fun List<Statement>.unwrap(parent: UnwrappedStatementData? = null): List<UnwrappedStatementData> {
+    val result = mutableListOf<UnwrappedStatementData>()
+    forEach {
+        when (it) {
+            is CustomStatementUnwrap -> {
+                val unwrapped = it.unwrap(parent)
+                result.addAll(unwrapped)
+            }
+            is CompositeStatement -> {
+                val current = UnwrappedStatementData(it, it.body.size, parent)
+                val body = it.body.unwrap(current)
+
+                /**
+                 * body might contain CompositeStatements recursively
+                 * we need to update the offset with the actual body length after unwrapping
+                 */
+                current.nextOperationOffset = body.size
+
+                result.add(current)
+                result.addAll(body)
+            }
+            else -> {
+                val unwrapped = UnwrappedStatementData(it, 0, parent)
+                result.add(unwrapped)
+            }
+        }
+    }
+    return result
+}
+
 fun List<Statement>.explode(preserveCompositeStatement: Boolean = false): List<Statement> {
     val result = mutableListOf<Statement>()
     forEach {
@@ -145,8 +189,8 @@ data class ExecuteSubroutine(var subroutine: ReferenceByName<Subroutine>, overri
                 interpreter.execute(body)
             }.exceptionOrNull()
 
-            val unwrappedStatements = body.explode(true)
-            val containingCU = unwrappedStatements.firstOrNull()?.getContainingCompilationUnit()
+            val unwrappedStatements = body.unwrap()
+            val containingCU = unwrappedStatements.firstOrNull()?.statement?.getContainingCompilationUnit()
 
             // Recursive deal with goto
             while (throwable is GotoException) {
@@ -157,7 +201,7 @@ data class ExecuteSubroutine(var subroutine: ReferenceByName<Subroutine>, overri
                 }
 
                 // If tag is in top level we need to quit subroutine and rollback context to top level
-                val topLevelStatements = containingCU?.main?.stmts?.explode(true)
+                val topLevelStatements = containingCU?.main?.stmts?.unwrap()
                 topLevelStatements?.let {
                     val goto = throwable as GotoException
                     val topLevelIndex = goto.indexOfTaggedStatement(it)
@@ -212,7 +256,7 @@ data class SelectStmt(
     var other: SelectOtherClause? = null,
     @Derived val dataDefinition: InStatementDataDefinition? = null,
     override val position: Position? = null
-) : Statement(position), CompositeStatement, StatementThatCanDefineData {
+) : Statement(position), CompositeStatement, StatementThatCanDefineData, CustomStatementUnwrap {
     override val loggableEntityName: String
         get() = "SELECT"
 
@@ -265,6 +309,47 @@ data class SelectStmt(
             if (other?.body != null) result.addAll(other!!.body.explode(preserveCompositeStatement = true))
             return result
         }
+
+    override fun unwrap(parent: UnwrappedStatementData?): List<UnwrappedStatementData> {
+        val switchStmt = UnwrappedStatementData(this, this.body.size, parent)
+        val casesBodies = this.cases.map { it.body.unwrap(switchStmt) }
+        val otherBody = this.other?.body?.unwrap(switchStmt) ?: emptyList()
+
+        /**
+         * Unwrapped order is like following:
+         * - SELECT statement
+         * - 1 or more WHEN cases body instructions
+         * - optional OTHER with body instructions
+         * - next operation
+         */
+        val totalCasesStatementsCount = casesBodies.sumOf { it.size }
+        val nextOperationAt = totalCasesStatementsCount + otherBody.size
+        switchStmt.nextOperationOffset = nextOperationAt
+
+        /**
+         * Each branch last instruction must point to the end of the SWITCH statement
+         * after unwrapping we need to update the offset of each 'last' statement
+         */
+
+        // Update last pointer in when bodies
+        var alreadyProcessedCasesStatements = 0
+        for (case in casesBodies) {
+            val offsetOfLastStatement = alreadyProcessedCasesStatements + case.size
+            val lastStatementMustRedirectTo = nextOperationAt - offsetOfLastStatement
+            if (case.isNotEmpty()) {
+                case.last().nextOperationOffset = lastStatementMustRedirectTo
+            }
+            alreadyProcessedCasesStatements += case.size
+        }
+
+        // Update last pointer in else body
+        if (otherBody.isNotEmpty()) {
+            val lastStatementMustRedirectTo = nextOperationAt - totalCasesStatementsCount
+            otherBody.last().nextOperationOffset = lastStatementMustRedirectTo
+        }
+
+        return listOf(switchStmt) + casesBodies.flatten() + otherBody
+    }
 }
 
 @Serializable
@@ -1059,7 +1144,7 @@ data class IfStmt(
     val elseIfClauses: List<ElseIfClause> = emptyList(),
     val elseClause: ElseClause? = null,
     override val position: Position? = null
-) : Statement(position), CompositeStatement {
+) : Statement(position), CompositeStatement, CustomStatementUnwrap {
     override val loggableEntityName: String
         get() = "IF"
 
@@ -1120,6 +1205,57 @@ data class IfStmt(
                 interpreter.execute(elseClause.body)
             }
         }
+    }
+
+    override fun unwrap(parent: UnwrappedStatementData?): List<UnwrappedStatementData> {
+        val ifStmt = UnwrappedStatementData(this, this.body.size, parent)
+        val thenBody = this.thenBody.unwrap(ifStmt)
+        val elseIfBodies = this.elseIfClauses.map { it.body.unwrap(ifStmt) }
+        val elseBody = this.elseClause?.body?.unwrap(ifStmt) ?: emptyList()
+
+        /**
+         * Unwrapped order is like following:
+         * - IF statement
+         * - THEN body instructions
+         * - 0 or more ELSE IF with body instructions
+         * - optional ELSE with body instructions
+         * - next operation
+         */
+        val totalElseIfStatementsCount = elseIfBodies.sumOf { it.size }
+        val nextOperationAt = thenBody.size + totalElseIfStatementsCount + elseBody.size
+        ifStmt.nextOperationOffset = nextOperationAt
+
+        /**
+         * Each branch last instruction must point to the end of the IF statement
+         * after unwrapping we need to update the offset of each 'last' statement
+         */
+
+        // Update last pointer in then body
+        if (thenBody.isNotEmpty()) {
+            val offsetOfLastStatement = thenBody.size
+            val lastStatementMustRedirectTo = nextOperationAt - offsetOfLastStatement
+            thenBody.last().nextOperationOffset = lastStatementMustRedirectTo
+        }
+
+        // Update last pointer in else if bodies
+        var alreadyProcessedElifStatements = 0
+        for (elif in elseIfBodies) {
+            val offsetOfLastStatement = alreadyProcessedElifStatements + elif.size
+            val lastStatementMustRedirectTo = nextOperationAt - offsetOfLastStatement
+            if (elif.isNotEmpty()) {
+                elif.last().nextOperationOffset = lastStatementMustRedirectTo
+            }
+            alreadyProcessedElifStatements += elif.size
+        }
+
+        // Update last pointer in else body
+        if (elseBody.isNotEmpty()) {
+            val offsetOfLastStatement = thenBody.size + totalElseIfStatementsCount
+            val lastStatementMustRedirectTo = nextOperationAt - offsetOfLastStatement
+            elseBody.last().nextOperationOffset = lastStatementMustRedirectTo
+        }
+
+        return listOf(ifStmt) + thenBody + elseIfBodies.flatten() + elseBody
     }
 
     override fun getStatementLogRenderer(source: LogSourceProvider, action: String): LazyLogEntry {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
@@ -18,8 +18,8 @@ package com.smeup.rpgparser.utils
 
 import com.smeup.rpgparser.execution.ParsingProgram
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
-import com.smeup.rpgparser.parsing.ast.Statement
 import com.smeup.rpgparser.parsing.ast.TagStmt
+import com.smeup.rpgparser.parsing.ast.UnwrappedStatementData
 import com.strumenta.kolasu.model.Node
 import com.strumenta.kolasu.model.ancestor
 import java.math.BigDecimal
@@ -176,6 +176,6 @@ internal fun <T> Stack<T>.peekOrNull(): T? = if (isNotEmpty()) {
  */
 internal fun Node.getContainingCompilationUnit() = ancestor(CompilationUnit::class.java)
 
-internal fun List<Statement>.indexOfTag(tag: String) = indexOfFirst {
-    it is TagStmt && it.tag.lowercase() == tag.lowercase()
+internal fun List<UnwrappedStatementData>.indexOfTag(tag: String) = indexOfFirst {
+    it.statement is TagStmt && (it.statement as TagStmt).tag.lowercase() == tag.lowercase()
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -1418,6 +1418,12 @@ Test 6
     }
 
     @Test
+    fun executeGOTOTST13() {
+        val expected = listOf("ok")
+        assertEquals(expected, outputOf("GOTOTST13"))
+    }
+
+    @Test
     fun executeGotoENDSR() {
         assertEquals(listOf("1", "2", "3"), outputOf("GOTOENDSR"))
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -1424,6 +1424,12 @@ Test 6
     }
 
     @Test
+    fun executeGOTOTST14() {
+        val expected = listOf("1", "2")
+        assertEquals(expected, outputOf("GOTOTST14"))
+    }
+
+    @Test
     fun executeGotoENDSR() {
         assertEquals(listOf("1", "2", "3"), outputOf("GOTOENDSR"))
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -1406,6 +1406,18 @@ Test 6
     }
 
     @Test
+    fun executeGOTOTST11() {
+        val expected = listOf("ok")
+        assertEquals(expected, outputOf("GOTOTST11"))
+    }
+
+    @Test
+    fun executeGOTOTST12() {
+        val expected = listOf("ok")
+        assertEquals(expected, outputOf("GOTOTST12"))
+    }
+
+    @Test
     fun executeGotoENDSR() {
         assertEquals(listOf("1", "2", "3"), outputOf("GOTOENDSR"))
     }

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST11.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST11.rpgle
@@ -1,0 +1,13 @@
+     V* ==============================================================
+     V* 29/11/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a GOTO into an IF with an ELSE body
+     V* ==============================================================
+     C                   GOTO      BGN
+     C                   IF        *OFF
+     C     BGN           TAG
+     C     'ok'          DSPLY
+     C                   ELSE
+     C     'ko'          DSPLY
+     C                   ENDIF

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST12.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST12.rpgle
@@ -1,0 +1,15 @@
+     V* ==============================================================
+     V* 29/11/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a GOTO into an IF with an ELSE IF body
+     V* ==============================================================
+     C                   GOTO      BGN
+     C                   IF        *OFF
+     C     'ko'          DSPLY
+     C                   ELSEIF    *OFF
+     C     BGN           TAG
+     C     'ok'          DSPLY
+     C                   ELSE
+     C     'ko'          DSPLY
+     C                   ENDIF

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST13.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST13.rpgle
@@ -1,0 +1,41 @@
+     V* ==============================================================
+     V* 02/12/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a GOTO into an IF with an ELSE IF body
+    O * with multiple nested CompositeStatement
+    O * duplications are needed to shift each instruction index
+     V* ==============================================================
+     C                   GOTO      BGN
+     C                   IF        *OFF
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C                   ELSEIF    *OFF
+     C     BGN           TAG
+     C     'ok'          DSPLY
+     C                   ELSE
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C                   IF        *OFF
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C                   IF        *OFF
+     C                   IF        *OFF
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C                   ENDIF
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C     'ko'          DSPLY
+     C                   ENDIF
+     C                   ENDIF
+     C                   ENDIF

--- a/rpgJavaInterpreter-core/src/test/resources/GOTOTST14.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/GOTOTST14.rpgle
@@ -1,0 +1,19 @@
+     V* ==============================================================
+     V* 02/12/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Execute a SELECT with a GOTO to a TAG in its first branch
+     V* ==============================================================
+     C                   GOTO      BGN
+     C                   SELECT
+     C                   WHEN      1=2
+     C     'ko'          DSPLY
+     C                   WHEN      2=3
+     C     BGN           TAG
+     C     '1'           DSPLY
+     C                   WHEN      3=4
+     C     'ko'          DSPLY
+     C                   OTHER
+     C     'ko'          DSPLY
+     C                   ENDSL
+     C     '2'           DSPLY


### PR DESCRIPTION
## Description

Fix an issue that caused `GOTO` pointing inside statements with branches not to quit the statement after the corresponding branch execution was finished.

### Technical notes

The issue was caused by the fact that after the statement unwrapping (needed to perform `GOTO` jumps in nested operations without particular overhead, see #643) we lost cognition of where each branch teminated, treating each subsequent instruction as a standalone non-scoped instruction.

To address this issue:
- The concept of unwrapping was separated from just doing an explode on statements
- A dedicated `UnwrappedStatementData` structure was created to enforce clean and understandable interfaces when dealing with unwrapped statements
- A new utility `List<Statement>.unwrap()` method was added (with a behaviour similar to `List<Statement>.explode()` but with custom logics)
- A new `CustomStatementUnwrap` interface was added to allow custom unwrap behaviour for inheriting statements. There should really be only 2 (`IF`, `SELECT`) but this mechanism allow for easier debug, more coincise code, separation of concerns and easier maintenance in case with find further issues. All for a very low cost.

Related to:
- LS24005170
- #643

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [x] Relevant documentation is included in the `docs` directory.
