### PR TITLE
Bugfix/bugfix/Fix DS fields duplication which uses `EXTNAME`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -1304,8 +1304,9 @@ internal fun RpgParser.Dcl_dsContext.getExtnameFields(
             val prefixIsNull = keywordPrefix == null && it.key.prefix == null
             val prefixIsValid = keywordPrefix != null && it.key.prefix != null && it.key.prefix is Prefix
             val prefixMatches = prefixIsValid && it.key.prefix?.prefix == prefixName
+            val isForExtname = it.key.justExtName
 
-            nameMatches && (prefixIsNull || prefixMatches)
+            nameMatches && (prefixIsNull || prefixMatches) && isForExtname
         }.values.flatten()
 
     if (fileDataDefinitions.isEmpty()) return emptyList()

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
@@ -407,7 +407,7 @@ open class ToAstSmokeTest : AbstractTest() {
 
             val dataStructure: DataDefinition = this.getAnyDataDefinition("DS_ST01") as DataDefinition
 
-            assertEquals(dataStructure.fields.size, 4)
+            assertEquals(dataStructure.fields.size, 4, "Number of fields is correct.")
             assertNotNull(dataStructure.fields.firstOrNull { fieldDefinition -> fieldDefinition.name.equals("ST01_KEY") }, "ST01_KEY is defined under DS_ST01")
             assertNotNull(dataStructure.fields.firstOrNull { fieldDefinition -> fieldDefinition.name.equals("ST01_COL1") }, "ST01_COL1 is defined under DS_ST01")
             assertNotNull(dataStructure.fields.firstOrNull { fieldDefinition -> fieldDefinition.name.equals("ST01_COL2") }, "ST01_COL2 is defined under DS_ST01")

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
@@ -17,7 +17,10 @@
 package com.smeup.rpgparser.parsing.ast
 
 import com.smeup.rpgparser.AbstractTest
-import com.smeup.rpgparser.interpreter.*
+import com.smeup.rpgparser.interpreter.DataDefinition
+import com.smeup.rpgparser.interpreter.DataStructureType
+import com.smeup.rpgparser.interpreter.Scope
+import com.smeup.rpgparser.interpreter.Visibility
 import com.smeup.rpgparser.parsing.parsetreetoast.DSFieldInitKeywordType
 import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import org.junit.Ignore

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
@@ -20,7 +20,6 @@ import com.smeup.rpgparser.AbstractTest
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.parsing.parsetreetoast.DSFieldInitKeywordType
 import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
-import com.smeup.rpgparser.parsing.parsetreetoast.toDataDefinitions
 import org.junit.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/ToAstSmokeTest.kt
@@ -17,11 +17,10 @@
 package com.smeup.rpgparser.parsing.ast
 
 import com.smeup.rpgparser.AbstractTest
-import com.smeup.rpgparser.interpreter.DataStructureType
-import com.smeup.rpgparser.interpreter.Scope
-import com.smeup.rpgparser.interpreter.Visibility
+import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.parsing.parsetreetoast.DSFieldInitKeywordType
 import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
+import com.smeup.rpgparser.parsing.parsetreetoast.toDataDefinitions
 import org.junit.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -394,6 +393,24 @@ open class ToAstSmokeTest : AbstractTest() {
             this.resolveAndValidate()
             assertNotNull(this.getAnyDataDefinition("SQLCOD"), "SQLCOD is defined")
             assertNotNull(this.getAnyDataDefinition("SQLERM"), "SQLERM is defined")
+        }
+    }
+
+    /**
+     * Test the declaration of a DS which uses `EXTNAME` to a file already declared as `F` specification.
+     * The purpose of this test is to ensure about the right number of fields to avoid duplications.
+     */
+    @Test
+    fun buildAstForEXTNAMEDS01() {
+        assertASTCanBeProduced(exampleName = "EXTNAMEDS01", printTree = false).apply {
+            this.resolveAndValidate()
+
+            val dataStructure: DataDefinition = this.getAnyDataDefinition("DS_ST01") as DataDefinition
+
+            assertEquals(dataStructure.fields.size, 4)
+            assertNotNull(dataStructure.fields.firstOrNull { fieldDefinition -> fieldDefinition.name.equals("ST01_KEY") }, "ST01_KEY is defined under DS_ST01")
+            assertNotNull(dataStructure.fields.firstOrNull { fieldDefinition -> fieldDefinition.name.equals("ST01_COL1") }, "ST01_COL1 is defined under DS_ST01")
+            assertNotNull(dataStructure.fields.firstOrNull { fieldDefinition -> fieldDefinition.name.equals("ST01_COL2") }, "ST01_COL2 is defined under DS_ST01")
         }
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/EXTNAMEDS01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/EXTNAMEDS01.rpgle
@@ -1,0 +1,2 @@
+     FST01      IF   E           K DISK
+     D DS_ST01       E DS                  EXTNAME(ST01) INZ

--- a/rpgJavaInterpreter-core/src/test/resources/db/metadata/ST01.json
+++ b/rpgJavaInterpreter-core/src/test/resources/db/metadata/ST01.json
@@ -1,0 +1,11 @@
+{"name": "ST01",
+  "tableName": "ST01T",
+  "recordFormat": "ST01RF",
+  "fields": [
+    { "fieldName": "ST01_KEY",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":20, "varying":false}}
+  , { "fieldName": "ST01_COL1",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "ST01_COL2",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  ], "accessFields": [ "ST01_KEY" ]}


### PR DESCRIPTION
## Description
This work is an improvement for Jariko. The purpose of this PR is to resolve a wrong duplication of fields for a DS which uses `EXTNAME` to a file already used as `F` spec.

## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
