### PR TITLE
Fix DO statement end position

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -289,16 +289,18 @@ datatypeName:
   | OBJECT;
 
 block:
-	((csDOUxx | csDOWxx | begindou | begindow | begindo)
-		statement*
-		enddo
-	)
+	dostatement
 	| ifstatement
 	| selectstatement
 	| forstatement
 	| monitorstatement
 	| casestatement
 ;
+
+dostatement: ((csDOUxx | csDOWxx | begindou | begindow | begindo)
+             		statement*
+             		enddo
+             	);
 
 ifstatement:
 	(beginif

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -2687,4 +2687,14 @@ Test 6
         // by setting 2nd param value to 5 we specify that the block should occur in called program
         assertTrue(simulateBlockingOperation("CALLEE_ERROR", 5) is InterruptedException)
     }
+
+    @Test
+    fun doStatementPositionTest() {
+        val cu = assertASTCanBeProduced("DO_TST02", true)
+        cu.resolveAndValidate()
+
+        val doStmt = cu.main.stmts.first()
+        assertEquals(4, doStmt.position?.start?.line)
+        assertEquals(6, doStmt.position?.end?.line)
+    }
 }


### PR DESCRIPTION
## Description

> Note: This PR does not alter or add any RPGLE functionality.

This PR resolves a core issue in Jariko logic that was discovered while developing #732 causing `DO` statements to report a wrong end position.

### Technical notes

The issue was forced by an improper design of the `DO` statement grammar in the parser.
Basically every type of `DO` statement was bound to its beginning keyword. This caused to consider the end position of the statement as the end position of the begin statement instead of it being correctly reported at the end of the corresponding `ENDDO`.

This seems to be a small and irrelevant thing but in reality it is a very severe issue when dealing with:
- Logic bound to lines (for instance the profiling annotations in #732).
- Observability and logging.

Changes are:

- Refactor on how `DO` statements are parsed in `RpgParser.g4`. They are now grouped under the `dostatement` rule.
- The AST generation logic now redirects the `dostatement` syntax tree generation to its own rule that only then internally dispatches the syntax tree to the specific rules. This ensures the end position is correctly evaluated and not lost when generating the output `Statement`.

Related to:
- #732

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
