### PR TITLE
Bugfix/LS24005314/Fix DS value size at next assignment

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -170,7 +170,7 @@ private fun coerceString(value: StringValue, type: Type): Value {
             if (value.isBlank()) {
                 type.blank()
             } else {
-                DataStructValue(value.value.padEnd(6))
+                DataStructValue(value.value.padEnd(type.elementSize))
             }
         }
         is CharacterType -> {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -170,7 +170,7 @@ private fun coerceString(value: StringValue, type: Type): Value {
             if (value.isBlank()) {
                 type.blank()
             } else {
-                DataStructValue(value.value)
+                DataStructValue(value.value.padEnd(6))
             }
         }
         is CharacterType -> {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -810,4 +810,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00181".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Assign a new value to a DS preserving the original DS size.
+     * @see #LS24005305
+     */
+    @Test
+    fun executeMUDRNRAPU00182() {
+        val expected = listOf("      ", "FOO", "BAR", "BARX")
+        assertEquals(expected, "smeup/MUDRNRAPU00182".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -813,7 +813,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
 
     /**
      * Assign a new value to a DS preserving the original DS size.
-     * @see #LS24005305
+     * @see #LS24005314
      */
     @Test
     fun executeMUDRNRAPU00182() {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -817,7 +817,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00182() {
-        val expected = listOf("      ", "FOO", "BAR", "BARX")
+        val expected = listOf("", "FOO", "BAR", "BARX")
         assertEquals(expected, "smeup/MUDRNRAPU00182".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00182.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00182.rpgle
@@ -1,0 +1,26 @@
+     V* ==============================================================
+     V* 09/12/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Assign a new value to a DS preserving the original DS size.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * DS1 value size changes to a size of a new value during assignment.
+    O * This causes:
+    O * `Issue arose while setting field DS1_FLD_2. Indexes: 3 to 4.
+    O *   Field size: 1. Value: StringValue[1](X)`
+    O * on a legal assignment.
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_FLD_1                     3
+     D  DS1_FLD_2                     1
+     D  DS1_FLD_3                     2
+
+     C     DS1           DSPLY
+     C                   EVAL      DS1='FOO'
+     C     DS1           DSPLY
+     C                   EVAL      DS1_FLD_1='BAR'
+     C     DS1           DSPLY
+     C                   EVAL      DS1_FLD_2='X'                                #Issue arose while setting field DS1_FLD_2. Indexes: 3 to 4. Field size: 1. Value: StringValue[1](X)
+     C     DS1           DSPLY
+     C                   SETON                                        RT


### PR DESCRIPTION
## Description
This work solves the DS value size at new assignment, like this snippet:
```
     D DS1             DS
     D  DS1_FLD_1                     3
     D  DS1_FLD_2                     1
     D  DS1_FLD_3                     2

     C                   EVAL      DS1='FOO'
     ...
     C                   EVAL      DS1_FLD_1='BAR'
     ...
     C                   EVAL      DS1_FLD_2='X'
```

### Technical notes
By considering this snippet, on Jariko the initial value of DS is blank with size as 6. A new assignment (`DS1='FOO'`) made the size of `DS` value as 3, without pad at the end. So, a new assignment to a specific field (`DS1_FLD_2='X'`), which is over over the new size, generates `Issue arose while setting field DS1_FLD_2. Indexes: 3 to 4. Field size: 1. Value: StringValue[1](X)`. So, with this fix every new assignment preserves the right size.

Related to #LS24005314

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
