### PR TITLE
Bugfix/LS25001614/Packed array as DS field

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -974,4 +974,25 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("FOO")
         assertEquals(expected, "smeup/MUDRNRAPU001105".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * This program defines several DS field declared as array of Packed, with several sizes and scale.
+     * @see #LS25001614
+     */
+    @Test
+    fun executeMUDRNRAPU001110() {
+        val expected = listOf("1.50", "1.50", "1.500000", "1.500000", "1", "1", "1", "1")
+        assertEquals(expected, "smeup/MUDRNRAPU001110".outputOf())
+    }
+
+    /**
+     * This program defines several DS field declared as array of Packed, with several sizes and scale,
+     *  and executes several sums between different declarations.
+     * @see #LS25001614
+     */
+    @Test
+    fun executeMUDRNRAPU001111() {
+        val expected = listOf("3.00", "3.00", "3.00", "3.00", "3.00")
+        assertEquals(expected, "smeup/MUDRNRAPU001111".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001110.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001110.rpgle
@@ -1,0 +1,55 @@
+     V* ==============================================================
+     V* 03/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program defines several DS field declared as array
+    O *  of Packed, with several sizes and scale.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The evaluation of packed number, of DS array item, is wrong.
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_F1                        5P 2 DIM(3) INZ
+     D  DS1_F2                        5  2 DIM(3) INZ
+     D  DS1_F3                       20P 6 DIM(3) INZ
+     D  DS1_F4                       20  6 DIM(3) INZ
+     D  DS1_F5                        5P 0 DIM(3) INZ
+     D  DS1_F6                        5  0 DIM(3) INZ
+     D  DS1_F7                       20P 0 DIM(3) INZ
+     D  DS1_F8                       20  0 DIM(3) INZ
+     D RES             S             50
+     D SUM             S              5P 2
+
+     C                   EVAL      DS1_F1(1)=1.5
+     C                   EVAL      RES=%CHAR(DS1_F1(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F2(1)=1.5
+     C                   EVAL      RES=%CHAR(DS1_F2(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F3(1)=1.5
+     C                   EVAL      RES=%CHAR(DS1_F3(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F4(1)=1.5
+     C                   EVAL      RES=%CHAR(DS1_F4(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F5(1)=1
+     C                   EVAL      RES=%CHAR(DS1_F5(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F6(1)=1
+     C                   EVAL      RES=%CHAR(DS1_F6(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F7(1)=1
+     C                   EVAL      RES=%CHAR(DS1_F7(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F8(1)=1
+     C                   EVAL      RES=%CHAR(DS1_F8(1))
+     C     RES           DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001111.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001111.rpgle
@@ -1,0 +1,46 @@
+     V* ==============================================================
+     V* 03/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program defines several DS field declared as array
+    O *  of Packed, with several sizes and scale, and executes several
+    O *  sums between different declarations.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The evaluation of packed number, of DS array item, is wrong.
+    O * This implies a wrong sum.
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_F1                        5P 2 DIM(3) INZ
+     D  DS1_F2                        5  2 DIM(3) INZ
+     D  DS1_F3                       20P 6 DIM(3) INZ
+     D  DS1_F4                       20  6 DIM(3) INZ
+     D RES             S             50
+     D SUM             S              5P 2
+
+     C                   EVAL      DS1_F1(1)=1.5
+     C                   EVAL      DS1_F2(1)=1.5
+     C                   EVAL      DS1_F3(1)=1.5
+     C                   EVAL      DS1_F4(1)=1.5
+
+     C                   EVAl      SUM=DS1_F1(1)+DS1_F2(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   EVAl      SUM=DS1_F1(1)+DS1_F2(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   EVAl      SUM=DS1_F1(1)+DS1_F2(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   EVAl      SUM=DS1_F3(1)+DS1_F4(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   EVAl      SUM=DS1_F1(1)+DS1_F3(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work has been being made with @dom-apuliasoft; the logic on `coercing.ks` has been made by him. This work resolves the evaluation of Packed number which is an element of an array declared as DS field, too. By considering this snippet:
```
     D DS1             DS
     D  DS1_F1                        5P 2 DIM(3) INZ

     C                   EVAL      DS1_F1(1)=1.5
     C                   EVAL      RES=%CHAR(DS1_F1(1))
     C     RES           DSPLY
```

The result was `150` and not `1.50`.

Related to #LS25001614

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
