### PR TITLE
Bugfix/ls25002246/varying field from ds

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/ValueTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/ValueTest.kt
@@ -44,4 +44,20 @@ class ValueTest {
             assertEquals(dataStructBlankValue, occurableDataStructBlankValue[i])
         }
     }
+
+    @Test
+    fun varyingDSField() {
+        val fields = listOf(
+            FieldType("A", StringType(30000, true))
+        )
+        val fieldDefinitions = fields.toFieldDefinitions()
+        val aFieldDefinition = fieldDefinitions.first()
+        val dataStructureType = DataStructureType(fields = fields, elementSize = 99999)
+        val dataStructValue = dataStructureType.blank() as DataStructValue
+        dataStructValue.set(aFieldDefinition, StringValue("ABCDE", true))
+
+        val outputValue = dataStructValue.get(aFieldDefinition) as StringValue
+        assertEquals(outputValue.length(), 5)
+        assertEquals(outputValue.value, "ABCDE")
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT02ConstAndDSpecTest.kt
@@ -995,4 +995,14 @@ open class MULANGT02ConstAndDSpecTest : MULANGTTest() {
         val expected = listOf("3.00", "3.00", "3.00", "3.00", "3.00")
         assertEquals(expected, "smeup/MUDRNRAPU001111".outputOf())
     }
+
+    /**
+     * Extracting a VARYING field from a DS
+     * @see #LS25002246
+     */
+    @Test
+    fun executeMUDRNRAPU00291() {
+        val expected = listOf("5")
+        assertEquals(expected, "smeup/MUDRNRAPU00291".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00291.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00291.rpgle
@@ -1,0 +1,16 @@
+     V* ==============================================================
+     V* 16/05/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Extract a VARYING field from a DS
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, jariko did not consider the VARYING length
+     V* ==============================================================
+     D £JaxDSGen       DS
+     D £JaxCP                     30000    INZ VARYING
+     D MSG            S           30000    VARYING
+     C                   EVAL      £JaxCP='ABCDE'
+     C                   EVAL      MSG=£JaxCP
+     C                   EVAL      MSG=%LEN(MSG)
+     C     MSG           DSPLY


### PR DESCRIPTION
## Description

Fix an issue that caused `VARYING` fields in `DS` to be longer than expected when their actual length was less than the declared length

Related to:
- LS25002246

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
