### PR TITLE
Bugfix/LS24005329/Improve comparison between `*HIVAL` and String

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -211,7 +211,7 @@ data class StringValue(var value: String, var varying: Boolean = false) : Abstra
     override operator fun compareTo(other: Value): Int =
         when (other) {
             is StringValue -> compare(other, DEFAULT_CHARSET)
-            is HiValValue -> if (this == this.hiValue()) 0 else -1
+            is HiValValue -> if (this == this.hiValue()) EQUAL else SMALLER
             is BlanksValue -> if (this.isBlank()) EQUAL else SMALLER
             is BooleanValue -> if (this.value.isInt() && this.value.toInt() == other.value.toInt()) EQUAL else GREATER
             else -> super.compareTo(other)
@@ -804,8 +804,8 @@ object HiValValue : Value {
 
     override operator fun compareTo(other: Value): Int {
         return when (other) {
-            is StringValue -> if (other.hiValue() == other) 0 else 1
-            else -> if (other is HiValValue) 0 else 1
+            is StringValue -> if (other.hiValue() == other) EQUAL else GREATER
+            else -> if (other is HiValValue) EQUAL else GREATER   // TODO: Is much generic. Provide atomic cases.
         }
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -211,6 +211,7 @@ data class StringValue(var value: String, var varying: Boolean = false) : Abstra
     override operator fun compareTo(other: Value): Int =
         when (other) {
             is StringValue -> compare(other, DEFAULT_CHARSET)
+            is HiValValue -> if (this == this.hiValue()) 0 else -1
             is BlanksValue -> if (this.isBlank()) EQUAL else SMALLER
             is BooleanValue -> if (this.value.isInt() && this.value.toInt() == other.value.toInt()) EQUAL else GREATER
             else -> super.compareTo(other)
@@ -801,8 +802,12 @@ object HiValValue : Value {
 
     override fun copy(): HiValValue = this
 
-    override operator fun compareTo(other: Value): Int =
-        if (other is HiValValue) 0 else 1
+    override operator fun compareTo(other: Value): Int {
+        return when (other) {
+            is StringValue -> if (other.hiValue() == other) 0 else 1
+            else -> if (other is HiValValue) 0 else 1
+        }
+    }
 
     override fun asString(): StringValue {
         TODO("Not yet implemented")

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -805,7 +805,8 @@ object HiValValue : Value {
     override operator fun compareTo(other: Value): Int {
         return when (other) {
             is StringValue -> if (other.hiValue() == other) EQUAL else GREATER
-            else -> if (other is HiValValue) EQUAL else GREATER   // TODO: Is much generic. Provide atomic cases.
+            // TODO: Is much generic. Provide atomic cases.
+            else -> if (other is HiValValue) EQUAL else GREATER
         }
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -825,12 +825,15 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * Comparison between *HIVAL and String by using "greater" operator for `*HIVAL`.
+     * Comparison between:
+     * - *HIVAL and String,
+     * - *HIVAL and *HIVAL
+     * by using "greater" operator.
      * @see #LS24005329
      */
     @Test
     fun executeMUDRNRAPU00184() {
-        val expected = listOf("TRUE", "END", "TRUE", "END")
+        val expected = listOf("TRUE", "END", "TRUE", "END", "END", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00184".outputOf(configuration = smeupConfig))
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -830,4 +830,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("TRUE", "END", "TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00184".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Comparison between *HIVAL and String by using "greater/equal" operator for `*HIVAL`.
+     * @see #LS24005329
+     */
+    @Test
+    fun executeMUDRNRAPU00185() {
+        val expected = listOf("TRUE", "END", "TRUE", "END")
+        assertEquals(expected, "smeup/MUDRNRAPU00185".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -812,12 +812,15 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * Comparison between *HIVAL and String by using "not equal" operator.
+     * Comparison between:
+     * - *HIVAL and String,
+     * - *HIVAL and *HIVAL
+     * by using "not equal" operator.
      * @see #LS24005329
      */
     @Test
     fun executeMUDRNRAPU00183() {
-        val expected = listOf("TRUE", "END", "TRUE", "END")
+        val expected = listOf("TRUE", "END", "TRUE", "END", "END", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00183".outputOf(configuration = smeupConfig))
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -817,7 +817,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00183() {
-        val expected = listOf("TRUE", "END")
+        val expected = listOf("TRUE", "END", "TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00183".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -810,4 +810,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00181".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Comparison between *HIVAL, at left side, and String by using "not equal" operator.
+     * @see #LS24005329
+     */
+    @Test
+    fun executeMUDRNRAPU00183() {
+        val expected = listOf("TRUE", "END")
+        assertEquals(expected, "smeup/MUDRNRAPU00183".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -812,7 +812,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * Comparison between *HIVAL, at left side, and String by using "not equal" operator.
+     * Comparison between *HIVAL and String by using "not equal" operator.
      * @see #LS24005329
      */
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -864,12 +864,15 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * Comparison between *HIVAL and String by using "lower/equal" operator for `*HIVAL`.
+     * Comparison between:
+     * - *HIVAL and String,
+     * - *HIVAL and *HIVAL
+     * by using "lower/equal" operator.
      * @see #LS24005329
      */
     @Test
     fun executeMUDRNRAPU00187() {
-        val expected = listOf("END", "END")
+        val expected = listOf("END", "END", "TRUE", "END", "TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00187".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -840,4 +840,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("TRUE", "END", "TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00185".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Comparison between *HIVAL and String by using "lower" operator for `*HIVAL`.
+     * @see #LS24005329
+     */
+    @Test
+    fun executeMUDRNRAPU00186() {
+        val expected = listOf("END", "END")
+        assertEquals(expected, "smeup/MUDRNRAPU00186".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -850,4 +850,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("END", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00186".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Comparison between *HIVAL and String by using "lower/equal" operator for `*HIVAL`.
+     * @see #LS24005329
+     */
+    @Test
+    fun executeMUDRNRAPU00187() {
+        val expected = listOf("END", "END")
+        assertEquals(expected, "smeup/MUDRNRAPU00187".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -875,4 +875,17 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("END", "END", "TRUE", "END", "TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00187".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Comparison between:
+     * - *HIVAL as Standalone of 2 chars,
+     * - *HIVAL as Standalone of 4 chars,
+     * by using "equal" operator.
+     * @see #LS24005329
+     */
+    @Test
+    fun executeMUDRNRAPU00188() {
+        val expected = listOf("END")
+        assertEquals(expected, "smeup/MUDRNRAPU00188".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -820,4 +820,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("TRUE", "END", "TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00183".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Comparison between *HIVAL and String by using "greater" operator for `*HIVAL`.
+     * @see #LS24005329
+     */
+    @Test
+    fun executeMUDRNRAPU00184() {
+        val expected = listOf("TRUE", "END", "TRUE", "END")
+        assertEquals(expected, "smeup/MUDRNRAPU00184".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -838,12 +838,15 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * Comparison between *HIVAL and String by using "greater/equal" operator for `*HIVAL`.
+     * Comparison between:
+     * - *HIVAL and String,
+     * - *HIVAL and *HIVAL
+     * by using "greater/equals" operator.
      * @see #LS24005329
      */
     @Test
     fun executeMUDRNRAPU00185() {
-        val expected = listOf("TRUE", "END", "TRUE", "END")
+        val expected = listOf("TRUE", "END", "TRUE", "END", "TRUE", "END", "TRUE", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00185".outputOf(configuration = smeupConfig))
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -841,7 +841,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      * Comparison between:
      * - *HIVAL and String,
      * - *HIVAL and *HIVAL
-     * by using "greater/equals" operator.
+     * by using "greater/equal" operator.
      * @see #LS24005329
      */
     @Test
@@ -851,12 +851,15 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * Comparison between *HIVAL and String by using "lower" operator for `*HIVAL`.
+     * Comparison between:
+     * - *HIVAL and String,
+     * - *HIVAL and *HIVAL
+     * by using "lower" operator.
      * @see #LS24005329
      */
     @Test
     fun executeMUDRNRAPU00186() {
-        val expected = listOf("END", "END")
+        val expected = listOf("END", "END", "END", "END")
         assertEquals(expected, "smeup/MUDRNRAPU00186".outputOf(configuration = smeupConfig))
     }
 

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00183.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00183.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 10/12/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Comparison between *HIVAL, at left side, and String
+    O *  by using "not equal" operator.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The expression is not evaluated when it's true.
+     V* ==============================================================
+     D$$AZIE           S              2    DIM(100) INZ('FF')
+
+     C                   IF        *HIVAL<>$$AZIE(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00183.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00183.rpgle
@@ -8,14 +8,14 @@
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
-     D$$AZIE           S              2    DIM(100) INZ('FF')
+     D ARR01           S              2    DIM(10) INZ('FF')
 
-     C                   IF        *HIVAL<>$$AZIE(1)
+     C                   IF        *HIVAL<>ARR01(1)
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY
 
-     C                   IF        $$AZIE(1)<>*HIVAL
+     C                   IF        ARR01(1)<>*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00183.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00183.rpgle
@@ -2,13 +2,16 @@
      V* 10/12/2024 APU001 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Comparison between *HIVAL and String by using "not equal"
-    O *  operator.
+    O * Comparison between:
+    O * - *HIVAL and String,
+    O * - *HIVAL and *HIVAL
+    O * by using "not equal" operator.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
      D ARR01           S              2    DIM(10) INZ('FF')
+     D ARR02           S              2    DIM(10) INZ(*HIVAL)
 
      C                   IF        *HIVAL<>ARR01(1)
      C     'TRUE'        DSPLY
@@ -16,6 +19,16 @@
      C     'END'         DSPLY
 
      C                   IF        ARR01(1)<>*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        *HIVAL<>ARR02(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        ARR02(1)<>*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00183.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00183.rpgle
@@ -2,8 +2,8 @@
      V* 10/12/2024 APU001 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Comparison between *HIVAL, at left side, and String
-    O *  by using "not equal" operator.
+    O * Comparison between *HIVAL and String by using "not equal"
+    O *  operator.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
@@ -11,6 +11,11 @@
      D$$AZIE           S              2    DIM(100) INZ('FF')
 
      C                   IF        *HIVAL<>$$AZIE(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        $$AZIE(1)<>*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00184.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00184.rpgle
@@ -2,13 +2,16 @@
      V* 10/12/2024 APU001 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Comparison between *HIVAL and String by using "greater"
-    O *  operator for `*HIVAL`.
+    O * Comparison between:
+    O * - *HIVAL and String,
+    O * - *HIVAL and *HIVAL
+    O * by using "greater" operator.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
      D ARR01           S              2    DIM(10) INZ('FF')
+     D ARR02           S              2    DIM(10) INZ(*HIVAL)
 
      C                   IF        *HIVAL>ARR01(1)
      C     'TRUE'        DSPLY
@@ -16,6 +19,16 @@
      C     'END'         DSPLY
 
      C                   IF        ARR01(1)<*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        *HIVAL>ARR02(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        ARR02(1)<*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00184.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00184.rpgle
@@ -8,14 +8,14 @@
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
-     D$$AZIE           S              2    DIM(100) INZ('FF')
+     D ARR01           S              2    DIM(10) INZ('FF')
 
-     C                   IF        *HIVAL>$$AZIE(1)
+     C                   IF        *HIVAL>ARR01(1)
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY
 
-     C                   IF        $$AZIE(1)<*HIVAL
+     C                   IF        ARR01(1)<*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00184.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00184.rpgle
@@ -1,0 +1,23 @@
+     V* ==============================================================
+     V* 10/12/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Comparison between *HIVAL and String by using "greater"
+    O *  operator for `*HIVAL`.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The expression is not evaluated when it's true.
+     V* ==============================================================
+     D$$AZIE           S              2    DIM(100) INZ('FF')
+
+     C                   IF        *HIVAL>$$AZIE(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        $$AZIE(1)<*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00185.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00185.rpgle
@@ -2,13 +2,16 @@
      V* 10/12/2024 APU001 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Comparison between *HIVAL and String by using "greater/equal"
-    O *  operator for `*HIVAL`.
+    O * Comparison between:
+    O * - *HIVAL and String,
+    O * - *HIVAL and *HIVAL
+    O * by using "greater/equal" operator.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
      D ARR01           S              2    DIM(10) INZ('FF')
+     D ARR02           S              2    DIM(10) INZ('FF')
 
      C                   IF        *HIVAL>=ARR01(1)
      C     'TRUE'        DSPLY
@@ -16,6 +19,16 @@
      C     'END'         DSPLY
 
      C                   IF        ARR01(1)<=*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        *HIVAL>=ARR02(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        ARR02(1)<=*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00185.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00185.rpgle
@@ -8,14 +8,14 @@
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
-     D$$AZIE           S              2    DIM(100) INZ('FF')
+     D ARR01           S              2    DIM(10) INZ('FF')
 
-     C                   IF        *HIVAL>=$$AZIE(1)
+     C                   IF        *HIVAL>=ARR01(1)
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY
 
-     C                   IF        $$AZIE(1)<=*HIVAL
+     C                   IF        ARR01(1)<=*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00185.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00185.rpgle
@@ -1,0 +1,23 @@
+     V* ==============================================================
+     V* 10/12/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Comparison between *HIVAL and String by using "greater/equal"
+    O *  operator for `*HIVAL`.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The expression is not evaluated when it's true.
+     V* ==============================================================
+     D$$AZIE           S              2    DIM(100) INZ('FF')
+
+     C                   IF        *HIVAL>=$$AZIE(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        $$AZIE(1)<=*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00185.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00185.rpgle
@@ -11,7 +11,7 @@
     O * The expression is not evaluated when it's true.
      V* ==============================================================
      D ARR01           S              2    DIM(10) INZ('FF')
-     D ARR02           S              2    DIM(10) INZ('FF')
+     D ARR02           S              2    DIM(10) INZ(*HIVAL)
 
      C                   IF        *HIVAL>=ARR01(1)
      C     'TRUE'        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00186.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00186.rpgle
@@ -8,14 +8,14 @@
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
-     D$$AZIE           S              2    DIM(100) INZ('FF')
+     D ARR01           S              2    DIM(10) INZ('FF')
 
-     C                   IF        *HIVAL<$$AZIE(1)
+     C                   IF        *HIVAL<ARR01(1)
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY
 
-     C                   IF        $$AZIE(1)>*HIVAL
+     C                   IF        ARR01(1)>*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00186.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00186.rpgle
@@ -1,0 +1,23 @@
+     V* ==============================================================
+     V* 10/12/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Comparison between *HIVAL and String by using "lower"
+    O *  operator for `*HIVAL`.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The expression is not evaluated when it's true.
+     V* ==============================================================
+     D$$AZIE           S              2    DIM(100) INZ('FF')
+
+     C                   IF        *HIVAL<$$AZIE(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        $$AZIE(1)>*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00186.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00186.rpgle
@@ -11,7 +11,7 @@
     O * The expression is not evaluated when it's true.
      V* ==============================================================
      D ARR01           S              2    DIM(10) INZ('FF')
-     D ARR02           S              2    DIM(10) INZ('FF')
+     D ARR02           S              2    DIM(10) INZ(*HIVAL)
 
      C                   IF        *HIVAL<ARR01(1)
      C     'TRUE'        DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00186.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00186.rpgle
@@ -2,13 +2,16 @@
      V* 10/12/2024 APU001 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Comparison between *HIVAL and String by using "lower"
-    O *  operator for `*HIVAL`.
+    O * Comparison between:
+    O * - *HIVAL and String,
+    O * - *HIVAL and *HIVAL
+    O * by using "lower" operator.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
      D ARR01           S              2    DIM(10) INZ('FF')
+     D ARR02           S              2    DIM(10) INZ('FF')
 
      C                   IF        *HIVAL<ARR01(1)
      C     'TRUE'        DSPLY
@@ -16,6 +19,16 @@
      C     'END'         DSPLY
 
      C                   IF        ARR01(1)>*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        *HIVAL<ARR02(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        ARR02(1)>*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00187.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00187.rpgle
@@ -2,13 +2,16 @@
      V* 10/12/2024 APU001 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Comparison between *HIVAL and String by using "lower/equal"
-    O *  operator for `*HIVAL`.
+    O * Comparison between:
+    O * - *HIVAL and String,
+    O * - *HIVAL and *HIVAL
+    O * by using "lower/equal" operator.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
      D ARR01           S              2    DIM(10) INZ('FF')
+     D ARR02           S              2    DIM(10) INZ(*HIVAL)
 
      C                   IF        *HIVAL<=ARR01(1)
      C     'TRUE'        DSPLY
@@ -16,6 +19,16 @@
      C     'END'         DSPLY
 
      C                   IF        ARR01(1)>=*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        *HIVAL<=ARR02(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        ARR02(1)>=*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00187.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00187.rpgle
@@ -1,0 +1,23 @@
+     V* ==============================================================
+     V* 10/12/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Comparison between *HIVAL and String by using "lower/equal"
+    O *  operator for `*HIVAL`.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The expression is not evaluated when it's true.
+     V* ==============================================================
+     D$$AZIE           S              2    DIM(100) INZ('FF')
+
+     C                   IF        *HIVAL<=$$AZIE(1)
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   IF        $$AZIE(1)>=*HIVAL
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00187.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00187.rpgle
@@ -8,14 +8,14 @@
     O * JARIKO ANOMALY
     O * The expression is not evaluated when it's true.
      V* ==============================================================
-     D$$AZIE           S              2    DIM(100) INZ('FF')
+     D ARR01           S              2    DIM(10) INZ('FF')
 
-     C                   IF        *HIVAL<=$$AZIE(1)
+     C                   IF        *HIVAL<=ARR01(1)
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY
 
-     C                   IF        $$AZIE(1)>=*HIVAL
+     C                   IF        ARR01(1)>=*HIVAL
      C     'TRUE'        DSPLY
      C                   ENDIF
      C     'END'         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00188.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00188.rpgle
@@ -1,0 +1,21 @@
+     V* ==============================================================
+     V* 10/12/2024 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Comparison between:
+    O * - *HIVAL as Standalone of 2 chars,
+    O * - *HIVAL as Standalone of 4 chars,
+    O * by using "equal" operator.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The expression is not evaluated when it's true.
+     V* ==============================================================
+     D D1              S              2    INZ(*HIVAL)
+     D D2              S              4    INZ(*HIVAL)
+
+     C                   IF        D1=D2
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+     C     'END'         DSPLY
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work is an improvement for PR #680, by using other comparison operators between `*HIVAL` and String.

Related to #LS24005329

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
