### PR TITLE
Bugfix/ls25001162/zadd binary

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -808,12 +808,9 @@ internal fun RpgParser.Parm_fixedContext.calculateExplicitElementType(arraySizeD
             }
         }
         RpgType.BINARY.rpgType -> {
+            // Works like a packed or zoned
             val elementSize = explicitElementSize ?: (precision!! + decimalPositions!!)
-            when (elementSize) {
-                2, 3, 4 -> NumberType(2, 0, rpgCodeType)
-                5, 6, 7, 8 -> NumberType(4, 0, rpgCodeType)
-                else -> NumberType(8, 0, rpgCodeType)
-            }
+            NumberType(elementSize, 0, rpgCodeType)
         }
         RpgType.CHARACTER.rpgType -> {
             CharacterType(precision!!)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgParserOverlayTest12.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/overlay/RpgParserOverlayTest12.kt
@@ -104,7 +104,7 @@ open class RpgParserOverlayTest12 : AbstractTest() {
         assertEquals(2, ds0011.size)
 
         val ds0012 = ds.getFieldByName("DS0012")
-        assertEquals(NumberType(2, 0, RpgType.BINARY), ds0012.type)
+        assertEquals(NumberType(4, 0, RpgType.BINARY), ds0012.type)
         assertEquals(2, ds0012.size)
 
         val ds0013 = ds.getFieldByName("DS0013")

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1010,7 +1010,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * Z-ADD on a from a binary field to a binary data definition
+     * Z-ADD from a binary field to a binary data definition
      * @see #LS25001162
      */
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1008,4 +1008,17 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf(".010000")
         assertEquals(expected, "smeup/MUDRNRAPU00284".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Z-ADD on a from a binary field to a binary data definition
+     * @see #LS25001162
+     */
+    @Test
+    fun executeMUDRNRAPU00285() {
+        // The magic number 8224 correspond to the deserialization of the "  " DS substring
+        // code of ' ' = 32
+        // 8224 = 8192 + 32 = (32 << 8) + 32
+        val expected = listOf("8224", "8224")
+        assertEquals(expected, "smeup/MUDRNRAPU00285".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/overlay/MUTE12_02.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/overlay/MUTE12_02.rpgle
@@ -277,15 +277,15 @@
      C                   EVAL      DS0010=*HIVAL
     MU* VAL1(DS0010) VAL2(-9999999999,99999) COMP(EQ)
      C                   EVAL      DS0010=*LOVAL
-      * TODO incorrect, DS0011 is 2 bytes
+      * TODO incorrect, DS0011 is 2 bytes with precision 2
     MU* VAL1(DS0011) VAL2(99) COMP(EQ)
      C                   EVAL      DS0011=*HIVAL
     MU* VAL1(DS0011) VAL2(-99) COMP(EQ)
      C                   EVAL      DS0011=*LOVAL
-      * TODO incorrect, DS0012 is 2 bytes
-    MU* VAL1(DS0012) VAL2(99) COMP(EQ)
+      * TODO incorrect, DS0012 is 2 bytes with precision 4
+    MU* VAL1(DS0012) VAL2(9999) COMP(EQ)
      C                   EVAL      DS0012=*HIVAL
-    MU* VAL1(DS0012) VAL2(-99) COMP(EQ)
+    MU* VAL1(DS0012) VAL2(-9999) COMP(EQ)
      C                   EVAL      DS0012=*LOVAL
     MU* VAL1(DS0013) VAL2(127) COMP(EQ)
      C                   EVAL      DS0013=*HIVAL

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00285.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00285.rpgle
@@ -2,7 +2,7 @@
      V* 10/03/2025 APU002 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Z-ADD on a from a binary field to a binary data definition
+    O * Z-ADD from a binary field to a binary data definition
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, we had an assignment error

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00285.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00285.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 10/03/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Z-ADD on a from a binary field to a binary data definition
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, we had an assignment error
+     V* ==============================================================
+     D DSREC0          DS
+     D  X0NREC               397    400B 0
+
+     C     X0NREC        DSPLY
+
+     C                   Z-ADD     X0NREC        XXNREC
+     C     XXNREC        DSPLY
+     C     *LIKE         DEFINE    X0NREC        XXNREC
+     C                   SETON                                        RT


### PR DESCRIPTION
## Description

Adjust logic applied to binary fields that caused an error on reassignments

## Technical notes

The issue was caused by an improper assignment of the size when binary numbers where applied to fields.

In this case binary fields should behave like follows:
- Precision 1 to 4: 2 bytes in size
- Precision 5 to 9: 4 bytes in size

To simulate this behaviour we used the digits to determine its size, however:
- This was not right because assigning correct values could arise not assignable errors (for instance precision 4 assigning value 8224).
- The size was already properly retrieved accordingly when calling the `size` getter making the previous logic an unnecessary duplicate.

Related to:
- LS25001162

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
