### PR TITLE
Bugfix/ls25000333/ds like define to string

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1481,7 +1481,10 @@ data class DefineStmt(
         }
 
         if (originalDataDefinition != null) {
-            return listOf(InStatementDataDefinition(newVarName, originalDataDefinition.type, position))
+            val newType = if (originalDataDefinition.type is DataStructureType) {
+                StringType.createInstance(originalDataDefinition.elementSize())
+            } else originalDataDefinition.type
+            return listOf(InStatementDataDefinition(newVarName, newType, position))
         } else {
             if (!this.enterInStack()) {
                 // This check is necessary to avoid infinite recursion

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -1,9 +1,11 @@
 package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.db.utilities.DBServer
+import com.smeup.rpgparser.interpreter.AbstractDataDefinition
 import com.smeup.rpgparser.interpreter.DataDefinition
 import com.smeup.rpgparser.interpreter.DataStructureType
 import com.smeup.rpgparser.interpreter.StringType
+import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.smeup.dbmock.MULANGTLDbMock
 import org.junit.Test
 import kotlin.test.*
@@ -886,5 +888,25 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         assertIs<DataStructureType>(mlDataDefinition?.type)
         assertIs<StringType>(ds0002DataDefinition?.type)
         assertEquals(mlDataDefinition?.elementSize(), ds0002DataDefinition?.elementSize())
+    }
+
+    /**
+     * Definitions with *LIKE DEFINE referencing a DS must be defined as strings with the same size as the DS
+     * @see #LS25000333
+     */
+    @Test
+    fun executeMUDRNRAPU00282() {
+        var aDefinition: AbstractDataDefinition? = null
+        var bDefinition: AbstractDataDefinition? = null
+
+        assertASTCanBeProduced("smeup/MUDRNRAPU00282", afterAstCreation = {
+            it.resolveAndValidate() // Needed to solve InStatementDataDefinitions
+            aDefinition = it.allDataDefinitions.firstOrNull { def -> def.name.equals("\$A", ignoreCase = true) }
+            bDefinition = it.allDataDefinitions.firstOrNull { def -> def.name.equals("\$B", ignoreCase = true) }
+        })
+
+        assertIs<DataStructureType>(aDefinition?.type)
+        assertIs<StringType>(bDefinition?.type)
+        assertEquals(aDefinition?.elementSize(), bDefinition?.elementSize())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00282.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00282.rpgle
@@ -1,0 +1,12 @@
+     V* ==============================================================
+     V* 24/01/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * *LIKE DEFINE referencing a DS must be defined as
+    0 * strings with the same size as the DS
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, they were defined as DS themselves
+     V* ==============================================================
+     D $A              DS           512
+     C     *LIKE         DEFINE    $A            $B


### PR DESCRIPTION
## Description

Definitions with `*LIKE DEFINE` referencing a DS must be defined as strings with the same size as the referenced DS. This was not the case prior to this fix.

Related to:
- LS25000333
- #695 

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
