### PR TITLE
Bugfix/ls25000738/like define indicators improvement

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -947,6 +947,16 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
     }
 
     /**
+     * LIKE DEFINE on an indicator defined without a SET statement
+     * @see #LS25000738
+     */
+    @Test
+    fun executeMUDRNRAPU00283() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00283".outputOf(configuration = smeupConfig))
+    }
+
+    /**
      * Writing on a field of DS which use `EXTNAME` of a file. In this case the file in `EXTNAME` is different
      *  from `F` spec but shares same fields.
      * @see #LS25000430

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00283.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00283.rpgle
@@ -1,0 +1,12 @@
+     V* ==============================================================
+     V* 11/02/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * *LIKE DEFINE referencing an indicator turned on with an eval
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, jariko could not define XIN10
+     V* ==============================================================
+     C                   EVAL      *IN10=*ON
+     C     *LIKE         DEFINE    *IN10         XIN10
+     C     'ok'          DSPLY


### PR DESCRIPTION
## Description

Improve definition logic when defining a data definition starting from an indicator starting from a `*LIKE DEFINE`.

### Technical notes

This kind of definition is constraint by the fact that the original indicator must be used and set in the program elsewise an error must occur.

The previous implementation detected this kind of behaviour by analyzing the indicator usage inside `SET` statements.

With these changed we expanded the query set to detect all kinds of `IndicatorExpr` statically.

Related to:
- LS25000738

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
