### PR TITLE
Bugfix/LS25001775/Added position during construction of `MvrStmt`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -1696,6 +1696,7 @@ internal fun CsMVRContext.toAst(conf: ToAstConfiguration = ToAstConfiguration())
     )
     return MvrStmt(
         target = target,
+        position = toPosition(conf.considerPosition),
         dataDefinition = dataDefinition
     )
 }


### PR DESCRIPTION
## Description
This fix is related to Jariko. Concerns the construction of a `MVR` statement, by passing the missed position.

Related to #LS25001775

## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
