### PR TITLE
Bugfix/ls25000333/ds like to string

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -404,7 +404,12 @@ internal fun RpgParser.DspecContext.toAst(
                 NumberType(elementSize!! - decimalPositions, decimalPositions)
             } else {
                 if (like != null) {
-                    compileTimeInterpreter.evaluateTypeOf(this.rContext(), like!!, conf, procedureName)
+                    val baseType = compileTimeInterpreter.evaluateTypeOf(this.rContext(), like!!, conf, procedureName)
+
+                    // When LIKE is used on a DS we must declare a string with size == to the DS size
+                    if (baseType is DataStructureType) {
+                        StringType.createInstance(elementSize!!, varying)
+                    } else baseType
                 } else {
                     StringType.createInstance(elementSize!!, varying)
                 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -1,11 +1,12 @@
 package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.db.utilities.DBServer
+import com.smeup.rpgparser.interpreter.DataDefinition
+import com.smeup.rpgparser.interpreter.DataStructureType
+import com.smeup.rpgparser.interpreter.StringType
 import com.smeup.rpgparser.smeup.dbmock.MULANGTLDbMock
 import org.junit.Test
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     @BeforeTest
@@ -427,7 +428,7 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00227() {
-        val expected = listOf("9991\uFFFF\uFFFF99999")
+        val expected = listOf("\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF\uFFFF")
         assertEquals(expected, "smeup/MUDRNRAPU00227".outputOf(configuration = smeupConfig))
     }
 
@@ -866,5 +867,24 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     fun executeMUDRNRAPU00190() {
         val expected = listOf("IBMI", "", "IBMI")
         assertEquals(expected, "smeup/MUDRNRAPU00190".outputOf(configuration = smeupConfig))
+    }
+
+    /**
+     * Definitions with LIKE referencing a DS must be defined as strings with the same size as the DS
+     * @see #LS25000333
+     */
+    @Test
+    fun executeMUDRNRAPU00281() {
+        var mlDataDefinition: DataDefinition? = null
+        var ds0002DataDefinition: DataDefinition? = null
+
+        assertASTCanBeProduced("smeup/MUDRNRAPU00281", afterAstCreation = {
+            mlDataDefinition = it.getDataDefinition("ML")
+            ds0002DataDefinition = it.getDataDefinition("DS0002")
+        })
+
+        assertIs<DataStructureType>(mlDataDefinition?.type)
+        assertIs<StringType>(ds0002DataDefinition?.type)
+        assertEquals(mlDataDefinition?.elementSize(), ds0002DataDefinition?.elementSize())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/db/metadata/MULANGTL.json
+++ b/rpgJavaInterpreter-core/src/test/resources/db/metadata/MULANGTL.json
@@ -1,0 +1,49 @@
+{"name": "MULANGTL",
+  "tableName": "MULANGTF",
+  "recordFormat": "MULANGR",
+  "fields": [
+    { "fieldName": "MLSYST",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":20, "varying":false}}
+  , { "fieldName": "MLLIBR",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLFILE",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLTIPO",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLPROG",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLPSEZ",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLPPAS",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLPDES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":256, "varying":false}}
+  , { "fieldName": "MLSQIN",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLSQFI",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLAAAT",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1024, "varying":false}}
+  , { "fieldName": "MLAAVA",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":1024, "varying":false}}
+  , { "fieldName": "MLNNAT",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":21, "decimalDigits":9, "rpgType":"P"}}
+  , { "fieldName": "MLNNVA",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":21, "decimalDigits":9, "rpgType":"P"}}
+  , { "fieldName": "MLINDI",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":99, "varying":false}}
+  , { "fieldName": "MLTEES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "MLUSES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLDTES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":8, "decimalDigits":0, "rpgType":"S"}}
+  , { "fieldName": "MLORES",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":6, "decimalDigits":0, "rpgType":"S"}}
+  , { "fieldName": "MLASLA",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":10, "varying":false}}
+  , { "fieldName": "MLASNR",
+      "type":{"type":"com.smeup.rpgparser.interpreter.NumberType","entireDigits":6, "decimalDigits":0, "rpgType":"P"}}
+  , { "fieldName": "MLLIBE",
+      "type":{"type":"com.smeup.rpgparser.interpreter.StringType","length":30000, "varying":true}}
+  ], "accessFields": [ "MLSYST", "MLTIPO", "MLPROG", "MLPSEZ", "MLPPAS"]}

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00281.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00281.rpgle
@@ -1,0 +1,13 @@
+     V* ==============================================================
+     V* 21/01/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Definitions with LIKE referencing a DS must be defined as
+    0 * strings with the same size as the DS
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, they were defined as DS themselves
+     V* ==============================================================
+     FMULANGTL  IF   E           K DISK
+     D ML            E DS                  EXTNAME(MULANGTL) INZ
+     D DS0002          S                   LIKE(ML)


### PR DESCRIPTION
## Description

Definitions with `LIKE` referencing a DS must be defined as strings with the same size as the referenced DS. To define a DS similar to another `LIKEDS` must be used instead. This was not the case prior to this fix.

### Technical notes

From a technical standpoint only two things really changed:
- A check was added to detect such cases and define the new variable as expected
- The test case `MUDRNRAPU00227` was adjusted (the new behaviour was checked on AS400)

Related to:
- LS25000333

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
