### PR TITLE
Bugfix/ls25002417/empty span scopes

### DIFF
--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/ProfilingAnnotationTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/ProfilingAnnotationTest.kt
@@ -360,6 +360,54 @@ open class ProfilingAnnotationTest : AbstractTest() {
     }
 
     /**
+     * Test the injection of telemetry spans in a simple use case (1 OPEN, 1 CLOSE) with an empty telemetry scope.
+     */
+    @Test
+    fun executeEmptyTelemetrySpan() {
+        val cu = assertASTCanBeProduced("profiling/EMPTY_TELEMETRY_SPAN", true, withProfilingSupport = true)
+        cu.resolveAndValidate()
+        execute(cu, emptyMap())
+
+        assertEquals(2, cu.resolvedProfilingAnnotations.size)
+        assertSourceLineEquivalence(cu.resolvedProfilingAnnotations)
+
+        val openAnnotations = cu.getOpenAnnotations()
+        val closeAnnotations = cu.getClosedAnnotations()
+
+        assertEquals(1, openAnnotations.size)
+        assertEquals(1, closeAnnotations.size)
+
+        assertSpanStartPositions(cu, listOf("_SPANID1" to 13), LookupMode.Annotation)
+        assertSpanStartPositions(cu, listOf("_SPANID1" to 14), LookupMode.Statement)
+        assertSpanEndAnnotationPositions(cu, listOf(15))
+        assertSpanEndStatementPositions(cu, listOf(14))
+    }
+
+    /**
+     * Test the injection of telemetry spans in a simple use case (1 OPEN, 1 CLOSE) with nested empty telemetry scopes.
+     */
+    @Test
+    fun executeEmptyNestedTelemetrySpan() {
+        val cu = assertASTCanBeProduced("profiling/EMPTY_NESTED_TELEMETRY_SPAN", true, withProfilingSupport = true)
+        cu.resolveAndValidate()
+        execute(cu, emptyMap())
+
+        assertEquals(2, cu.resolvedProfilingAnnotations.size)
+        assertSourceLineEquivalence(cu.resolvedProfilingAnnotations)
+
+        val openAnnotations = cu.getOpenAnnotations()
+        val closeAnnotations = cu.getClosedAnnotations()
+
+        assertEquals(1, openAnnotations.size)
+        assertEquals(1, closeAnnotations.size)
+
+        assertSpanStartPositions(cu, listOf("_SPANID1" to 17), LookupMode.Annotation)
+        assertSpanStartPositions(cu, listOf("_SPANID1" to 18), LookupMode.Statement)
+        assertSpanEndAnnotationPositions(cu, listOf(19))
+        assertSpanEndStatementPositions(cu, listOf(18))
+    }
+
+    /**
      * Lookup strategy for annotation lines.
      */
     private enum class LookupMode {

--- a/rpgJavaInterpreter-core/src/test/resources/profiling/EMPTY_NESTED_TELEMETRY_SPAN.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/profiling/EMPTY_NESTED_TELEMETRY_SPAN.rpgle
@@ -1,0 +1,20 @@
+     V* ==============================================================
+     V* 12/05/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Emit RPG Traces
+     V* ==============================================================
+     DA                S              8  0 INZ(5)
+     DB                S              8  0 INZ(8)
+     D RESULT          S              8  0 INZ(0)
+      *
+  PROF* SPANSTART _EMPTY "COMMENT"
+  PROF* SPANSTART _EMPTY2 "COMMENT"
+  PROF* SPANSTART _EMPTY3 "COMMENT"
+  PROF* SPANEND
+  PROF* SPANEND
+  PROF* SPANEND
+  PROF* SPANSTART _SPANID1 "COMMENT"
+     C                   EVAL      RESULT = A + B
+  PROF* SPANEND
+     C                   SETON                                        LR

--- a/rpgJavaInterpreter-core/src/test/resources/profiling/EMPTY_TELEMETRY_SPAN.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/profiling/EMPTY_TELEMETRY_SPAN.rpgle
@@ -1,0 +1,16 @@
+     V* ==============================================================
+     V* 12/05/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Emit RPG Traces
+     V* ==============================================================
+     DA                S              8  0 INZ(5)
+     DB                S              8  0 INZ(8)
+     D RESULT          S              8  0 INZ(0)
+      *
+  PROF* SPANSTART _EMPTY "COMMENT"
+  PROF* SPANEND
+  PROF* SPANSTART _SPANID1 "COMMENT"
+     C                   EVAL      RESULT = A + B
+  PROF* SPANEND
+     C                   SETON                                        LR


### PR DESCRIPTION
## Description

Fix a severe issue occurring when defining an empty telemetry scope, causing incorrect binding of profiling annotations.

### Technical notes

The issue occurred when we declared an empty scope as follows:

```rpgle
  PROF* SPANSTART _EMPTY
  PROF* SPANEND
```

In cases like this the `SPANEND` was attached to the first statement before the scope and `SPANSTART` was attached to the first statement after the scope. 
For instance:

```rpgle
  PROF* SPANSTART _EMPTY   <--- This was attached to the EVAL or caused an error
  PROF* SPANEND            <--- This was attached to the statement before the SPANSTART or caused an error
     C                   EVAL      RESULT = A + B
```

This issue is moderately severe because it caused a wrong execution and injection of profiling annotations to statements.

The new logic performs a cleanup step calling `ProfilingImmutableMap.removeEmptySpans` during injection that:
- Strips out empty spans from the candidates to inject
- Logs a warning informing of the span being ignored

`ProfilingImmutableMap.removeEmptySpans` also supports and takes care of multiple nested ignored statements like in the following case:

```rpgle
  PROF* SPANSTART EMPTY1
  PROF* SPANSTART EMPTY2
  PROF* SPANSTART EMPTY3
  PROF* SPANEND
  PROF* SPANEND
  PROF* SPANEND
```

Related to:
- LS25002417

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
