### PR TITLE
Bugfix/ls25001595/comp int all

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -259,10 +259,10 @@ data class UnlimitedStringValue(var value: String) : AbstractStringValue {
 
 @Serializable
 data class IntValue(val value: Long) : NumberValue() {
-    val digits: Int get() {
+    val digits: Int by lazy {
         // Maybe not the most efficient way but the simplest. Should be called very rarely anyway.
         val length = value.toString().length
-        return if (value < 0) length - 1 else length
+        if (value < 0) length - 1 else length
     }
 
     override val bigDecimal: BigDecimal by lazy { BigDecimal(value) }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -22,6 +22,8 @@ import com.smeup.rpgparser.parsing.parsetreetoast.DateFormat
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
 import com.smeup.rpgparser.parsing.parsetreetoast.isInt
 import com.smeup.rpgparser.parsing.parsetreetoast.toInt
+import com.smeup.rpgparser.utils.asInt
+import com.smeup.rpgparser.utils.repeatWithMaxSize
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal
@@ -257,6 +259,12 @@ data class UnlimitedStringValue(var value: String) : AbstractStringValue {
 
 @Serializable
 data class IntValue(val value: Long) : NumberValue() {
+    val digits: Int get() {
+        // Maybe not the most efficient way but the simplest. Should be called very rarely anyway.
+        val length = value.toString().length
+        return if (value < 0) length - 1 else length
+    }
+
     override val bigDecimal: BigDecimal by lazy { BigDecimal(value) }
     override fun negate(): NumberValue = IntValue(-value)
     override fun increment(amount: Long): NumberValue = this + IntValue(amount)
@@ -339,6 +347,10 @@ data class IntValue(val value: Long) : NumberValue() {
         is DecimalValue -> this.asDecimal().compareTo(other)
         is PointerValue -> value.compareTo(other.address)
         is ZeroValue -> value.compareTo(ZeroValue.asInt().value)
+        is AllValue -> {
+            val computedAll = other.toIntOfLength(this.digits)
+            value.compareTo(computedAll)
+        }
         else -> super.compareTo(other)
     }
 
@@ -921,6 +933,14 @@ class AllValue(val charsToRepeat: String) : Value {
 
     override fun asString(): StringValue {
         TODO("'AllValue.asString' is not yet implemented")
+    }
+
+    fun toStringOfLength(length: Int): String {
+        return this.charsToRepeat.repeatWithMaxSize(length)
+    }
+
+    fun toIntOfLength(length: Int): Int {
+        return toStringOfLength(length).asInt()
     }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/misc.kt
@@ -108,6 +108,10 @@ fun String.asBigDecimal(): BigDecimal? =
         null
     }
 
+fun Int.ceilDiv(divisor: Int): Int {
+    return this / divisor + if (this % divisor > 0) 1 else 0
+}
+
 fun BigDecimal?.isZero() = this != null && BigDecimal.ZERO.compareTo(this) == 0
 
 fun Any?.asNonNullString(): String = this?.toString() ?: ""
@@ -120,7 +124,7 @@ fun String.moveEndingString(s: String): String =
         }
 
 fun String.repeatWithMaxSize(l: Int): String {
-    val repetitions = (l / this.length) + 1
+    val repetitions = l.ceilDiv(this.length)
     return this.repeat(repetitions).take(l)
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1038,7 +1038,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00287() {
-        val expected = listOf("0", "0", "0", "0", "1", "0")
+        val expected = listOf("010", "010", "100", "100")
         assertEquals(expected, "smeup/MUDRNRAPU00287".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1038,7 +1038,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00287() {
-        val expected = listOf("0", "0", "0", "0", "1", "0", "1", "0")
+        val expected = listOf("0", "0", "0", "0", "1", "0")
         assertEquals(expected, "smeup/MUDRNRAPU00287".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1038,7 +1038,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU00287() {
-        val expected = listOf("0", "0")
+        val expected = listOf("0", "0", "0", "0", "1", "0", "1", "0")
         assertEquals(expected, "smeup/MUDRNRAPU00287".outputOf(configuration = smeupConfig))
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1031,4 +1031,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00286".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * COMP with an int on the left and an *ALL on the right
+     * @see #LS25001595
+     */
+    @Test
+    fun executeMUDRNRAPU00287() {
+        val expected = listOf("0", "0")
+        assertEquals(expected, "smeup/MUDRNRAPU00287".outputOf(configuration = smeupConfig))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00287.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00287.rpgle
@@ -1,0 +1,15 @@
+     V* ==============================================================
+     V* 26/03/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Perform COMP between an IntValue and an AllValue
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, jariko crashed
+     V* ==============================================================
+     D £100DSI         DS          2000
+     D  £100I_DT                      8P 0
+     C     £100I_DT      COMP      *ALL'9'                                09
+     C     £100I_DT      COMP      *ALL'90'                               10
+     C     *IN09         DSPLY
+     C     *IN10         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00287.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00287.rpgle
@@ -13,3 +13,16 @@
      C     £100I_DT      COMP      *ALL'90'                               10
      C     *IN09         DSPLY
      C     *IN10         DSPLY
+     C                   EVAL £100I_DT = *HIVAL
+     C     £100I_DT      COMP      *ALL'8'                              09
+     C     £100I_DT      COMP      *ALL'90'                             10
+     C     *IN09         DSPLY
+     C     *IN10         DSPLY
+     C     £100I_DT      COMP      *ALL'9'                                09
+     C     £100I_DT      COMP      *ALL'90'                               10
+     C     *IN09         DSPLY
+     C     *IN10         DSPLY
+     C     £100I_DT      COMP      *ALL'8'                                  09
+     C     £100I_DT      COMP      *ALL'90'                                 10
+     C     *IN09         DSPLY
+     C     *IN10         DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00287.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00287.rpgle
@@ -7,22 +7,26 @@
     O * JARIKO ANOMALY
     O * Before the fix, jariko crashed
      V* ==============================================================
+     DMSG              S              3
      D £100DSI         DS          2000
      D  £100I_DT                      8P 0
 
      C                   EVAL      £100I_DT = *LOVAL
-     C     £100I_DT      COMP      *ALL'9'                                09
-     C     £100I_DT      COMP      *ALL'90'                               10
-     C     *IN09         DSPLY
-     C     *IN10         DSPLY
+     C* Compare to higher single char
+     C     £100I_DT      COMP      *ALL'9'                            091011
+     C                   EVAL      MSG=%CHAR(*IN09)+%CHAR(*IN10)+%CHAR(*IN11)
+     C     MSG           DSPLY
+     C* Compare to higher multiple char
+     C     £100I_DT      COMP      *ALL'90'                           091011
+     C                   EVAL      MSG=%CHAR(*IN09)+%CHAR(*IN10)+%CHAR(*IN11)
+     C     MSG           DSPLY
      C                   EVAL      £100I_DT = *HIVAL
-     C     £100I_DT      COMP      *ALL'8'                              09
-     C     £100I_DT      COMP      *ALL'90'                             10
-     C     *IN09         DSPLY
-     C     *IN10         DSPLY
-     C     £100I_DT      COMP      *ALL'9'                                09
-     C     £100I_DT      COMP      *ALL'90'                               10
-     C     *IN09         DSPLY
-     C     *IN10         DSPLY
-
+     C* Compare to lower single char
+     C     £100I_DT      COMP      *ALL'8'                            091011
+     C                   EVAL      MSG=%CHAR(*IN09)+%CHAR(*IN10)+%CHAR(*IN11)
+     C     MSG           DSPLY
+     C* Compare to lower multiple char
+     C     £100I_DT      COMP      *ALL'90'                           091011
+     C                   EVAL      MSG=%CHAR(*IN09)+%CHAR(*IN10)+%CHAR(*IN11)
+     C     MSG           DSPLY
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00287.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00287.rpgle
@@ -9,11 +9,13 @@
      V* ==============================================================
      D £100DSI         DS          2000
      D  £100I_DT                      8P 0
+
+     C                   EVAL      £100I_DT = *LOVAL
      C     £100I_DT      COMP      *ALL'9'                                09
      C     £100I_DT      COMP      *ALL'90'                               10
      C     *IN09         DSPLY
      C     *IN10         DSPLY
-     C                   EVAL £100I_DT = *HIVAL
+     C                   EVAL      £100I_DT = *HIVAL
      C     £100I_DT      COMP      *ALL'8'                              09
      C     £100I_DT      COMP      *ALL'90'                             10
      C     *IN09         DSPLY
@@ -22,7 +24,5 @@
      C     £100I_DT      COMP      *ALL'90'                               10
      C     *IN09         DSPLY
      C     *IN10         DSPLY
-     C     £100I_DT      COMP      *ALL'8'                                  09
-     C     £100I_DT      COMP      *ALL'90'                                 10
-     C     *IN09         DSPLY
-     C     *IN10         DSPLY
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description

Add support for `COMP` between an integer and a `*ALL'xx'` value. Tested on AS400.

Related to:
- LS25001595

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
