### PR TITLE
fix: breaking change of DataStructValue constructor

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -1100,6 +1100,7 @@ fun Type.blank(): Value {
 data class DataStructValue(@Contextual val value: StringBuilder, private val optionalExternalLen: Int? = null) : Value {
 
     constructor(value: String) : this(StringBuilder(value))
+    constructor(value: String, len: Int) : this(StringBuilder(value), len)
 
     // We can't serialize a class with a var computed from another one because of a bug in the serialization plugin
     // See https://github.com/Kotlin/kotlinx.serialization/issues/133


### PR DESCRIPTION
## Description
Breaking change of DataStructValue constructor

Related to # (issue)

## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [X] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [X] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
