### PR TITLE
Add Call and SR time aggregate in analytics output

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -274,7 +274,14 @@ Symbol table analytics provide the same information of other analytics but refer
 +---------- header ---------+------ prog ------+---------- entity ---------+- time -+- hit -+
 ```
 
-There are also other analytics which provide their own informational data. Here are some examples:
+Call analytics provide aggregated information about CALL and EXSR times.
+```
+14:37:03.552 	ANALYTICS			            PGM CALL	CALLDEFV2	    65933	 1
+14:37:03.552 	ANALYTICS			            EXSR CALL	CALLSR	        1800	 1
++---------- header ---------+------ prog ------+---------- entity ---------+- time -+- hit -+
+```
+
+There are also analytics which provide their own informational data. Here are some examples:
 ```
 12:42:44.070    ANALYTICS                       LOG TIME                     61886   1900103
 12:42:44.070    ANALYTICS                       INTERPRETATION TIME          4706819 1

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/logging/AnalyticsLoggingContext.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/logging/AnalyticsLoggingContext.kt
@@ -188,11 +188,12 @@ class AnalyticsLoggingContext {
     private fun generateProgramCallLogEntries(): Sequence<LazyLogEntry> {
         return programCalls.asSequence().map {
             val programName = it.key
-            val hit = it.value
+            val duration = it.value.duration
+            val hit = it.value.hit
 
             val entry = LogEntry({ LogSourceData.UNKNOWN }, LogChannel.ANALYTICS.getPropertyName(), "PGM CALL")
             LazyLogEntry(entry) { sep ->
-                "$programName$sep$sep$hit"
+                "$programName$sep${duration.inWholeMicroseconds}${sep}$hit"
             }
         }
     }
@@ -200,11 +201,12 @@ class AnalyticsLoggingContext {
     private fun generateSubroutineCallLogEntries(): Sequence<LazyLogEntry> {
         return subroutineCalls.asSequence().map {
             val subroutineName = it.key
-            val hit = it.value
+            val duration = it.value.duration
+            val hit = it.value.hit
 
             val entry = LogEntry({ LogSourceData.UNKNOWN }, LogChannel.ANALYTICS.getPropertyName(), "EXSR CALL")
             LazyLogEntry(entry) { sep ->
-                "$subroutineName$sep$sep$hit"
+                "$subroutineName$sep${duration.inWholeMicroseconds}${sep}$hit"
             }
         }
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/logging/LoggingTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/logging/LoggingTest.kt
@@ -313,6 +313,37 @@ class LoggingTest : AbstractTest() {
     }
 
     /**
+     * Test if analytics are printed out in the appropriate format
+     * @see #LS25002960
+     */
+    @Test
+    fun analyticsFormat() {
+        val defaultOut = System.out
+        val virtualOut = StringOutputStream()
+        System.setOut(PrintStream(virtualOut))
+
+        val configuration = Configuration()
+        val systemInterface = JavaSystemInterface(configuration = configuration).apply {
+            loggingConfiguration = consoleLoggingConfiguration(LogChannel.ANALYTICS)
+        }
+        executePgm(programName = "CALLSCOPE2", configuration = configuration, systemInterface = systemInterface)
+        virtualOut.flush()
+
+        val logEntries = virtualOut.toString().trim().split(regex = Regex("\\n|\\r\\n"))
+
+        assertTrue { logEntries.any { it.contains("ANALYTICS\tCALLSCOPE2\t\tSTMT TIME") } }
+        assertTrue { logEntries.any { it.contains("ANALYTICS\tCALLSCOPE2\t\tEXPR TIME") } }
+        assertTrue { logEntries.any { it.contains("ANALYTICS\tCALLSCOPE2\t\tSYMTBL TIME") } }
+        assertTrue { logEntries.any { it.contains("ANALYTICS\tCALLSCOPE2\t\tPARS TIME") } }
+        assertTrue { logEntries.any { it.contains("ANALYTICS\t\t\tPGM CALL\tCALLDEFV2") } }
+        assertTrue { logEntries.any { it.contains("ANALYTICS\t\t\tEXSR CALL\tCALLSR") } }
+        assertTrue { logEntries.any { it.contains("ANALYTICS\t\t\tLOG TIME") } }
+        assertTrue { logEntries.any { it.contains("ANALYTICS\t\t\tINTERPRETATION TIME") } }
+
+        System.setOut(defaultOut)
+    }
+
+    /**
      * Test if mock statements are printed out in the appropriate format
      * @see #LS24004983
      */

--- a/rpgJavaInterpreter-core/src/test/resources/CALLSCOPE2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/CALLSCOPE2.rpgle
@@ -1,0 +1,8 @@
+     D STR10           S             10
+     C                   EXSR      CALLSR
+     C                   CALL      'CALLDEFV2'
+     C                   PARM                    $A                2
+     C                   EVAL      $A='T'
+     C     CALLSR        BEGSR
+     C                   EVAL      STR10='ABCDE'
+     C                   ENDSR


### PR DESCRIPTION
## Description

Add aggregate usage of CALLs and SRs in analytics output.

Related to:
- LS25002960

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
