### PR TITLE
Perf/data field access and resolution

### DIFF
--- a/kolasu/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
+++ b/kolasu/src/main/kotlin/com/strumenta/kolasu/model/Model.kt
@@ -73,8 +73,18 @@ data class ReferenceByName<N>(val name: String, var referred: N? = null) where N
         get() = referred != null
 }
 
+@Deprecated(
+    message = "Deprecated for performance reasons",
+    replaceWith = ReplaceWith("tryToResolve(candidates: Map<String, N>, caseInsensitive: Boolean = false)")
+)
 fun <N> ReferenceByName<N>.tryToResolve(candidates: List<N>, caseInsensitive: Boolean = false): Boolean where N : Named {
     val res = candidates.find { if (it.name == null) false else it.name.equals(this.name, caseInsensitive) }
+    this.referred = res
+    return res != null
+}
+
+fun <N> ReferenceByName<N>.tryToResolve(candidates: Map<String, N>, caseInsensitive: Boolean = false): Boolean where N : Named {
+    val res = if (caseInsensitive) candidates[this.name.uppercase()] else candidates[this.name]
     this.referred = res
     return res != null
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/compile_time_interpreter.kt
@@ -71,12 +71,16 @@ open class BaseCompileTimeInterpreter(
     private val delegatedCompileTimeInterpreter: CompileTimeInterpreter? = null
 ) : CompileTimeInterpreter {
 
+    private val knownDataDefinitionsByName: Map<String, DataDefinition> by lazy {
+        knownDataDefinitions.associateBy { it.name }
+    }
+
     override fun evaluate(rContext: RContext, expression: Expression): Value {
         return when (expression) {
             is NumberOfElementsExpr -> IntValue(evaluateNumberOfElementsOf(rContext, expression.value).toLong())
             is IntLiteral -> IntValue(expression.value)
             is StringLiteral -> StringValue(expression.value)
-            is DataRefExpr -> if (expression.variable.tryToResolve(knownDataDefinitions))
+            is DataRefExpr -> if (expression.variable.tryToResolve(knownDataDefinitionsByName))
                 return this.evaluate(rContext, (expression.variable.referred as? DataDefinition)?.initializationValue as Expression)
                     else
                 TODO(expression.toString())

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -187,6 +187,12 @@ data class FileDefinition private constructor(
 data class DataDefinition(
     override val name: String,
     @SerialName(value = "dataDefType") override var type: Type,
+    /***
+     * The fields associated with the data definition.
+     * This property is used to define the fields of the data structure.
+     * After initialization if you want to change the fields, use the newFields property.
+     * @see newFields
+     */
     var fields: List<FieldDefinition> = emptyList(),
     val initializationValue: Expression? = null,
     val inz: Boolean = false,
@@ -214,6 +220,22 @@ data class DataDefinition(
     init {
         this.require(name.trim().isNotEmpty(), { "name cannot be empty" })
     }
+
+    // If you want to change visibility of this property, decorate as @Derived
+    /**
+     * A list of fields associated with the data definition.
+     * When this property is updated, it also updates the `fields` property
+     * and rebuilds the `fieldsByName` map to ensure consistency.
+     */
+    @Transient
+    internal var newFields: List<FieldDefinition> = fields
+        set(value) {
+            fields = value
+            fieldsByName = fields.associateBy { it.name.uppercase() }
+        }
+
+    @Transient
+    internal var fieldsByName: Map<String, FieldDefinition> = fields.associateBy { it.name.uppercase() }
 
     @Deprecated("The start offset should be calculated before defining the FieldDefinition")
     fun startOffset(fieldDefinition: FieldDefinition): Int {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
@@ -111,6 +111,18 @@ data class CompilationUnit(
         subroutines.associateBy { it.name.uppercase() }
     }
 
+    internal val dataDefinitionsByName: Map<String, DataDefinition> by lazy {
+        dataDefinitions.associateBy { it.name.uppercase() }
+    }
+
+    internal val compileTimeArraysByName: Map<String, CompileTimeArray> by lazy {
+        compileTimeArrays.associateBy { it.name.uppercase() }
+    }
+
+    internal val fileDefinitionsByName: Map<String, FileDefinition> by lazy {
+        fileDefinitions.associateBy { it.name.uppercase() }
+    }
+
     /**
      * This returns `true` if this procedure is a prototype by its empty lists for file definition,
      *  data definition, subroutines, compile time arrays and directive.
@@ -124,20 +136,21 @@ data class CompilationUnit(
                 this.directives.isEmpty()
     }
 
-    fun hasDataDefinition(name: String) = dataDefinitions.any { it.name.equals(name, ignoreCase = true) }
+    fun hasDataDefinition(name: String) = dataDefinitionsByName.containsKey(name.uppercase())
 
-    fun getDataDefinition(name: String, errorMessage: () -> String = { "Data definition $name was not found" }) = dataDefinitions.firstOrNull { it.name.equals(name, ignoreCase = true) }
+    fun getDataDefinition(name: String, errorMessage: () -> String = { "Data definition $name was not found" }) = dataDefinitionsByName[name.uppercase()]
             ?: throw IllegalArgumentException(errorMessage.invoke())
 
     fun getDataOrFieldDefinition(name: String) = dataDefinitions.firstOrNull { it.name.equals(name, ignoreCase = true) }
             ?: dataDefinitions.mapNotNull { it -> it.fields.find { it.name.equals(name, ignoreCase = true) } }.firstOrNull()
             ?: throw IllegalArgumentException("Data or field definition $name was not found")
 
-    fun hasAnyDataDefinition(name: String) = allDataDefinitions.any { it.name.equals(name, ignoreCase = true) }
+    fun hasAnyDataDefinition(name: String) = allDataDefinitionsByName.containsKey(name.uppercase())
 
-    fun getAnyDataDefinition(name: String) = allDataDefinitions.first { it.name.equals(name, ignoreCase = true) }
+    fun getAnyDataDefinition(name: String) = allDataDefinitionsByName[name.uppercase()]
+        ?: throw IllegalArgumentException("Data definition $name was not found")
 
-    fun getAnyDataDefinition(name: String, errorMessage: () -> String = { "Data definition $name was not found" }) = allDataDefinitions.first { it.name.equals(name, ignoreCase = true) }
+    fun getAnyDataDefinition(name: String, errorMessage: () -> String = { "Data definition $name was not found" }) = allDataDefinitionsByName[name.uppercase()]
         ?: throw IllegalArgumentException(errorMessage.invoke())
 
     fun compileTimeArray(name: String): CompileTimeArray {
@@ -146,7 +159,7 @@ data class CompilationUnit(
         } else {
             CompileTimeArray("", emptyList())
         }
-        return compileTimeArrays.firstOrNull { it.name.equals(name, ignoreCase = true) } ?: firstCompileTimeArray()
+        return compileTimeArraysByName[name.uppercase()] ?: firstCompileTimeArray()
     }
 
     fun compileTimeArray(index: Int): CompileTimeArray {
@@ -156,9 +169,10 @@ data class CompilationUnit(
         return compileTimeArrays[index]
     }
 
-    fun hasFileDefinition(name: String) = fileDefinitions.any { it.name.equals(name, ignoreCase = true) }
+    fun hasFileDefinition(name: String) = fileDefinitionsByName.containsKey(name.uppercase())
 
-    fun getFileDefinition(name: String) = fileDefinitions.first { it.name.equals(name, ignoreCase = true) }
+    fun getFileDefinition(name: String) = fileDefinitionsByName[name.uppercase()]
+        ?: throw IllegalArgumentException("File definition $name was not found")
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
@@ -103,6 +103,10 @@ data class CompilationUnit(
             return _allDataDefinitions
         }
 
+    internal val allDataDefinitionsByName: Map<String, AbstractDataDefinition> by lazy {
+        allDataDefinitions.associateBy { it.name.uppercase() }
+    }
+
     /**
      * This returns `true` if this procedure is a prototype by its empty lists for file definition,
      *  data definition, subroutines, compile time arrays and directive.

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
@@ -107,6 +107,10 @@ data class CompilationUnit(
         allDataDefinitions.associateBy { it.name.uppercase() }
     }
 
+    internal val subroutinesByName: Map<String, Subroutine> by lazy {
+        subroutines.associateBy { it.name.uppercase() }
+    }
+
     /**
      * This returns `true` if this procedure is a prototype by its empty lists for file definition,
      *  data definition, subroutines, compile time arrays and directive.

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -1176,7 +1176,7 @@ internal fun RpgParser.Dcl_dsContext.toAst(
             referredDs.fields,
             position = this.toPosition(true)
         )
-        dataDefinition.fields = dataDefinition.fields.map { it.copy(overriddenContainer = dataDefinition) }
+        dataDefinition.newFields = dataDefinition.fields.map { it.copy(overriddenContainer = dataDefinition) }
         return dataDefinition
     }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -102,7 +102,7 @@ private fun Node.resolveDataRefs(cu: CompilationUnit) {
                     var currentCu: CompilationUnit? = cu
                     var resolved = false
                     while (currentCu != null && !resolved) {
-                        resolved = dre.variable.tryToResolve(currentCu.allDataDefinitions, caseInsensitive = true)
+                        resolved = dre.variable.tryToResolve(currentCu.allDataDefinitionsByName, caseInsensitive = true)
                         currentCu = currentCu.parent?.let { it as CompilationUnit }
                     }
                     if (!resolved) {
@@ -265,7 +265,7 @@ private fun ReferenceByName<AbstractDataDefinition>.tryToResolveRecursively(posi
         var currentCu: CompilationUnit? = cu
         var resolved = false
         while (currentCu != null && !resolved) {
-            resolved = this.tryToResolve(currentCu.allDataDefinitions, caseInsensitive = true)
+            resolved = this.tryToResolve(currentCu.allDataDefinitionsByName, caseInsensitive = true)
             currentCu = currentCu.parent?.let { it as CompilationUnit }
         }
         val relativePosition = position?.adaptInFunctionOf(getProgramNameToCopyBlocks().second)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -208,7 +208,7 @@ private fun CompilationUnit.resolve() {
     this.specificProcess(ExecuteSubroutine::class.java) { esr ->
         if (!esr.subroutine.resolved) {
             kotlin.runCatching {
-                esr.require(esr.subroutine.tryToResolve(this.subroutines, caseInsensitive = true)) {
+                esr.require(esr.subroutine.tryToResolve(this.subroutinesByName, caseInsensitive = true)) {
                     "Subroutine call not resolved: ${esr.subroutine.name}"
                 }
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/resolution.kt
@@ -221,7 +221,7 @@ private fun CompilationUnit.resolve() {
                 val dataDefinition = dataRef.variable.referred!! as DataDefinition
                 qae.runNode {
                     kotlin.runCatching {
-                        require(qae.field.tryToResolve(dataDefinition.fields, caseInsensitive = true)) {
+                        require(qae.field.tryToResolve(dataDefinition.fieldsByName, caseInsensitive = true)) {
                             "Field access not resolved: ${qae.field.name} in data definition ${dataDefinition.name}"
                         }
                     }


### PR DESCRIPTION
## Description

This pull request introduces performance optimizations and refactors the resolution logic by replacing list-based lookups with map-based lookups for various entities. It also adds new helper methods and updates documentation to improve maintainability and clarity.

### Performance Optimizations:
* Replaced list-based lookups with map-based lookups for `DataDefinition`, `Subroutine`, `FileDefinition`, and other entities to improve resolution performance. This includes introducing properties like `knownDataDefinitionsByName`, `fieldsByName`, and `allDataDefinitionsByName` for efficient access. [[1]](diffhunk://#diff-f7be7d0ccf3fd32828f9fc29ae1689e278c2f9ce6801212356ac43721946d12cR74-R83) [[2]](diffhunk://#diff-5c4e13aa1944172e68e2bdd5d37b3d62fdb32877143a0e7bd7bad9a739ba6d8eR224-R239) [[3]](diffhunk://#diff-6f0fa8ce942a153bc5ff9c44e822d083fe443a2ee72ab2a08862ec0e9625678eR106-R125) [[4]](diffhunk://#diff-6f0fa8ce942a153bc5ff9c44e822d083fe443a2ee72ab2a08862ec0e9625678eL119-R153) [[5]](diffhunk://#diff-6f0fa8ce942a153bc5ff9c44e822d083fe443a2ee72ab2a08862ec0e9625678eL141-R162) [[6]](diffhunk://#diff-ce618a5d7de6fab50000c77f4b0771785d4b019e10831bfe0974d2710051d0feL105-R105) [[7]](diffhunk://#diff-ce618a5d7de6fab50000c77f4b0771785d4b019e10831bfe0974d2710051d0feL211-R211) [[8]](diffhunk://#diff-ce618a5d7de6fab50000c77f4b0771785d4b019e10831bfe0974d2710051d0feL224-R224) [[9]](diffhunk://#diff-ce618a5d7de6fab50000c77f4b0771785d4b019e10831bfe0974d2710051d0feL268-R268)

### Refactoring and Deprecations:
* Deprecated the `tryToResolve(candidates: List<N>, caseInsensitive: Boolean)` method in `ReferenceByName` in favor of a new map-based `tryToResolve(candidates: Map<String, N>, caseInsensitive: Boolean)` method for better performance.
* Updated the `CompilationUnit` class to use map-based resolution methods for subroutines, compile-time arrays, and file definitions. [[1]](diffhunk://#diff-6f0fa8ce942a153bc5ff9c44e822d083fe443a2ee72ab2a08862ec0e9625678eL119-R153) [[2]](diffhunk://#diff-6f0fa8ce942a153bc5ff9c44e822d083fe443a2ee72ab2a08862ec0e9625678eL141-R162)

### New Features:
* Added a `merge` extension function to combine lists of `Named` nodes while avoiding duplicates based on the `name` property.
* Introduced a new `newFields` property in `DataDefinition` to allow updating fields dynamically while maintaining consistency with the `fieldsByName` map. [[1]](diffhunk://#diff-5c4e13aa1944172e68e2bdd5d37b3d62fdb32877143a0e7bd7bad9a739ba6d8eR224-R239) [[2]](diffhunk://#diff-88f967a748040d52240062535252671bcc1e6bab30c1720d3938f3e28ea5446aL1179-R1179)

### Documentation and Code Clarity:
* Added detailed comments and documentation for new methods and properties, such as `merge` and `newFields`, to improve readability and clarity. [[1]](diffhunk://#diff-5c4e13aa1944172e68e2bdd5d37b3d62fdb32877143a0e7bd7bad9a739ba6d8eR224-R239) [[2]](diffhunk://#diff-0b728d1d95fc6b652ba0bf1913a4129f067bf05c11561a3287345eee9d0445a3R118-R131)

### Licensing and Header Updates:
* Added a missing Apache License header to the `Processing.kt` file to ensure compliance with licensing requirements.

Related to # (issue)

## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [X] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [X] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
