### PR TITLE
Bugfix/LS25001579/Array of DS as param of `CALL`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -18,8 +18,7 @@ package com.smeup.rpgparser.interpreter
 
 import com.smeup.dspfparser.linesclassifier.DSPFValue
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
-import com.smeup.rpgparser.parsing.parsetreetoast.DateFormat
-import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
+import com.smeup.rpgparser.parsing.parsetreetoast.*
 import com.smeup.rpgparser.parsing.parsetreetoast.isInt
 import com.smeup.rpgparser.parsing.parsetreetoast.toInt
 import kotlinx.serialization.Contextual
@@ -1042,19 +1041,21 @@ class ProjectedArrayValue(
             is DecimalValue -> {
                 /*
                  * More important: a decimal value as Packed has own format and business logic.
-                 * So, in this case isn't manipulated, even if is a plain number without any character which must be encoded/decoded.
+                 * So, in this case is removed only the dot.
                  */
                 result = if (this.elementType is NumberType && (this.elementType as NumberType).rpgType != RpgType.PACKED.rpgType) {
                     result.asStringWithZerosAndWithoutComma(this.elementType as NumberType).padLeftWithZerosAndByDigits(this.elementType as NumberType)
                 } else {
-                    result.asString()
+                    result.asStringWithoutComma()
                 }
 
                 for (i in 1 until arrayLength()) {
+                    val element = (elements()[i] as DecimalValue)
+
                     val itemResult = if (this.elementType is NumberType && (this.elementType as NumberType).rpgType != RpgType.PACKED.rpgType) {
-                        (elements()[i] as DecimalValue).asStringWithZerosAndWithoutComma(this.elementType as NumberType).padLeftWithZerosAndByDigits(this.elementType as NumberType)
+                        element.asStringWithZerosAndWithoutComma(this.elementType as NumberType).padLeftWithZerosAndByDigits(this.elementType as NumberType)
                     } else {
-                        (elements()[i] as DecimalValue).asString()
+                        element.asStringWithoutComma()
                     }
                     result = result.concatenate(itemResult)
                 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -1019,9 +1019,7 @@ class ProjectedArrayValue(
         }
     }
 
-    override fun asString(): StringValue {
-        TODO("'ProjectedArrayValue.asString' is not yet implemented")
-    }
+    override fun asString(): StringValue = takeAll().asString()
 
     fun takeAll(): Value {
         var result = elements()[0]

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -1023,9 +1023,21 @@ class ProjectedArrayValue(
 
     fun takeAll(): Value {
         var result = elements()[0]
-        for (i in 1 until arrayLength()) {
-            result = result.concatenate(elements()[i])
+        when (result) {
+            is DecimalValue -> {
+                result = StringValue(result.value.toString().replace(".", ""))
+                for (i in 1 until arrayLength()) {
+                    val valueWithoutDot = elements()[i].asString().value.replace(".", "")
+                    result = result.concatenate(StringValue(valueWithoutDot))
+                }
+            }
+            else -> {
+                for (i in 1 until arrayLength()) {
+                    result = result.concatenate(elements()[i])
+                }
+            }
         }
+
         return result
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -974,4 +974,25 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("FOO")
         assertEquals(expected, "smeup/MUDRNRAPU001105".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * This program defines several DS field declared as array of Packed, with several sizes and scale.
+     * @see #LS25001614
+     */
+    @Test
+    fun executeMUDRNRAPU001110() {
+        val expected = listOf("1.50", "1.50", "1.500000", "1.500000", "1", "1", "1", "1")
+        assertEquals(expected, "smeup/MUDRNRAPU001110".outputOf())
+    }
+
+    /**
+     * This program defines several DS field declared as array of Packed, with several sizes and scale,
+     *  and executes several sums between different declarations.
+     * @see #LS25001614
+     */
+    @Test
+    fun executeMUDRNRAPU001111() {
+        val expected = listOf("3.00", "3.00", "3.00", "3.00", "3.00")
+        assertEquals(expected, "smeup/MUDRNRAPU001111".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1038,7 +1038,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU001107() {
-        val expected = listOf("123")
+        val expected = listOf("1", "2", "3", "123")
         assertEquals(expected, "smeup/MUDRNRAPU001107".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1038,7 +1038,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU001107() {
-        val expected = listOf("1", "2", "3", "123")
+        val expected = listOf("1", "2", "3", "000010000200003")
         assertEquals(expected, "smeup/MUDRNRAPU001107".outputOf())
     }
 
@@ -1049,7 +1049,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU001108() {
-        val expected = listOf("1.5", "2.5", "3.5", "152535", "1.5", "2.5", "3.5")
+        val expected = listOf("1.50", "2.50", "3.50", "001500025000350", "1.50", "2.50", "3.50")
         assertEquals(expected, "smeup/MUDRNRAPU001108".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1,7 +1,6 @@
 package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.smeup.dbmock.C5ADFF9LDbMock
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1031,4 +1031,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("ok")
         assertEquals(expected, "smeup/MUDRNRAPU00286".outputOf(configuration = smeupConfig))
     }
+
+    /**
+     * Pass an array declared as DS field to a program which declares same program entry as Standalone.
+     * @see #LS25001579
+     */
+    @Test
+    fun executeMUDRNRAPU001107() {
+        val expected = listOf("123")
+        assertEquals(expected, "smeup/MUDRNRAPU001107".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1,6 +1,7 @@
 package com.smeup.rpgparser.smeup
 
 import com.smeup.rpgparser.smeup.dbmock.C5ADFF9LDbMock
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -1051,5 +1052,17 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     fun executeMUDRNRAPU001108() {
         val expected = listOf("1.50", "2.50", "3.50", "001500025000350", "1.50", "2.50", "3.50")
         assertEquals(expected, "smeup/MUDRNRAPU001108".outputOf())
+    }
+
+    /**
+     * Pass an array declared as DS field to a program which declares same program entry as Standalone.
+     * Is similar to `MUDRNRAPU001107` but the DS field is declared as array of packed instead integers.
+     * @see #LS25001579
+     */
+    @Test
+    @Ignore
+    fun executeMUDRNRAPU001109() {
+        val expected = listOf("1.50", "2.50", "3.50", "1.50", "2.50", "3.50")
+        assertEquals(expected, "smeup/MUDRNRAPU001109".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1041,4 +1041,15 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("1", "2", "3", "123")
         assertEquals(expected, "smeup/MUDRNRAPU001107".outputOf())
     }
+
+    /**
+     * Pass an array declared as DS field to a program which declares same program entry as Standalone.
+     * Is similar to `MUDRNRAPU001107` but the DS field is declared as array of decimals instead integers.
+     * @see #LS25001579
+     */
+    @Test
+    fun executeMUDRNRAPU001108() {
+        val expected = listOf("1.5", "2.5", "3.5", "152535", "1.5", "2.5", "3.5")
+        assertEquals(expected, "smeup/MUDRNRAPU001108".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1060,7 +1060,6 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      * @see #LS25001579
      */
     @Test
-    @Ignore
     fun executeMUDRNRAPU001109() {
         val expected = listOf("1.50", "2.50", "3.50", "1.50", "2.50", "3.50")
         assertEquals(expected, "smeup/MUDRNRAPU001109".outputOf())

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107.rpgle
@@ -1,0 +1,25 @@
+     V* ==============================================================
+     V* 01/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Pass an array declared as DS field to a program which
+    O *  declares same program entry as Standalone.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *     `An operation is not implemented:
+    O *      'ProjectedArrayValue.asString' is not yet implemented.`
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_F1                        1  0 DIM(3) INZ
+     D INX             S              1  0
+     D PGM             S             17    INZ('MUDRNRAPU001107_P')
+
+     C                   FOR       INX=1 TO 3
+     C                   EVAL      DS1_F1(INX)=INX
+     C                   ENDFOR
+
+     C                   CALL      PGM                                          # An operation is not implemented: 'ProjectedArrayValue.asString' is not yet implemented.
+     C                   PARM                    DS1_F1
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107.rpgle
@@ -13,10 +13,13 @@
      D DS1             DS
      D  DS1_F1                        1  0 DIM(3) INZ
      D INX             S              1  0
+     D RES             S              3
      D PGM             S             17    INZ('MUDRNRAPU001107_P')
 
      C                   FOR       INX=1 TO 3
      C                   EVAL      DS1_F1(INX)=INX
+     C                   EVAL      RES=%CHAR(DS1_F1(INX))
+     C     RES           DSPLY
      C                   ENDFOR
 
      C                   CALL      PGM                                          # An operation is not implemented: 'ProjectedArrayValue.asString' is not yet implemented.

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
      V* 01/04/2025 APU001 Creation
+     V* 02/04/2025 APU001 Edited size for `DS1_F1`
      V* ==============================================================
     O * PROGRAM GOAL
     O * Pass an array declared as DS field to a program which
@@ -11,9 +12,9 @@
     O *      'ProjectedArrayValue.asString' is not yet implemented.`
      V* ==============================================================
      D DS1             DS
-     D  DS1_F1                        1  0 DIM(3) INZ
+     D  DS1_F1                        5  0 DIM(3) INZ
      D INX             S              1  0
-     D RES             S              3
+     D RES             S             15
      D PGM             S             17    INZ('MUDRNRAPU001107_P')
 
      C                   FOR       INX=1 TO 3

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107_P.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107_P.rpgle
@@ -1,15 +1,16 @@
      V* ==============================================================
      V* 01/04/2025 APU001 Creation
+     V* 02/04/2025 APU001 Edited size for `VAR_PARM`
      V* ==============================================================
     O * PROGRAM GOAL
     O * This program is used by 'MUDRNRAPU001107_P' for its purpose.
      V* ==============================================================
-     D VAR_PARM        S              3
+     D VAR_PARM        S             15
 
      C     VAR_PARM      DSPLY
      C                   SETON                                          LR
 
      C     *INZSR        BEGSR
      C     *ENTRY        PLIST
-     C                   PARM                    VAR_PARM          3
+     C                   PARM                    VAR_PARM
      C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107_P.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001107_P.rpgle
@@ -1,0 +1,15 @@
+     V* ==============================================================
+     V* 01/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program is used by 'MUDRNRAPU001107_P' for its purpose.
+     V* ==============================================================
+     D VAR_PARM        S              3
+
+     C     VAR_PARM      DSPLY
+     C                   SETON                                          LR
+
+     C     *INZSR        BEGSR
+     C     *ENTRY        PLIST
+     C                   PARM                    VAR_PARM          3
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001108.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001108.rpgle
@@ -1,0 +1,30 @@
+     V* ==============================================================
+     V* 01/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Pass an array declared as DS field to a program which
+    O *  declares same program entry as Standalone.
+    O * Is similar to `MUDRNRAPU001107` but the DS field is declared
+    O *  as array of decimals instead integers.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *     `An operation is not implemented:
+    O *      'ProjectedArrayValue.concatenate' is not yet implemented.`
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_F1                        2  1 DIM(3) INZ
+     D INX             S              1  0
+     D RES             S              3
+     D PGM             S             17    INZ('MUDRNRAPU001108_P')
+
+     C                   FOR       INX=1 TO 3
+     C                   EVAL      DS1_F1(INX)=INX + 0.5
+     C                   EVAL      RES=%CHAR(DS1_F1(INX))
+     C     RES           DSPLY
+     C                   ENDFOR
+
+     C                   CALL      PGM                                          # An operation is not implemented: 'ProjectedArrayValue.concatenate' is not yet implemented.
+     C                   PARM                    DS1_F1
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001108.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001108.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
      V* 01/04/2025 APU001 Creation
+     V* 02/04/2025 APU001 Edited size for `DS1_F1`
      V* ==============================================================
     O * PROGRAM GOAL
     O * Pass an array declared as DS field to a program which
@@ -13,9 +14,9 @@
     O *      'ProjectedArrayValue.concatenate' is not yet implemented.`
      V* ==============================================================
      D DS1             DS
-     D  DS1_F1                        2  1 DIM(3) INZ
+     D  DS1_F1                        5  2 DIM(3) INZ
      D INX             S              1  0
-     D RES             S              3
+     D RES             S             10
      D PGM             S             17    INZ('MUDRNRAPU001108_P')
 
      C                   FOR       INX=1 TO 3

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001108_P.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001108_P.rpgle
@@ -1,0 +1,23 @@
+     V* ==============================================================
+     V* 01/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program is used by 'MUDRNRAPU001108_P' for its purpose.
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_F1                        2  1 DIM(3) INZ
+     D INX             S              1  0
+     D RES             S              3
+
+     C     VAR_PARM      DSPLY
+     C                   MOVE      VAR_PARM      DS1
+     C                   FOR       INX=1 TO 3
+     C                   EVAL      RES=%CHAR(DS1_F1(INX))
+     C     RES           DSPLY
+     C                   ENDFOR
+     C                   SETON                                          LR
+
+     C     *INZSR        BEGSR
+     C     *ENTRY        PLIST
+     C                   PARM                    VAR_PARM          6
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001108_P.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001108_P.rpgle
@@ -1,13 +1,15 @@
      V* ==============================================================
      V* 01/04/2025 APU001 Creation
+     V* 02/04/2025 APU001 Edited size for `DS1_F1`
      V* ==============================================================
     O * PROGRAM GOAL
     O * This program is used by 'MUDRNRAPU001108_P' for its purpose.
      V* ==============================================================
      D DS1             DS
-     D  DS1_F1                        2  1 DIM(3) INZ
+     D  DS1_F1                        5  2 DIM(3) INZ
+     D VAR_PARM        S                   LIKE(DS1)
      D INX             S              1  0
-     D RES             S              3
+     D RES             S              6
 
      C     VAR_PARM      DSPLY
      C                   MOVE      VAR_PARM      DS1
@@ -19,5 +21,5 @@
 
      C     *INZSR        BEGSR
      C     *ENTRY        PLIST
-     C                   PARM                    VAR_PARM          6
+     C                   PARM                    VAR_PARM
      C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001109.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001109.rpgle
@@ -1,0 +1,30 @@
+     V* ==============================================================
+     V* 02/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Pass an array declared as DS field to a program which
+    O *  declares same program entry as Standalone.
+    O * Is similar to `MUDRNRAPU001107` but the DS field is declared
+    O *  as array of packed instead integers.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *     `An operation is not implemented:
+    O *      'ProjectedArrayValue.concatenate' is not yet implemented.`
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_F1                        5P 2 DIM(3) INZ
+     D INX             S              1  0
+     D RES             S             50
+     D PGM             S             17    INZ('MUDRNRAPU001109_P')
+
+     C                   FOR       INX=1 TO 3
+     C                   EVAL      DS1_F1(INX)=INX + 0.5
+     C                   EVAL      RES=%CHAR(DS1_F1(INX))
+     C     RES           DSPLY
+     C                   ENDFOR
+
+     C                   CALL      PGM                                          # An operation is not implemented: 'ProjectedArrayValue.concatenate' is not yet implemented.
+     C                   PARM                    DS1_F1
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001109_P.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001109_P.rpgle
@@ -1,0 +1,23 @@
+     V* ==============================================================
+     V* 02/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program is used by 'MUDRNRAPU001109_P' for its purpose.
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_F1                        5P 2 DIM(3) INZ
+     D VAR_PARM        S                   LIKE(DS1)
+     D INX             S              1  0
+     D RES             S             50
+
+     C                   MOVE      VAR_PARM      DS1
+     C                   FOR       INX=1 TO 3
+     C                   EVAL      RES=%CHAR(DS1_F1(INX))
+     C     RES           DSPLY
+     C                   ENDFOR
+     C                   SETON                                          LR
+
+     C     *INZSR        BEGSR
+     C     *ENTRY        PLIST
+     C                   PARM                    VAR_PARM
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001110.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001110.rpgle
@@ -1,0 +1,55 @@
+     V* ==============================================================
+     V* 03/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program defines several DS field declared as array
+    O *  of Packed, with several sizes and scale.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The evaluation of packed number, of DS array item, is wrong.
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_F1                        5P 2 DIM(3) INZ
+     D  DS1_F2                        5  2 DIM(3) INZ
+     D  DS1_F3                       20P 6 DIM(3) INZ
+     D  DS1_F4                       20  6 DIM(3) INZ
+     D  DS1_F5                        5P 0 DIM(3) INZ
+     D  DS1_F6                        5  0 DIM(3) INZ
+     D  DS1_F7                       20P 0 DIM(3) INZ
+     D  DS1_F8                       20  0 DIM(3) INZ
+     D RES             S             50
+     D SUM             S              5P 2
+
+     C                   EVAL      DS1_F1(1)=1.5
+     C                   EVAL      RES=%CHAR(DS1_F1(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F2(1)=1.5
+     C                   EVAL      RES=%CHAR(DS1_F2(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F3(1)=1.5
+     C                   EVAL      RES=%CHAR(DS1_F3(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F4(1)=1.5
+     C                   EVAL      RES=%CHAR(DS1_F4(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F5(1)=1
+     C                   EVAL      RES=%CHAR(DS1_F5(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F6(1)=1
+     C                   EVAL      RES=%CHAR(DS1_F6(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F7(1)=1
+     C                   EVAL      RES=%CHAR(DS1_F7(1))
+     C     RES           DSPLY
+
+     C                   EVAL      DS1_F8(1)=1
+     C                   EVAL      RES=%CHAR(DS1_F8(1))
+     C     RES           DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001111.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001111.rpgle
@@ -1,0 +1,46 @@
+     V* ==============================================================
+     V* 03/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program defines several DS field declared as array
+    O *  of Packed, with several sizes and scale, and executes several
+    O *  sums between different declarations.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * The evaluation of packed number, of DS array item, is wrong.
+    O * This implies a wrong sum.
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_F1                        5P 2 DIM(3) INZ
+     D  DS1_F2                        5  2 DIM(3) INZ
+     D  DS1_F3                       20P 6 DIM(3) INZ
+     D  DS1_F4                       20  6 DIM(3) INZ
+     D RES             S             50
+     D SUM             S              5P 2
+
+     C                   EVAL      DS1_F1(1)=1.5
+     C                   EVAL      DS1_F2(1)=1.5
+     C                   EVAL      DS1_F3(1)=1.5
+     C                   EVAL      DS1_F4(1)=1.5
+
+     C                   EVAl      SUM=DS1_F1(1)+DS1_F2(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   EVAl      SUM=DS1_F1(1)+DS1_F2(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   EVAl      SUM=DS1_F1(1)+DS1_F2(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   EVAl      SUM=DS1_F3(1)+DS1_F4(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   EVAl      SUM=DS1_F1(1)+DS1_F3(1)
+     C                   EVAL      RES=%CHAR(SUM)
+     C     RES           DSPLY
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work resolves the utilization of DS field, declared as array, as parameter of `CALL`, like in these snippets:
##### Main program
```
     D DS1             DS
     D  DS1_F1                        5  0 DIM(3) INZ

     ...
     C                   CALL      `OTHER_PGM`
     C                   PARM                    DS1_F1
```

##### Called program
```
     D VAR_PARM        S             15

     C     VAR_PARM      DSPLY

     C     *INZSR        BEGSR
     C     *ENTRY        PLIST
     C                   PARM                    VAR_PARM
     C                   ENDSR
```
### Technical notes
On Jariko missed the implementation for `asString` and `takeAll`, on `ProjectedArrayValue`. `takeAll` constructs, as string, the concatenation of numbers by considering the size and scale of declared array, as well as on AS400.

Related to #LS25001579

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
