### PR TITLE
Bugfix/ls25002734/call indicator external error

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -553,6 +553,10 @@ open class InternalInterpreter(
         }
     }
 
+    override fun fireErrorEvent(throwable: Throwable, position: Position?) {
+        throwable.fireErrorEvent(position)
+    }
+
     @Deprecated(message = "No longer used")
     open fun fireOnEnterPgmCallBackFunction() {
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1111,7 +1111,15 @@ data class CallStmt(
                     }
 
                     interpreter.getIndicators()[errorIndicator] = BooleanValue.TRUE
-                    MainExecutionContext.getConfiguration().jarikoCallback.onCallPgmError.invoke(popRuntimeErrorEvent())
+
+                    // If event is not in jariko runtime error stack it means the error originated externally
+                    // In this case we need to report it first.
+                    val errorEvent = popRuntimeErrorIfMatches(e) ?: run {
+                        interpreter.fireErrorEvent(e, position)
+                        popRuntimeErrorEvent()
+                    }
+
+                    MainExecutionContext.getConfiguration().jarikoCallback.onCallPgmError.invoke(errorEvent)
                     null
                 }
             paramValuesAtTheEnd?.forEachIndexed { index, value ->

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT03IndicatorTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT03IndicatorTest.kt
@@ -73,4 +73,14 @@ open class MULANGT03IndicatorTest : MULANGTTest() {
         val expected = listOf("10", "10")
         assertEquals(expected, "smeup/MUDRNRAPU00130".outputOf())
     }
+
+    /**
+     * Execute a CALL with error state bound to an indicator where the error is originated externally
+     * @see #LS25002734
+     */
+    @Test
+    fun executeMUDRNRAPU00292() {
+        val expected = listOf("ok")
+        assertEquals(expected, "smeup/MUDRNRAPU00292".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT03IndicatorTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT03IndicatorTest.kt
@@ -22,6 +22,7 @@ import com.smeup.rpgparser.interpreter.SystemInterface
 import com.smeup.rpgparser.interpreter.Value
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
 import org.junit.Test
+import java.util.LinkedList
 import kotlin.test.assertEquals
 
 open class MULANGT03IndicatorTest : MULANGTTest() {
@@ -104,10 +105,11 @@ open class MULANGT03IndicatorTest : MULANGTTest() {
         val expected = listOf("ok")
 
         class MySystemInterface : JavaSystemInterface() {
+            val displayed = LinkedList<String>()
 
-            override fun findProgram(nameOrSource: String): Program? {
-                if (nameOrSource == "DOPEDPGM") {
-                    return object : Program {
+            override fun findProgram(name: String): Program? {
+                return if (name == "DOPEDPGM") {
+                    object : Program {
                         override fun params() = emptyList<ProgramParam>()
 
                         override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
@@ -115,11 +117,17 @@ open class MULANGT03IndicatorTest : MULANGTTest() {
                         }
                     }
                 } else {
-                    return super.findProgram(nameOrSource)
+                    super.findProgram(name)
                 }
+            }
+
+            override fun display(value: String) {
+                displayed.add(value)
+                println(value)
             }
         }
         val systemInterface = MySystemInterface()
         executePgm("smeup/MUDRNRAPU00292", systemInterface = systemInterface)
+        assertEquals(expected, systemInterface.displayed)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT03IndicatorTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT03IndicatorTest.kt
@@ -1,5 +1,26 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.smeup.rpgparser.smeup
 
+import com.smeup.rpgparser.interpreter.Program
+import com.smeup.rpgparser.interpreter.ProgramParam
+import com.smeup.rpgparser.interpreter.SystemInterface
+import com.smeup.rpgparser.interpreter.Value
+import com.smeup.rpgparser.jvminterop.JavaSystemInterface
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -81,6 +102,24 @@ open class MULANGT03IndicatorTest : MULANGTTest() {
     @Test
     fun executeMUDRNRAPU00292() {
         val expected = listOf("ok")
-        assertEquals(expected, "smeup/MUDRNRAPU00292".outputOf())
+
+        class MySystemInterface : JavaSystemInterface() {
+
+            override fun findProgram(nameOrSource: String): Program? {
+                if (nameOrSource == "DOPEDPGM") {
+                    return object : Program {
+                        override fun params() = emptyList<ProgramParam>()
+
+                        override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
+                            error("todo")
+                        }
+                    }
+                } else {
+                    return super.findProgram(nameOrSource)
+                }
+            }
+        }
+        val systemInterface = MySystemInterface()
+        executePgm("smeup/MUDRNRAPU00292", systemInterface = systemInterface)
     }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00292.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00292.rpgle
@@ -7,7 +7,7 @@
     O * JARIKO ANOMALY
     O * Before the fix, jariko reported a null error
      V* ==============================================================
-     D MSG            S           30000    VARYING
-     C                   CALL      DOPEDPGM                             37
+     D MSG             S          30000    VARYING
+     C                   CALL      'DOPEDPGM'                           37
      C                   EVAL      MSG='ok'
      C     MSG           DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00292.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00292.rpgle
@@ -1,0 +1,13 @@
+     V* ==============================================================
+     V* 16/06/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Call statement with indicator throwing an external error
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, jariko reported a null error
+     V* ==============================================================
+     D MSG            S           30000    VARYING
+     C                   CALL      DOPEDPGM                             37
+     C                   EVAL      MSG='ok'
+     C     MSG           DSPLY


### PR DESCRIPTION
## Description

Fix an issue that caused `CALL` with indicators to crash with a `null` error.

### Technical notes

The issue derived from the fact that when we had a `CALL` of this kind we popped the last error from the runtime error stack in order not to throw and instead manage it locally.
This worked fine, however if the error was thrown from an external source (for instace a doped program) we tried to pop:
- A wrong error if there was an error prior to the one we caught
- From an empty stack when there was no other error

The latter case is the one that made this issue known.

To fix this a specialized step was added in `CallStmt` that checks if the error we capture is present in the runtime stack before popping and records it in case it was not present (because it means the error originated externally).

Related to:
- LS25002734

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
