### PR TITLE
Bugfix/LS25002684/Error casting during utilization `Z-ADD` where the result is an array of a DS declared as `OCCURS`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -185,7 +185,13 @@ open class InternalInterpreter(
             is FieldDefinition -> {
                 val ds = data.parent as DataDefinition
                 if (data.declaredArrayInLine != null) {
-                    val dataStructValue = get(ds.name) as DataStructValue
+                    val dataStructValue: DataStructValue = get(ds.name).let {
+                        if (it is OccurableDataStructValue) {
+                            return@let it.get(it.occurrence)
+                        }
+
+                        return@let it as DataStructValue
+                    }
                     var startOffset = data.startOffset
                     val size = data.endOffset - data.startOffset
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1078,7 +1078,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      */
     @Test
     fun executeMUDRNRAPU001126() {
-        val expected = listOf("0", "0", "0", "1", "1", "1", "0", "0", "0", "2", "2", "2")
+        val expected = listOf("0", "0", "0", "1", "1", "1", "0", "0", "0", "2", "2", "2", "1", "1", "1", "2", "2", "2")
         assertEquals(expected, "smeup/MUDRNRAPU001126".outputOf())
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1072,4 +1072,13 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("0", ".0", "1", "1.1", "0", ".0", "2", "2.2")
         assertEquals(expected, "smeup/MUDRNRAPU001125".outputOf())
     }
+
+    /**
+     * Using `Z-ADD` with a field of occurable DS declared as array.
+     */
+    @Test
+    fun executeMUDRNRAPU001126() {
+        val expected = listOf("0", "0", "0", "1", "1", "1", "0", "0", "0", "2", "2", "2")
+        assertEquals(expected, "smeup/MUDRNRAPU001126".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001126.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001126.rpgle
@@ -1,5 +1,6 @@
      V* ==============================================================
-     V* 09/06/2025 APU001 Creation
+     V* 10/06/2025 APU001 Creation
+     V* 11/06/2025 APU001 Improvements
      V* ==============================================================
     O * PROGRAM GOAL
     O * Using `Z-ADD` with a field of occurable DS declared as array.
@@ -15,16 +16,19 @@
      D  DS1_FL1                       2  0 DIM(3)
      D TMP             S              5
 
-     C                   Z-ADD     1             I                 4 0
-     C     I             OCCUR     DS1
+     C     1             OCCUR     DS1
      C                   EXSR      SHOW
      C                   Z-ADD     1             DS1_FL1
      C                   EXSR      SHOW
 
-     C                   Z-ADD     2             I                 4 0
-     C     I             OCCUR     DS1
+     C     2             OCCUR     DS1
      C                   EXSR      SHOW
      C                   Z-ADD     2             DS1_FL1
+     C                   EXSR      SHOW
+
+     C     1             OCCUR     DS1
+     C                   EXSR      SHOW
+     C     2             OCCUR     DS1
      C                   EXSR      SHOW
 
      C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001126.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001126.rpgle
@@ -1,0 +1,39 @@
+     V* ==============================================================
+     V* 09/06/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Using `Z-ADD` with a field of occurable DS declared as array.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *   `Issue executing ZAddStmt at line 21.
+    O *    OccurableDataStructValue cannot be cast to class
+    O *    DataStructValue`
+     V* ==============================================================
+     D SIZE_OCCURS     C                   CONST(2)
+     D DS1             DS                  OCCURS(SIZE_OCCURS) INZ
+     D  DS1_FL1                       2  0 DIM(3)
+     D TMP             S              5
+
+     C                   Z-ADD     1             I                 4 0
+     C     I             OCCUR     DS1
+     C                   EXSR      SHOW
+     C                   Z-ADD     1             DS1_FL1
+     C                   EXSR      SHOW
+
+     C                   Z-ADD     2             I                 4 0
+     C     I             OCCUR     DS1
+     C                   EXSR      SHOW
+     C                   Z-ADD     2             DS1_FL1
+     C                   EXSR      SHOW
+
+     C                   SETON                                          LR
+
+     C     SHOW          BEGSR
+     C                   EVAL      TMP=%CHAR(DS1_FL1(1))
+     C     TMP           DSPLY
+     C                   EVAL      TMP=%CHAR(DS1_FL1(2))
+     C     TMP           DSPLY
+     C                   EVAL      TMP=%CHAR(DS1_FL1(3))
+     C     TMP           DSPLY
+     C                   ENDSR


### PR DESCRIPTION
## Description
This work improves the `Z-ADD` where the result is a DS field declared as array. Also, the DS has the keyword `OCCURS`, like this snippet:
```
     D SIZE_OCCURS     C                   CONST(2)
     D DS1             DS                  OCCURS(SIZE_OCCURS) INZ
     D  DS1_FL1                       2  0 DIM(3)
     ...
     C                   Z-ADD     1             DS1_FL1
```

### Techincal notes
On Jariko the error was: `Issue executing ZAddStmt at line xy. OccurableDataStructValue cannot be cast to class DataStructValue`. To achieve the goal, `InternalInterpreter.set` has been improved to cover this case.

Related to #LS25002684

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
