### PR TITLE
Bugfix/ls25001512/printer open

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -880,13 +880,12 @@ open class InternalInterpreter(
     }
 
     override fun dbFile(name: String, statement: Statement): EnrichedDBFile {
-
-        // Nem could be file name or format name
+        // Name could be file name or format name
         val dbFile = status.dbFileMap[name]
-
         require(dbFile != null) {
             "Line: ${statement.position.line()} - File definition $name not found"
         }
+
         status.lastDBFile = dbFile
         return dbFile
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -2619,6 +2619,18 @@ data class OpenStmt(
     }
 
     override fun execute(interpreter: InterpreterCore) {
+        // NOTE: Printer file are mocked for now, log a warning
+        val cu = getContainingCompilationUnit()
+        val isPrinter = cu?.fileDefinitions?.any { it.fileType == FileType.PRINTER && it.name.equals(name, ignoreCase = true) } ?: false
+        if (isPrinter) {
+            val programName = MainExecutionContext.getExecutionProgramName()
+            val provider = { LogSourceData(programName, position?.line() ?: "") }
+            val entry = LazyLogEntry.produceInformational(provider, "MOCKOPEN", name)
+            val rendered = entry.renderScoped()
+            System.err.println(rendered)
+            return
+        }
+
         val dbFile = interpreter.dbFile(name, this)
         dbFile.open = true
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/logging/LoggingTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/logging/LoggingTest.kt
@@ -360,6 +360,28 @@ class LoggingTest : AbstractTest() {
     }
 
     /**
+     * Test if mock OPEN are printed out in the appropriate format
+     * @see #LS25001512
+     */
+    @Test
+    fun mockOpenFormat() {
+        val defaultErr = System.err
+        val virtualErr = StringOutputStream()
+        System.setErr(PrintStream(virtualErr))
+        val systemInterface = JavaSystemInterface()
+        executePgm(programName = "MOCK02", systemInterface = systemInterface)
+        virtualErr.flush()
+        val logEntries = virtualErr.toString().trim().split(regex = Regex("\\n|\\r\\n"))
+        val stmtLogEntries = logEntries.filter { it.contains("MOCKOPEN") }
+        assertEquals(1, stmtLogEntries.size)
+
+        val logFormatRegexMockStatement = Regex(pattern = "\\d+:\\d+:\\d+\\.\\d+\\s*\\tMOCKOPEN\\tMOCK02.*")
+        assertTrue(stmtLogEntries[0].matches(logFormatRegexMockStatement), "Error entry: ${stmtLogEntries[0]} does not match $logFormatRegexMockStatement")
+
+        System.setErr(defaultErr)
+    }
+
+    /**
      * Test if function resolution logs are correctly printed out
      */
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1021,4 +1021,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("8224", "8224")
         assertEquals(expected, "smeup/MUDRNRAPU00285".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Perform OPEN on a F-spec marked with PRINTER
+     * @see #LS25001512
+     */
+    @Test
+    fun executeMUDRNRAPU00286() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00286".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/MOCK02.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/MOCK02.rpgle
@@ -1,0 +1,6 @@
+     V* ==============================================================
+     D* This program executes some mock OPEN statement
+     V* ==============================================================
+     FPRT198    O    F  198        PRINTER OFLIND(*INOF) USROPN
+     C                   OPEN      PRT198
+     OPRT198    E            E1WRIT      1

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00286.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00286.rpgle
@@ -1,0 +1,38 @@
+     V* ==============================================================
+     V* 26/03/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Perform open on F-spec with PRINTER
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, jariko crashed
+     V* ==============================================================
+     FPRT198    O    F  198        PRINTER OFLIND(*INOF) USROPN
+
+     C                   OPEN      PRT198
+     C     'ok'          DSPLY
+
+     OPRT198    E            E1WRIT      1
+     O                                              'Write  '                   COSTANTE
+     O                       J1IDOG           +   1
+     O                       J1TREC           +   1
+     O                       J1ORIG           +   1
+     O                       J1ASLA           +   1
+     O                       J1ASUT           +   1
+     O                       J1AMBI           +   1
+     O                       J1WEUT           +   1
+     O                       J1WEMS           +   1
+     O                       J1WEFU           +   1
+     O                       J1WEME           +   1
+     O          E            E1UPDT      1
+     O                                              'Update '                   COSTANTE
+     O                       J1IDOG           +   1
+     O                       J1TREC           +   1
+     O                       J1ORIG           +   1
+     O                       J1ASLA           +   1
+     O                       J1ASUT           +   1
+     O                       J1AMBI           +   1
+     O                       J1WEUT           +   1
+     O                       J1WEMS           +   1
+     O                       J1WEFU           +   1
+     O                       J1WEME           +   1


### PR DESCRIPTION
## Description

Log a mock execution warning instead of crashing when performing an `OPEN` on a F-spec marked with `PRINTER`.

Related to:
- LS25001512

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
