### PR TITLE
Bugfix/LS25002334/Coercing parameters of `CALL`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -244,7 +244,14 @@ fun coerce(value: Value, type: Type): Value {
         is ArrayValue -> {
             return when (type) {
                 is StringType -> {
-                    value.asString()
+                    val result = value.asString()
+                    if (result.length() > type.length) {
+                        result.setSubstring(0, type.length)
+                    }
+                    StringValue(
+                        result.value.padEnd(type.length, ' '),
+                        type.varying
+                    )
                 }
                 is ArrayType -> {
                     if (value.elements().size > type.nElements) {
@@ -331,7 +338,35 @@ fun coerce(value: Value, type: Type): Value {
         }
         is BooleanValue -> coerceBoolean(value, type)
         is UnlimitedStringValue -> coerceString(value.value.asValue(), type)
+        is DataStructValue -> coerceDataStruct(value, type)
         else -> value
+    }
+}
+
+/**
+ * Coerces a given DataStructValue to a target type.
+ *
+ * This method handles type conversions for a DataStructValue into its corresponding
+ * target type while enforcing rules such as length constraints for string types.
+ *
+ * @param value the DataStructValue to be coerced
+ * @param type the target Type to which the value is coerced
+ * @return a Value instance after applying the necessary transformations
+ */
+private fun coerceDataStruct(value: DataStructValue, type: Type): Value {
+    return when (type) {
+        is StringType -> {
+            val valueAsString: StringValue = value.asString().copy()
+            if (type.varying && valueAsString.length() < type.length) {
+                valueAsString.pad(type.length)
+            } else if (valueAsString.length() > type.length) {
+                valueAsString.setSubstring(0, type.length)
+            }
+
+            valueAsString
+        }
+        is DataStructureType -> value
+        else -> TODO("Converting DataStructValue to $type")
     }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1009,7 +1009,7 @@ data class CallStmt(
                 val resultName = if (it.result.name.contains("."))
                     it.result.name.substring(it.result.name.indexOf(".") + 1)
                 else it.result.name
-                targetProgramParams[index].name to interpreter[resultName]
+                targetProgramParams[index].name to coerce(interpreter[resultName], targetProgramParams[index].type)
             }.toMap(LinkedHashMap())
 
             val paramValuesAtTheEnd =
@@ -1047,7 +1047,7 @@ data class CallStmt(
             paramValuesAtTheEnd?.forEachIndexed { index, value ->
                 if (this.params.size > index) {
                     val currentParam = this.params[index]
-                    interpreter.assign(currentParam.result.referred!!, value)
+                    interpreter.assign(currentParam.result.referred!!, coerce(value, currentParam.result.referred!!.type))
 
                     // If we also have a result field, assign to it
                     currentParam.factor1?.let { interpreter.assign(it, value) }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/JDExamplesTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/JDExamplesTest.kt
@@ -192,7 +192,7 @@ open class JDExamplesTest : AbstractTest() {
         assertEquals(1, callsToJDURL.size)
         val urlCalled = callsToJDURL[0]["URL"]
         assertNotNull(urlCalled)
-        assert(urlCalled is ArrayValue)
+        assert(urlCalled is StringValue)
     }
 
     @Test
@@ -459,8 +459,8 @@ open class JDExamplesTest : AbstractTest() {
         assertEquals(5, callsToListFld.size)
         assertEquals(
                 mapOf(
-                        "foldern" to StringValue.padded("my/path/to/folder", 1000),
-                        "name" to StringValue.blank(1000),
+                        "foldern" to StringValue.padded("my/path/to/folder", 100),
+                        "name" to StringValue.blank(10),
                         "tip" to StringValue.blank(10),
                         "ope" to StringValue.blank(10)
                 ), callsToListFld[0])
@@ -514,22 +514,15 @@ open class JDExamplesTest : AbstractTest() {
         assertEquals(1, callsToListFld.size)
         assertEquals(
                 mapOf(
-                        "foldern" to StringValue.padded("my/path/to/folder", 1000),
-                        "name" to StringValue.blank(1000),
+                        "foldern" to StringValue.padded("my/path/to/folder", 100),
+                        "name" to StringValue.blank(10),
                         "tip" to StringValue.blank(10),
                         "ope" to StringValue.blank(10)
                 ), callsToListFld[0])
         assertEquals(1, callsToNfyeve.size)
-        val v = callsToNfyeve[0]["var"] as ArrayValue
-        assertEquals(StringValue("Object name".padEnd(50, PAD_CHAR) +
-                "myFile.png".padEnd(1000, PAD_CHAR)),
-                v.getElement(1))
-        assertEquals(StringValue("Object type".padEnd(50, PAD_CHAR) +
-                "FILE".padEnd(1000, PAD_CHAR)),
-                v.getElement(2))
-        assertEquals(StringValue("Operation type".padEnd(50, PAD_CHAR) +
-                "ADD".padEnd(1000, PAD_CHAR)),
-                v.getElement(3))
+        val v = callsToNfyeve[0]["var"] as StringValue
+        assertEquals(StringValue("Object nam"),
+                v)
     }
 
     @Test
@@ -617,9 +610,8 @@ open class JDExamplesTest : AbstractTest() {
         interpreter.execute(cu, mapOf("U\$FUNZ" to "EXE".asValue()), reinitialization = false)
         interpreter.execute(cu, mapOf("U\$FUNZ" to "CLO".asValue()), reinitialization = false)
         assertEquals(1, callsToRcvsck.size)
-        assertEquals("addressToListen", callsToRcvsck[0]["addr"]!!.asString().value)
-        assertEquals(1, callsToNfyeve.size)
-        assertEquals("Targa".padEnd(50, PAD_CHAR) + "ZZ000AA".padEnd(1000, PAD_CHAR), callsToNfyeve[0]["var"]!!.asArray().getElement(2).asString().value)
+        assertEquals("addressToL", callsToRcvsck[0]["addr"]!!.asString().value)
+        assertEquals("SOCKET    ", callsToNfyeve[0]["var"]!!.asString().value)
     }
 
     @Test
@@ -731,7 +723,7 @@ open class JDExamplesTest : AbstractTest() {
 
         execute("JD_003_V2", parms, si, logHandlers)
         assertEquals(1, callsToNfyeve.size)
-        assertTrue((callsToNfyeve[0]["var"] as ConcreteArrayValue).getElement(2).asString().value.contains(targa))
+        assertTrue(callsToNfyeve[0]["var"]!!.asString().value.contains("PORT"))
         assertEquals(" ", parms[returnStatus]!!.asString().value)
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/JDExamplesTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/JDExamplesTest.kt
@@ -192,6 +192,7 @@ open class JDExamplesTest : AbstractTest() {
         assertEquals(1, callsToJDURL.size)
         val urlCalled = callsToJDURL[0]["URL"]
         assertNotNull(urlCalled)
+
         assert(urlCalled is StringValue)
     }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/SymbolTableTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/SymbolTableTest.kt
@@ -2,6 +2,8 @@ package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.AbstractTest
 import com.smeup.rpgparser.PerformanceTest
+import com.smeup.rpgparser.execution.Configuration
+import com.smeup.rpgparser.jvminterop.JavaSystemInterface
 import com.smeup.rpgparser.parsing.ast.CompilationUnit
 import org.junit.experimental.categories.Category
 import kotlin.test.*
@@ -148,5 +150,130 @@ class SymbolTableTest : AbstractTest() {
             dataDefinition,
             dataDefinition.defaultValue ?: dataDefinition.type.blank()
         )
+    }
+
+    /**
+     * Tests the interaction between a program with a data structure and another program using standalone variables,
+     * validating symbol table entries and execution behavior.
+     *
+     * This test simulates the execution of a program (`symboltable/ST_CALL01`) that interacts with a called program
+     * (`ST_CALL01C`). Both programs pass data between them, and the symbol table entries for data structures and standalone
+     * variables are validated for correctness.
+     *
+     * Key Validations:
+     * 1. For the called program (`ST_CALL01C`):
+     *    - Verifies the type of the data definition `£G90WK` as `StringValue`.
+     * 2. For the calling program (`ST_CALL01`):
+     *    - Verifies the type of the data definition `£G90DS` as `DataStructValue`.
+     *
+     * Additional Assertions:
+     * - Captures system outputs during the execution using a mocked system interface.
+     * - Asserts expected output messages in the sequence: ["CALLED", "CALLER"].
+     */
+    @Test
+    fun callWithDataStructureToStandalone() {
+        val messages = emptyList<String>().toMutableList()
+        val systemInterface = JavaSystemInterface().apply { onDisplay = { message, printStream -> run {
+            messages.add(message)
+        } } }
+        executePgm(systemInterface = systemInterface, programName = "symboltable/ST_CALL01", configuration = Configuration().apply {
+            jarikoCallback.onExitPgm = { programName: String, symbolTable: ISymbolTable, _: Throwable? ->
+                if (programName.equals("ST_CALL01C", ignoreCase = true)) {
+                    val dataDefinition = symbolTable.get("£G90WK")
+                    assertIs<StringValue>(dataDefinition)
+                }
+
+                if (programName.equals("ST_CALL01", ignoreCase = true)) {
+                    val dataDefinition = symbolTable.get("£G90DS")
+                    assertIs<DataStructValue>(dataDefinition)
+                }
+            }
+        })
+
+        assertEquals(listOf("CALLED", "CALLER"), messages)
+    }
+
+    /**
+     * Tests the interaction between standalone variables of different sizes across programs using a symbol table.
+     *
+     * The test simulates the execution of a program that calls another program, validating the behavior and properties
+     * of standalone variables (`VARSTD`) in both the calling and called programs. A mocked system interface captures
+     * output messages for validation.
+     *
+     * Key Validations:
+     * 1. For the standalone variable (`VARSTD`) in the called program:
+     *    - Confirms the type is `StringValue`.
+     *    - Verifies the length of the variable is 5.
+     * 2. For the standalone variable (`VARSTD`) in the calling program:
+     *    - Confirms the type is `StringValue`.
+     *    - Verifies the length of the variable is 6.
+     *
+     * Additional Assertions:
+     * - Verifies the system output messages during the execution sequence:
+     *   - Ensures expected outputs are captured in the order: ["CALLER", "FOOBAR", "CALLED", "FOOBA"].
+     */
+    @Test
+    fun callWithStandaloneToStandaloneWithDifferentSizes() {
+        val messages = emptyList<String>().toMutableList()
+        val systemInterface = JavaSystemInterface().apply { onDisplay = { message, printStream -> run {
+            messages.add(message)
+        } } }
+        executePgm(systemInterface = systemInterface, programName = "symboltable/ST_CALL02", configuration = Configuration().apply {
+            jarikoCallback.onExitPgm = { programName: String, symbolTable: ISymbolTable, _: Throwable? ->
+                if (programName.equals("ST_CALL02C", ignoreCase = true)) {
+                    val dataDefinition = symbolTable.get("VARSTD")
+                    assertIs<StringValue>(dataDefinition)
+                    assertEquals(5, dataDefinition.length())
+                }
+
+                if (programName.equals("ST_CALL02", ignoreCase = true)) {
+                    val dataDefinition = symbolTable.get("VARSTD")
+                    assertIs<StringValue>(dataDefinition)
+                    assertEquals(6, dataDefinition.length())
+                }
+            }
+        })
+
+        assertEquals(listOf("CALLER", "FOOBAR", "CALLED", "FOOBA"), messages)
+    }
+
+    /**
+     * Tests the behavior of calling a program with an array of data structures, verifying its interaction
+     * with a standalone field using a symbol table.
+     *
+     * The test simulates program execution using a mocked system interface and verifies the following:
+     * 1. An array of data structures (`DS1_ARR`) is passed, checked for its properties such as array length
+     *    and element type (`StringType`).
+     * 2. A standalone variable (`VARSTD`) is validated in a called program for its type (`StringValue`)
+     *    and length.
+     *
+     * Assertions:
+     * - Verifies the system output messages during execution.
+     * - Confirms the symbol table contains the expected values and types for both standalone and array data.
+     */
+    @Test
+    fun callWithArrayOfDataStructureToStandalone() {
+        val messages = emptyList<String>().toMutableList()
+        val systemInterface = JavaSystemInterface().apply { onDisplay = { message, printStream -> run {
+            messages.add(message)
+        } } }
+        executePgm(systemInterface = systemInterface, programName = "symboltable/ST_CALL03", configuration = Configuration().apply {
+            jarikoCallback.onExitPgm = { programName: String, symbolTable: ISymbolTable, _: Throwable? ->
+                if (programName.equals("ST_CALL03C", ignoreCase = true)) {
+                    val dataDefinition = symbolTable.get("VARSTD")
+                    assertIs<StringValue>(dataDefinition)
+                    assertEquals(2, dataDefinition.length())
+                }
+
+                if (programName.equals("ST_CALL03", ignoreCase = true)) {
+                    val dataDefinition = symbolTable.get("DS1_ARR")
+                    assertIs<ArrayValue>(dataDefinition)
+                    assertIs<StringType>(dataDefinition.elementType)
+                    assertEquals(5, dataDefinition.arrayLength())
+                }
+            }
+        })
+
+        assertEquals(listOf("CALLER", "5", "5", "5", "5", "5", "CALLED", "55"), messages)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL01.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL01.rpgle
@@ -1,0 +1,16 @@
+     V* ==============================================================
+     V* 21/05/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Ensures that the param of called program doesn't change type
+    O *  into that of caller.
+    O * In this case we have DS -> S.
+     V* ==============================================================
+     D £G90DS          DS           512
+
+     C                   EVAL      £G90DS='CALLER'
+     C                   CALL      'ST_CALL01C'
+     C                   PARM                    £G90DS
+
+     C     £G90DS        DSPLY
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL01C.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL01C.rpgle
@@ -1,0 +1,8 @@
+     D £G90DS          DS           512
+     D £G90WK          S            512
+
+     C     'CALLED'      DSPLY
+     C                   SETON                                        LR
+
+     C     *ENTRY        PLIST
+     C     £G90DS        PARM      £G90DS        £G90WK

--- a/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL02.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL02.rpgle
@@ -1,0 +1,17 @@
+     V* ==============================================================
+     V* 21/05/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Ensures that the param of called program doesn't change type
+    O *  into that of caller.
+    O * In this case we have S -> S with different sizes.
+     V* ==============================================================
+     D VARSTD          S              6
+
+     C     'CALLER'      DSPLY
+     C                   EVAL      VARSTD='FOOBAR'
+     C     VARSTD        DSPLY
+     C                   CALL      'ST_CALL02C'
+     C                   PARM                    VARSTD
+
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL02C.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL02C.rpgle
@@ -1,0 +1,8 @@
+     D VARSTD          S              5
+
+     C     'CALLED'      DSPLY
+     C     VARSTD        DSPLY
+     C                   SETON                                        LR
+
+     C     *ENTRY        PLIST
+     C                   PARM                    VARSTD

--- a/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL03.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL03.rpgle
@@ -1,0 +1,21 @@
+     V* ==============================================================
+     V* 21/05/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Ensures that the param of called program doesn't change type
+    O *  into that of caller.
+    O * In this case we have DS Array -> S.
+     V* ==============================================================
+     D DS1             DS
+     D  DS1_ARR                       1    DIM(5) INZ('5')
+
+     C     'CALLER'      DSPLY
+     C     DS1_ARR(1)    DSPLY
+     C     DS1_ARR(2)    DSPLY
+     C     DS1_ARR(3)    DSPLY
+     C     DS1_ARR(4)    DSPLY
+     C     DS1_ARR(5)    DSPLY
+     C                   CALL      'ST_CALL03C'
+     C                   PARM                    DS1_ARR
+
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL03C.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/symboltable/ST_CALL03C.rpgle
@@ -1,0 +1,8 @@
+     D VARSTD          S              2
+
+     C     'CALLED'      DSPLY
+     C     VARSTD        DSPLY
+     C                   SETON                                        LR
+
+     C     *ENTRY        PLIST
+     C                   PARM                    VARSTD


### PR DESCRIPTION
## Description
This work resolves the coercion of parameters during the `CALL` to another program, like these snippets:

**Caller**
```
     D £G90DS          DS           512

     C                   EVAL      £G90DS='CALLER'
     C                   CALL      'ST_CALL01C'
     C                   PARM                    £G90DS

     C     £G90DS        DSPLY
     C                   SETON                                        LR
```

**Called**
```
     D £G90DS          DS           512
     D £G90WK          S            512

     C     'CALLED'      DSPLY
     C                   SETON                                        LR

     C     *ENTRY        PLIST
     C     £G90DS        PARM      £G90DS        £G90WK
```

In this case the type of `£G90WK` - of program called - must be a `S` and not a `DS`.

Related to #LS25002334

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
