### PR TITLE
Bugfix/LS25002674/Fix `OCCURS` when the argument is a variable

### DIFF
--- a/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
+++ b/rpgJavaInterpreter-core/src/main/antlr/RpgParser.g4
@@ -159,7 +159,7 @@ keyword_likerec : KEYWORD_LIKEREC OPEN_PAREN intrecname=simpleExpression
 	(COLON (SPLAT_ALL | SPLAT_INPUT | SPLAT_OUTPUT | SPLAT_KEY))?
 	CLOSE_PAREN; 
 keyword_noopt : KEYWORD_NOOPT;
-keyword_occurs : KEYWORD_OCCURS OPEN_PAREN ((numeric_constant=number | function | identifier)|(expr=expression)) CLOSE_PAREN;
+keyword_occurs : KEYWORD_OCCURS OPEN_PAREN expr=occurExpression CLOSE_PAREN;
 keyword_opdesc : KEYWORD_OPDESC;
 keyword_options : KEYWORD_OPTIONS OPEN_PAREN identifier (COLON identifier)* CLOSE_PAREN; 
 keyword_overlay : KEYWORD_OVERLAY OPEN_PAREN name=simpleExpression (COLON (SPLAT_NEXT | pos=simpleExpression))? CLOSE_PAREN; 
@@ -2414,7 +2414,16 @@ simpleExpression:
 	| number 
 	| literal
 	| OPEN_PAREN expression CLOSE_PAREN
-	; 
+	;
+
+occurExpression:
+	number
+	| indicator
+	| function
+	| identifier
+	| literal
+	| bif
+	;
 	
 unaryExpression:
 	sign expression;

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -611,7 +611,6 @@ internal fun RpgParser.Dcl_dsContext.type(
  */
 internal fun RpgParser.Keyword_occursContext.evaluate(conf: ToAstConfiguration = ToAstConfiguration()): Int? {
     return when {
-        this.numeric_constant != null -> numeric_constant?.getChild(0)?.text?.toInt()
         this.expr != null -> {
             val injectableCompileTimeInterpreter = InjectableCompileTimeInterpreter(
                 knownDataDefinitions = KnownDataDefinition.getInstance().values.toList(),

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/data_definitions.kt
@@ -610,15 +610,14 @@ internal fun RpgParser.Dcl_dsContext.type(
  * Evaluates the OCCURS keyword between a number or an expression to evaluate at runtime.
  */
 internal fun RpgParser.Keyword_occursContext.evaluate(conf: ToAstConfiguration = ToAstConfiguration()): Int? {
-    return when {
-        this.expr != null -> {
-            val injectableCompileTimeInterpreter = InjectableCompileTimeInterpreter(
-                knownDataDefinitions = KnownDataDefinition.getInstance().values.toList(),
-                delegatedCompileTimeInterpreter = conf.compileTimeInterpreter
-            )
-            injectableCompileTimeInterpreter.evaluate(rContext(), this.expr.toAst(conf)).asInt().value.toInt()
-        }
-        else -> null
+    return if (this.expr != null) {
+        val injectableCompileTimeInterpreter = InjectableCompileTimeInterpreter(
+            knownDataDefinitions = KnownDataDefinition.getInstance().values.toList(),
+            delegatedCompileTimeInterpreter = conf.compileTimeInterpreter
+        )
+        injectableCompileTimeInterpreter.evaluate(rContext(), this.expr.toAst(conf)).asInt().value.toInt()
+    } else {
+        null
     }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/expressions.kt
@@ -57,6 +57,18 @@ fun RpgParser.ExpressionContext.toAst(conf: ToAstConfiguration = ToAstConfigurat
     }
 }
 
+fun RpgParser.OccurExpressionContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Expression {
+    return when {
+        this.number() != null -> this.number()!!.toAst(conf)
+        this.identifier() != null -> this.identifier().toAst(conf)
+        this.bif() != null -> this.bif().toAst(conf)
+        this.literal() != null -> this.literal().toAst(conf)
+        this.function() != null -> this.function().toAst(conf)
+        this.indicator() != null -> this.indicator().toAst(conf)
+        else -> todo(conf = conf)
+    }
+}
+
 internal fun RpgParser.UnaryExpressionContext.toAst(conf: ToAstConfiguration = ToAstConfiguration()): Expression {
     if (this.children.isEmpty()) {
         todo(conf = conf)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1065,7 +1065,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     }
 
     /**
-     * Using `OCCUR` by passing a variable as argument.
+     * Using `OCCURS` by passing a variable as argument.
      */
     @Test
     fun executeMUDRNRAPU001125() {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1063,4 +1063,13 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("1.50", "2.50", "3.50", "1.50", "2.50", "3.50")
         assertEquals(expected, "smeup/MUDRNRAPU001109".outputOf())
     }
+
+    /**
+     * Using `OCCUR` by passing a variable as argument.
+     */
+    @Test
+    fun executeMUDRNRAPU001125() {
+        val expected = listOf("0", ".0", "1", "1.1", "0", ".0", "2", "2.2")
+        assertEquals(expected, "smeup/MUDRNRAPU001125".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001125.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001125.rpgle
@@ -1,0 +1,40 @@
+     V* ==============================================================
+     V* 09/06/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Using `OCCUR` by passing a variable as argument.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *   `OCCUR not supported. Q£ORAR must be a DS defined
+    O *    with OCCURS keyword`
+     V* ==============================================================
+     D SIZE_OCCUR      C                   CONST(2)
+     D DS1             DS                  OCCURS(SIZE_OCCUR) INZ
+     D  DS1_FL1                       2  0
+     D  DS1_FL2                       2  1
+     D TMP             S              5
+
+     C                   Z-ADD     1             I                 4 0
+     C     I             OCCUR     DS1
+     C                   EXSR      SHOW
+     C                   EVAL      DS1_FL1=1
+     C                   EVAL      DS1_FL2=1.1
+     C                   EXSR      SHOW
+
+     C                   Z-ADD     2             I
+     C     I             OCCUR     DS1
+     C                   EXSR      SHOW
+     C                   EVAL      DS1_FL1=2
+     C                   EVAL      DS1_FL2=2.2
+     C                   EXSR      SHOW
+
+     C                   SETON                                          LR
+
+     C     SHOW          BEGSR
+     C                   EVAL      TMP=%CHAR(DS1_FL1)
+     C     TMP           DSPLY
+     C                   EVAL      TMP=%CHAR(DS1_FL2)
+     C     TMP           DSPLY
+     C                   ENDSR
+

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001125.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001125.rpgle
@@ -9,8 +9,8 @@
     O *   `OCCUR not supported. Q£ORAR must be a DS defined
     O *    with OCCURS keyword`
      V* ==============================================================
-     D SIZE_OCCUR      C                   CONST(2)
-     D DS1             DS                  OCCURS(SIZE_OCCUR) INZ
+     D SIZE_OCCURS     C                   CONST(2)
+     D DS1             DS                  OCCURS(SIZE_OCCURS) INZ
      D  DS1_FL1                       2  0
      D  DS1_FL2                       2  1
      D TMP             S              5

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001125.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001125.rpgle
@@ -2,7 +2,7 @@
      V* 09/06/2025 APU001 Creation
      V* ==============================================================
     O * PROGRAM GOAL
-    O * Using `OCCUR` by passing a variable as argument.
+    O * Using `OCCURS` by passing a variable as argument.
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, the error occurred was:


### PR DESCRIPTION
## Description
This work improved `OCCURS` keyword when the argument is a variable, like this snippet:
```
     D SIZE_OCCURS     C                   CONST(2)
     D DS1             DS                  OCCURS(SIZE_OCCURS) INZ
     ...
     C     I             OCCUR     DS1
```
As we can see, the argument is `SIZE_OCCURS` previously declared as `2`.

### Techincal notes
On Jariko the error was: `Issue executing OccurStmt at line x. OCCUR not supported. DS1 must be a DS defined with OCCURS keyword`. 
By starting from CU creation, `DS1` was `DataStructureType` instead a `OccurableDataStructureType`. This happened for a wrong rule on `RpgParser.g4`, specifically for the `keyword_occurs`. So, the improvement that has been made is the construction of `occurExpression` (like `simpleExpression`) specific for `OCCURS` argument, instead to use redundant `numeric_constant` which contains some rules of `expression` (that is more generic) used for `expr`.

Related to #LS25002674

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
