### PR TITLE
Bugfix/ls25001711/projectedvalue failed requirement

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -1018,10 +1018,10 @@ class ProjectedArrayValue(
 
     override fun getElement(index: Int): Value {
         if (index < 1) {
-            ProgramStatusCode.ARRAY_INDEX_NOT_VALID.toThrowable("Indexes should be >=1. Index asked: $index")
+            throw ProgramStatusCode.ARRAY_INDEX_NOT_VALID.toThrowable("Indexes should be >=1. Index asked: $index")
         }
         if (index > arrayLength()) {
-            ProgramStatusCode.ARRAY_INDEX_NOT_VALID.toThrowable("Indexes should be less than array length. Index asked: $index, Array length: ${arrayLength()}.")
+            throw ProgramStatusCode.ARRAY_INDEX_NOT_VALID.toThrowable("Indexes should be less than array length. Index asked: $index, Array length: ${arrayLength()}.")
         }
 
         val startIndex = (this.startOffset + this.step * (index - 1))

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -999,10 +999,10 @@ class ProjectedArrayValue(
 
     override fun setElement(index: Int, value: Value) {
         if (index < 1) {
-            ProgramStatusCode.ARRAY_INDEX_NOT_VALID.toThrowable("Indexes should be >=1. Index asked: $index")
+            throw ProgramStatusCode.ARRAY_INDEX_NOT_VALID.toThrowable("Indexes should be >=1. Index asked: $index")
         }
         if (index > arrayLength()) {
-            ProgramStatusCode.ARRAY_INDEX_NOT_VALID.toThrowable("Indexes should be less than array length. Index asked: $index, Array length: ${arrayLength()}.")
+            throw ProgramStatusCode.ARRAY_INDEX_NOT_VALID.toThrowable("Indexes should be less than array length. Index asked: $index, Array length: ${arrayLength()}.")
         }
         require(value.assignableTo((field.type as ArrayType).element)) { "Assigning to field $field incompatible value $value" }
         val startIndex = (this.startOffset + this.step * (index - 1))

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -1068,6 +1068,16 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR54CallBackTest() {
+        executePgmCallBackTest("ERROR54", SourceReferenceType.Program, "ERROR54", mapOf(5 to "Array index not valid - Indexes should be >=1. Index asked: 0"))
+    }
+
+    @Test
+    fun executeERROR54SourceLineTest() {
+        executeSourceLineTest("ERROR54")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -1078,6 +1078,16 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR55CallBackTest() {
+        executePgmCallBackTest("ERROR55", SourceReferenceType.Program, "ERROR55", mapOf(5 to "Array index not valid - Indexes should be >=1. Index asked: 0"))
+    }
+
+    @Test
+    fun executeERROR55SourceLineTest() {
+        executeSourceLineTest("ERROR54")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR54.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR54.rpgle
@@ -1,0 +1,5 @@
+     D$X               S              2  0
+     D $STRUCT         DS
+     D  $ARR                          2P 0 DIM(10) INZ
+     C                   EVAL      $X = 0
+     C                   EVAL      $ARR($X) = 1

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR54.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR54.rpgle
@@ -1,3 +1,13 @@
+     V* ==============================================================
+     V* 10/04/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Throw proper error on ProjectedArrayValue.setElement with
+    O * invalid index
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, jariko crashed
+     V* ==============================================================
      D$X               S              2  0
      D $STRUCT         DS
      D  $ARR                          2P 0 DIM(10) INZ

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR55.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR55.rpgle
@@ -1,3 +1,13 @@
+     V* ==============================================================
+     V* 10/04/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Throw proper error on ProjectedArrayValue.getElement with
+    O * invalid index
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, jariko crashed
+     V* ==============================================================
      D$X               S              2  0
      D $STRUCT         DS
      D  $ARR                          2P 0 DIM(10) INZ

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR55.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR55.rpgle
@@ -1,0 +1,5 @@
+     D$X               S              2  0
+     D $STRUCT         DS
+     D  $ARR                          2P 0 DIM(10) INZ
+     C                   EVAL      $X = 0
+     C                   EVAL      $X = $ARR($X)


### PR DESCRIPTION
## Description

Fix an issue causing to throw a `Failed requirement` instead of a proper error when index was not valid in arrays contained in a DS.

### Technical notes

Basically, even if the exceptions were constructed, some throw statements were just missing so the exception was never thrown. So simple and yet so subtle.
This caused the program to fail while extracting the substring from the DS instead of throwing an RPG error (with proper status code and `MONITOR` catching) in `ProjectedArrayValue.setElement` and `ProjectedArrayValue.getElement` when index was not valid.

Related to:
- LS25001711

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
