### PR TITLE
Bugfix/ls25003001/packed db notation

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/coercing.kt
@@ -17,6 +17,7 @@
 package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.parsing.parsetreetoast.RpgType
+import com.smeup.rpgparser.parsing.parsetreetoast.isFloatingPointNumber
 import com.smeup.rpgparser.parsing.parsetreetoast.isNumber
 import com.smeup.rpgparser.utils.repeatWithMaxSize
 import java.math.BigDecimal
@@ -169,9 +170,10 @@ private fun coerceString(value: StringValue, type: Type): Value {
                              *   StringValue[11](1.000000000)
                              */
                             val decimalValue = value.value.trim()
-                            if (decimalValue.isNumber()) {
+                            val isFloatWithNotation = decimalValue.isFloatingPointNumber() && decimalValue.contains("e", ignoreCase = true)
+                            if (decimalValue.isNumber() || isFloatWithNotation) {
                                 val isDecimal = decimalValue.lastIndexOf('.') != -1
-                                if (isDecimal) {
+                                if (isDecimal || isFloatWithNotation) {
                                     return DecimalValue(decimalValue.toBigDecimal())
                                 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/parsetreetoast/misc.kt
@@ -736,6 +736,8 @@ internal fun String.isInt() = this.matches(Regex("^-?[0-9]+$"))
 
 internal fun String.isDecimal() = this.matches(Regex("^-?[0-9]*.[0-9]+$"))
 
+internal fun String.isFloatingPointNumber() = this.matches(Regex("[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)"))
+
 internal fun String.toDecimal() = this.toDouble()
 
 internal fun String.isNumber() = this.isInt() || this.isDecimal()

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT50FileAccess1Test.kt
@@ -133,4 +133,18 @@ open class MULANGT50FileAccess1Test : MULANGTTest() {
             )
         )
     }
+
+    /**
+     * Packed numbers in floating point notation from DB
+     * @see #LS25003001
+     */
+    @Test
+    fun executeMUDRNRAPU00294() {
+        MULANGTLDbMock().usePopulated({
+            val expected = listOf(".000000000")
+            assertEquals(expected, "smeup/MUDRNRAPU00294".outputOf(configuration = smeupConfig))
+        }, listOf(
+            mapOf<String, Any>("MLNNAT" to "0E-09")
+        ))
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00294.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU00294.rpgle
@@ -1,0 +1,16 @@
+     V* ==============================================================
+     V* 27/06/2025 APU002 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * Packed numbers in floating point notation from DB
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, Jariko could not interpret the number
+     V* ==============================================================
+     FMULANGTL  UF A E           K DISK
+     C     KERR          KLIST
+     C                   KFLD                    MLSYST
+     C                   KFLD                    MLTIPO
+     C                   KFLD                    MLPROG
+     C     KERR          CHAIN     MULANGTL
+     C     MLNNAT        DSPLY


### PR DESCRIPTION
## Description

Fix an issue that caused the program to crash when receiving a packed number from DB with scientific notation exponential.

### Technical notes

To fix the issue a check on whether the number pattern matches a floating point number was added.
During coercion a double check on the exponent is performed because strings holding integer values (they match the floating point pattern) should be treated differently.

In order to test this behaviour the `DbMock` was extended in order to support mocked number values.

Related to:
- LS25003001

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
