### PR TITLE
refactor: made some tests as performance tests

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/DataStructValueBuilderTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/DataStructValueBuilderTest.kt
@@ -16,7 +16,9 @@
 
 package com.smeup.rpgparser.interpreter
 
+import com.smeup.rpgparser.PerformanceTest
 import com.smeup.rpgparser.parsing.ast.json
+import org.junit.experimental.categories.Category
 import kotlin.random.Random
 import kotlin.test.*
 import kotlin.time.measureTime
@@ -76,6 +78,7 @@ class DataStructValueBuilderTest {
     }
 
     @Test
+    @Category(PerformanceTest::class)
     fun littleDSBetterStringBuilderWrapper() {
         val littleDS = listOf(10, 20, 20, 4, 5)
         val value = "a".repeat(littleDS.sum())
@@ -109,6 +112,7 @@ class DataStructValueBuilderTest {
     }
 
     @Test
+    @Category(PerformanceTest::class)
     fun bigDSBetterIndexedStringBuilder() {
         val bigDS = List(100) { Random.nextInt(100, 1000) }
         val value = "a".repeat(bigDS.sum())
@@ -142,6 +146,7 @@ class DataStructValueBuilderTest {
     }
 
     @Test
+    @Category(PerformanceTest::class)
     fun overlayingDSMuchBetterIndexedStringBuilder() {
         val dsWithOverlay = List(10_000) { Random.nextInt(10, 101) }
         val value = "a".repeat(dsWithOverlay.sum())


### PR DESCRIPTION
## Description

This pull request introduces performance categorization for specific test cases in the `DataStructValueBuilderTest` class. The changes primarily involve marking certain tests with the `@Category(PerformanceTest::class)` annotation to classify them as performance tests.

Test categorization:

* [`rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/DataStructValueBuilderTest.kt`](diffhunk://#diff-4deb24c7fd7163f071bec5d82cb644aef83beb4dd0a41d9b4c972d083722d999R81): Added the `@Category(PerformanceTest::class)` annotation to the `littleDSBetterStringBuilderWrapper`, `bigDSBetterIndexedStringBuilder`, and `overlayingDSMuchBetterIndexedStringBuilder` test methods. This helps to identify them as performance-related tests. [[1]](diffhunk://#diff-4deb24c7fd7163f071bec5d82cb644aef83beb4dd0a41d9b4c972d083722d999R81) [[2]](diffhunk://#diff-4deb24c7fd7163f071bec5d82cb644aef83beb4dd0a41d9b4c972d083722d999R115) [[3]](diffhunk://#diff-4deb24c7fd7163f071bec5d82cb644aef83beb4dd0a41d9b4c972d083722d999R149)

Imports:

* [`rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/DataStructValueBuilderTest.kt`](diffhunk://#diff-4deb24c7fd7163f071bec5d82cb644aef83beb4dd0a41d9b4c972d083722d999R19-R21): Added imports for `PerformanceTest` and `org.junit.experimental.categories.Category` to support the new test categorization.

Related to # (issue)

## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [X] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [X] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
