### PR TITLE
Bugfix/LS24005305/`IF` comparison by using `*HIVAL`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -110,7 +110,12 @@ class ExpressionEvaluation(
 
     override fun eval(expression: EqualityExpr): Value = proxyLogging(expression) {
         val left = expression.left.evalWith(this)
-        val right = expression.right.evalWith(this)
+        val right = when (expression.right) {
+            /* In this case there is a comparison from *HIVAL and a generic Value. Is important to take the right "HIVAL" based of left side. */
+            is HiValExpr -> expression.left.type().hiValue()
+            // TODO: To provide, in the future, other cases by using special keyword.
+            else -> expression.right.evalWith(this)
+        }
         areEquals(left, right).asValue()
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -109,7 +109,12 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: EqualityExpr): Value = proxyLogging(expression) {
-        val left = expression.left.evalWith(this)
+        val left = when (expression.right) {
+            /* In this case there is a comparison from *HIVAL and a generic Value. Is important to take the right "HIVAL" based of right side. */
+            is HiValExpr -> expression.right.type().hiValue()
+            // TODO: To provide, in the future, other cases by using special keyword.
+            else -> expression.left.evalWith(this)
+        }
         val right = when (expression.right) {
             /* In this case there is a comparison from *HIVAL and a generic Value. Is important to take the right "HIVAL" based of left side. */
             is HiValExpr -> expression.left.type().hiValue()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -110,6 +110,7 @@ class ExpressionEvaluation(
 
     override fun eval(expression: EqualityExpr): Value = proxyLogging(expression) {
         val left = when (expression.right) {
+        val left = when (expression.left) {
             /* In this case there is a comparison from *HIVAL and a generic Value. Is important to take the right "HIVAL" based of right side. */
             is HiValExpr -> expression.right.type().hiValue()
             // TODO: To provide, in the future, other cases by using special keyword.

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -109,18 +109,32 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: EqualityExpr): Value = proxyLogging(expression) {
-        val left = when (expression.left) {
-            /* In this case there is a comparison from *HIVAL and a generic Value. Is important to take the right "HIVAL" based of right side. */
-            is HiValExpr -> expression.right.type().hiValue()
-            // TODO: To provide, in the future, other cases by using special keyword.
-            else -> expression.left.evalWith(this)
+        /**
+         * Evaluates and retrieves a `Value` based on the provided expressions.
+         *
+         * This function handles special cases, such as comparisons involving `*HIVAL`.
+         * When one of the expressions is `*HIVAL`, the appropriate high value is determined
+         * based on the type of the other expression. For all other cases, the first expression
+         * is evaluated using the current context.
+         *
+         * Either `expression1` or `expression2` can represent the left or right side of the evaluation,
+         * making their roles interchangeable in this context.
+         *
+         * @param expression1 one of the expressions to evaluate
+         * @param expression2 the other expression, used to determine the appropriate `*HIVAL` value when applicable
+         * @return the evaluated `Value` based on the expressions
+         */
+        fun getValue(expression1: Expression, expression2: Expression): Value {
+            return when (expression1) {
+                /* In this case there is a comparison from *HIVAL and a generic Value. Is important to take the right "HIVAL" based the other side. */
+                is HiValExpr -> expression2.type().hiValue()
+                // TODO: To provide, in the future, other cases by using special keyword.
+                else -> expression1.evalWith(this)
+            }
         }
-        val right = when (expression.right) {
-            /* In this case there is a comparison from *HIVAL and a generic Value. Is important to take the right "HIVAL" based of left side. */
-            is HiValExpr -> expression.left.type().hiValue()
-            // TODO: To provide, in the future, other cases by using special keyword.
-            else -> expression.right.evalWith(this)
-        }
+
+        val left = getValue(expression1 = expression.left, expression2 = expression.right)
+        val right = getValue(expression1 = expression.right, expression2 = expression.left)
         areEquals(left, right).asValue()
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -109,7 +109,6 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: EqualityExpr): Value = proxyLogging(expression) {
-        val left = when (expression.right) {
         val left = when (expression.left) {
             /* In this case there is a comparison from *HIVAL and a generic Value. Is important to take the right "HIVAL" based of right side. */
             is HiValExpr -> expression.right.type().hiValue()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -109,32 +109,8 @@ class ExpressionEvaluation(
     }
 
     override fun eval(expression: EqualityExpr): Value = proxyLogging(expression) {
-        /**
-         * Evaluates and retrieves a `Value` based on the provided expressions.
-         *
-         * This function handles special cases, such as comparisons involving `*HIVAL`.
-         * When one of the expressions is `*HIVAL`, the appropriate high value is determined
-         * based on the type of the other expression. For all other cases, the first expression
-         * is evaluated using the current context.
-         *
-         * Either `expression1` or `expression2` can represent the left or right side of the evaluation,
-         * making their roles interchangeable in this context.
-         *
-         * @param expression1 one of the expressions to evaluate
-         * @param expression2 the other expression, used to determine the appropriate `*HIVAL` value when applicable
-         * @return the evaluated `Value` based on the expressions
-         */
-        fun getValue(expression1: Expression, expression2: Expression): Value {
-            return when (expression1) {
-                /* In this case there is a comparison from *HIVAL and a generic Value. Is important to take the right "HIVAL" based the other side. */
-                is HiValExpr -> expression2.type().hiValue()
-                // TODO: To provide, in the future, other cases by using special keyword.
-                else -> expression1.evalWith(this)
-            }
-        }
-
-        val left = getValue(expression1 = expression.left, expression2 = expression.right)
-        val right = getValue(expression1 = expression.right, expression2 = expression.left)
+        val left = expression.left.evalWith(this)
+        val right = expression.right.evalWith(this)
         areEquals(left, right).asValue()
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -372,16 +372,6 @@ private fun computeHiValue(type: NumberType): Value {
     TODO("Type ${type.rpgType} with ${type.entireDigits} digit is not valid")
 }
 
-private fun computeLowValue(type: StringType): Value = StringValue(lowValueString(type))
-
-private fun computeHiValue(type: StringType): Value = StringValue(hiValueString(type))
-
-// TODO
-fun lowValueString(type: StringType) = " ".repeat(type.size)
-
-// TODO
-fun hiValueString(type: StringType) = "\uFFFF".repeat(type.size)
-
 private fun computeLowValue(type: NumberType): Value {
     // Packed and Zone
     if (type.rpgType == RpgType.PACKED.rpgType || type.rpgType == RpgType.ZONED.rpgType || type.rpgType.isNullOrBlank()) {
@@ -414,3 +404,13 @@ private fun computeLowValue(type: NumberType): Value {
     }
     TODO("Type '${type.rpgType}' with ${type.entireDigits} digit is not valid")
 }
+
+private fun computeHiValue(type: StringType): Value = StringValue(hiValueString(type.size))
+
+private fun computeLowValue(type: StringType): Value = StringValue(lowValueString(type.size))
+
+// TODO
+private fun hiValueString(size: Int) = "\uFFFF".repeat(size)
+
+// TODO
+private fun lowValueString(size: Int) = " ".repeat(size)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -331,6 +331,13 @@ fun Type.hiValue(): Value {
     }
 }
 
+fun Value.hiValue(): Value {
+    return when (this) {
+        is StringValue -> StringValue(hiValueString(this.value.length))
+        else -> TODO("Converting HiValValue to $this")
+    }
+}
+
 private fun computeHiValue(type: NumberType): Value {
     // Packed and Zone
     if (type.rpgType == RpgType.PACKED.rpgType || type.rpgType == RpgType.ZONED.rpgType || type.rpgType == "") {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -807,6 +807,13 @@ object HiValValue : Value {
     override fun asString(): StringValue {
         TODO("Not yet implemented")
     }
+
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            is StringValue -> other.hiValue() == other
+            else -> false
+        }
+    }
 }
 
 object LowValValue : Value {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -119,6 +119,7 @@ data class StringValue(var value: String, var varying: Boolean = false) : Abstra
     override fun equals(other: Any?): Boolean {
         return when (other) {
             is StringValue -> this.value == other.value
+            is HiValValue -> this == this.hiValue()
             else -> false
         }
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -117,10 +117,9 @@ data class StringValue(var value: String, var varying: Boolean = false) : Abstra
     }
 
     override fun equals(other: Any?): Boolean {
-        return if (other is StringValue) {
-            this.value == other.value
-        } else {
-            false
+        return when (other) {
+            is StringValue -> this.value == other.value
+            else -> false
         }
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -792,12 +792,22 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * IF comparison by using *HIVAL.
+     * IF comparison by using *HIVAL, right side.
      * @see #LS24005305
      */
     @Test
     fun executeMUDRNRAPU00180() {
         val expected = listOf("TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00180".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * IF comparison by using *HIVAL, left side.
+     * @see #LS24005305
+     */
+    @Test
+    fun executeMUDRNRAPU00181() {
+        val expected = listOf("TRUE", "END")
+        assertEquals(expected, "smeup/MUDRNRAPU00181".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -790,4 +790,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("CALLED", "BAZ", "BAZ", "CALLER", "BAZ", "BAZ")
         assertEquals(expected, "smeup/MUDRNRAPU00179".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * IF comparison by using *HIVAL.
+     * @see #LS24005305
+     */
+    @Test
+    fun executeMUDRNRAPU00180() {
+        val expected = listOf("TRUE", "END")
+        assertEquals(expected, "smeup/MUDRNRAPU00180".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00180.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00180.rpgle
@@ -1,0 +1,17 @@
+     V* ==============================================================
+     V* 06/12/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * IF comparison by using *HIVAL at right side.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The expression is not evaluated when it's true.
+     V* ==============================================================
+     D$$AZIE           S              2    DIM(100) INZ(*HIVAL)
+
+     C                   IF        $$AZIE(1)=*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00181.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00181.rpgle
@@ -1,0 +1,17 @@
+     V* ==============================================================
+     V* 06/12/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * IF comparison by using *HIVAL at left side.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The expression is not evaluated when it's true.
+     V* ==============================================================
+     D$$AZIE           S              2    DIM(100) INZ(*HIVAL)
+
+     C                   IF        *HIVAL=$$AZIE(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work improves the `IF` operation which compares `*HIVAL` with a content of a variable could also have `*HIVAL`, like this snippet:
```
     D ARRAY           S              2    DIM(100) INZ(*HIVAL)

     C                   IF        *HIVAL=ARRAY(1)
     ...
     C                   ENDIF
```

### Technical notes
On Jariko this utilization provokes a semantic error: the _true_ branch isn't evaluated when the condition is true. Under the hood there was comparison between:
- `*HIVAL` as `9223372036854775807` (in Kotlin is long max value);
- `ARRAY(1)` as `"\uFFFF"`.

The values are right but the comparison is wrong. The `*HIVAL` constant must refer to the type of `ARRAY` element. So, I have simply improved `coercing`. Then `equals` for `StringValue` and `HiValValue`. With this new fix, in that circumstance, `*HIVAL` will not be the generic _(2^63) -1_ but the `*HIVAL` of `StringType`.

Related to #LS24005305

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
