### PR TITLE
Bugfix/LS25001776/`%EOF` by passing name

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -704,7 +704,7 @@ class ExpressionEvaluation(
         if (expression.name == null) {
             return@proxyLogging BooleanValue(interpreterStatus.lastDBFile?.eof() ?: false)
         }
-        TODO("Line ${expression.position?.line()} - %EOF expression with file names is not implemented yet")
+        return@proxyLogging BooleanValue(interpreterStatus.dbFileMap[expression.name!!]?.eof() ?: false)
     }
 
     override fun eval(expression: EqualExpr): Value = proxyLogging(expression) {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
@@ -115,4 +115,22 @@ open class MULANGT50FileAccess1Test : MULANGTTest() {
             )
         )
     }
+
+    /**
+     * Using `SETGT` and `READ` in a cycle. The cycle is interrupted when the EOF had been reached.
+     * @see #LS25000910
+     */
+    @Test
+    fun executeMUDRNRAPU001120() {
+        ST02DbMock().usePopulated({
+                val expected = listOf("A003", "A547", "A634", "LEAVE")
+                assertEquals(expected, "smeup/MUDRNRAPU001120".outputOf(configuration = smeupConfig))
+            },
+            listOf(
+                mapOf("ST02F1" to "CNFOR", "ST02F2" to "A003"),
+                mapOf("ST02F1" to "CNFOR", "ST02F2" to "A547"),
+                mapOf("ST02F1" to "CNFOR", "ST02F2" to "A634")
+            )
+        )
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001120.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001120.rpgle
@@ -1,0 +1,35 @@
+     V* ==============================================================
+     V* 16/04/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Using `SETGT` and `READ` in a cycle. The cycle is interrupted
+    O *  when the EOF had been reached.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *   %EOF expression with file names is not implemented yet
+     V* ==============================================================
+     FST02      IF   E           K DISK
+     D KST02F1         S                   LIKE(ST02F1)
+     D KST02F2         S                   LIKE(ST02F2)
+     D I               S              1  0
+
+     C     KRIS12        KLIST
+     C                   KFLD                    KST02F1
+     C                   KFLD                    KST02F2
+
+     C                   EVAL      KST02F1='CN'
+
+     C                   FOR       I=1 TO 4
+     C     KRIS12        SETGT     ST02
+     C                   READ      ST02
+     C                   IF        %EOF(ST02)                                   #  %EOF expression with file names is not implemented yet
+     C     'LEAVE'       DSPLY
+     C                   LEAVE
+     C                   ENDIF
+     C     ST02F2        DSPLY
+     C                   EVAL      KST02F1=ST02F1
+     C                   EVAL      KST02F2=ST02F2
+     C                   ENDFOR
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work completes the implementation of `%EOF` when is provided the name of file, like in this snippet:
```
     FST02      IF   E           K DISK
     ...
     C                   READ      ST02
     C                   IF        %EOF(ST02)
     ...
```

### Technical notes
To achieve this goal, the name of file is found from `dbFileMap`, then the `eof` state.

Related to #LS25001776

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
