### PR TITLE
Bugfix/ls24005232/select with other only

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -396,9 +396,14 @@ onError:
 selectstatement:
     (beginselect endselect) |
 	(beginselect
-	whenstatement+
-	other?
+	whenstatement*
+	otherstatement?
 	endselect)
+;
+
+otherstatement:
+    other
+    statement*
 ;
 
 other:

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -663,4 +663,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("0", "0", "0", "1", "1", "1")
         assertEquals(expected, "smeup/MUDRNRAPU00167".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * SELECT statement containing only a OTHER clause
+     * @see #LS24005232
+     */
+    @Test
+    fun executeMUDRNRAPU00274() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00274".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00274.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00274.rpgle
@@ -1,0 +1,13 @@
+     V* ==============================================================
+     V* 03/12/2024 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * SELECT operation containing only a OTHER branch
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, jariko throw a syntax error
+     V* ==============================================================
+     C                   SELECT
+     C                   OTHER
+     C     'ok'          DSPLY
+     C                   ENDSL


### PR DESCRIPTION
## Description

Allow `SELECT` to only contain a `OTHER` branch.

### Technical notes

Changes consists of two parts:
- A new rule in the parsing grammar
- Management of the corner case during AST creation

Related to:
- LS24005232

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
