### PR TITLE
Feature/ls25003049/jariko traces filtering

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/Configuration.kt
@@ -93,6 +93,7 @@ data class DspfConfig(
  * is true.
  * @param profilingSupport Used to enable/disable scan execution of profiling annotations into rpg sources.
  * This is used to enable the [JarikoCallback.startRpgTrace] and [JarikoCallback.finishRpgTrace] callbacks.
+ * @param enabledJarikoTraces A whitelist of the enabled trace kinds to emit. All enabled if [null].
  * */
 data class Options(
     var muteSupport: Boolean = false,
@@ -102,11 +103,33 @@ data class Options(
     var callProgramHandler: CallProgramHandler? = null,
     var dumpSourceOnExecutionError: Boolean? = false,
     var debuggingInformation: Boolean? = false,
-    var profilingSupport: Boolean = false
+    var profilingSupport: Boolean = false,
+    private var enabledJarikoTraces: List<JarikoTraceKind>? = null
 ) {
     internal fun mustDumpSource() = dumpSourceOnExecutionError == true
     internal fun mustCreateCopyBlocks() = debuggingInformation == true || profilingSupport
     internal fun mustInvokeOnStatementCallback() = debuggingInformation == true
+
+    /**
+     * Enable all the Jariko traces.
+     */
+    fun enableAllJarikoTraces() {
+        enabledJarikoTraces = null
+    }
+
+    /**
+     * Get a list of the enabled Jariko traces.
+     */
+    fun getEnabledJarikoTraces(): List<JarikoTraceKind> {
+        return enabledJarikoTraces ?: JarikoTraceKind.entries
+    }
+
+    /**
+     * Set which Jariko traces are enabled.
+     */
+    fun setEnabledJarikoTraces(kinds: List<JarikoTraceKind>) {
+        this.enabledJarikoTraces = kinds
+    }
 }
 
 /**

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/execution/MainExecutionContext.kt
@@ -89,9 +89,7 @@ object MainExecutionContext {
                 val ctx = context.get()
                 val callback = ctx.configuration.jarikoCallback
                 val trace = JarikoTrace(JarikoTraceKind.MainExecutionContext)
-                callback.traceBlock(trace) {
-                    invoke(ctx)
-                }
+                callback.traceBlockIfEnabled(trace) { invoke(ctx) }
             }.onFailure {
                 if (isRootContext) memorySliceMgr?.afterMainProgramInterpretation(false)
             }.onSuccess {
@@ -222,6 +220,18 @@ object MainExecutionContext {
      * @return true if error log channel is configured
      * */
     val isErrorChannelConfigured get() = context.get()?.logHandlers?.isErrorChannelConfigured() ?: false
+
+    /**
+     * Get a list of all the enabled Jariko Traces.
+     */
+    fun getEnabledJarikoTraces() = getConfiguration().options.getEnabledJarikoTraces()
+
+    /**
+     * Check if a [JarikoTraceKind] is enabled.
+     */
+    fun isJarikoTraceEnabled(kind: JarikoTraceKind): Boolean {
+        return getEnabledJarikoTraces().contains(kind)
+    }
 }
 
 data class Context(

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/ExpressionEvaluation.kt
@@ -536,7 +536,7 @@ class ExpressionEvaluation(
         val functionToCall = expression.function.name
         val callback = MainExecutionContext.getConfiguration().jarikoCallback
         val trace = JarikoTrace(JarikoTraceKind.FunctionCall, functionToCall)
-        callback.traceBlock(trace) {
+        callback.traceBlockIfEnabled(trace) {
             val source: LogSourceProvider = {
                 LogSourceData(MainExecutionContext.getExecutionProgramName(), expression.startLine())
             }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -203,7 +203,7 @@ open class InternalInterpreter(
         val programName = getInterpretationContext().currentProgramName
         val logSourceProducer = { LogSourceData(programName = programName, line = compilationUnit.startLine()) }
 
-        callback.traceBlock(initTrace) {
+        callback.traceBlockIfEnabled(initTrace) {
             val start = System.nanoTime()
 
             renderLog { LazyLogEntry.produceInformational(logSourceProducer, "SYMTBLINI", "START") }
@@ -337,7 +337,7 @@ open class InternalInterpreter(
         }
 
         val loadTrace = JarikoTrace(JarikoTraceKind.SymbolTable, "LOAD")
-        callback.traceBlock(loadTrace) {
+        callback.traceBlockIfEnabled(loadTrace) {
             renderLog { LazyLogEntry.produceInformational(logSourceProducer, "SYMTBLLOAD", "START") }
             renderLog { LazyLogEntry.produceStatement(logSourceProducer, "SYMTBLLOAD", "START") }
 
@@ -1279,7 +1279,7 @@ open class InternalInterpreter(
             executeProfiling(attachAfterProfilingAnnotations)
         }
 
-        trace?.let { callback.traceBlock(it) { internalExecute() } } ?: internalExecute()
+        trace?.let { callback.traceBlockIfEnabled(it) { internalExecute() } } ?: internalExecute()
     }
 
     override fun onInterpretationEnd() {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -88,7 +88,7 @@ class RpgProgram(val cu: CompilationUnit, val name: String = "<UNNAMED RPG PROGR
     override fun execute(systemInterface: SystemInterface, params: LinkedHashMap<String, Value>): List<Value> {
         val callback = configuration.jarikoCallback
         val trace = JarikoTrace(JarikoTraceKind.RpgProgram, this.name)
-        return callback.traceBlock(trace) {
+        return callback.traceBlockIfEnabled(trace) {
             val expectedKeys = params().asSequence().map { it.name }.toSet()
 
             // Original params passed from the caller

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/tracing.kt
@@ -18,6 +18,7 @@
 package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.execution.JarikoCallback
+import com.smeup.rpgparser.execution.MainExecutionContext
 
 /**
  * Kind of a trace
@@ -58,6 +59,9 @@ data class RpgTrace(
     override fun toString() = "$fullName at line $line"
 }
 
+/**
+ * Open a trace block.
+ */
 internal fun <T> JarikoCallback.traceBlock(trace: JarikoTrace, block: () -> T): T {
     startJarikoTrace(trace)
     try {
@@ -67,4 +71,14 @@ internal fun <T> JarikoCallback.traceBlock(trace: JarikoTrace, block: () -> T): 
     } finally {
         finishJarikoTrace()
     }
+}
+
+/**
+ * Open a trace block if the corresponding kind is enabled. Just run the block otherwise.
+ */
+internal fun <T> JarikoCallback.traceBlockIfEnabled(trace: JarikoTrace, block: () -> T): T {
+    val isEnabled = MainExecutionContext.isJarikoTraceEnabled(trace.kind)
+    if (!isEnabled) return block()
+
+    return traceBlock(trace, block)
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/RpgParserFacade.kt
@@ -251,7 +251,7 @@ class RpgParserFacade {
         val callback = MainExecutionContext.getConfiguration().jarikoCallback
         val rpgLoadTrace = JarikoTrace(JarikoTraceKind.Parsing, "RPGLOAD")
         var charInput: CharStream? = null
-        callback.traceBlock(rpgLoadTrace) {
+        callback.traceBlockIfEnabled(rpgLoadTrace) {
             MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "RPGLOAD", "START"))
             MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "RPGLOAD"))
             val elapsedLoad = measureNanoTime {
@@ -275,7 +275,7 @@ class RpgParserFacade {
         }
 
         val lexerTrace = JarikoTrace(JarikoTraceKind.Parsing, "LEXER")
-        val lexer = callback.traceBlock(lexerTrace) {
+        val lexer = callback.traceBlockIfEnabled(lexerTrace) {
             val lexer: Lexer
             MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "LEXER", "START"))
             MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "LEXER"))
@@ -316,7 +316,7 @@ class RpgParserFacade {
         }
 
         val parserTrace = JarikoTrace(JarikoTraceKind.Parsing, "PARSER")
-        val parser = callback.traceBlock(parserTrace) {
+        val parser = callback.traceBlockIfEnabled(parserTrace) {
             val parser: RpgParser
             MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "PARSER", "START"))
             MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "PARSER"))
@@ -360,7 +360,7 @@ class RpgParserFacade {
     private fun verifyParseTree(parser: Parser, errors: MutableList<Error>, root: ParserRuleContext) {
         val callback = MainExecutionContext.getConfiguration().jarikoCallback
         val trace = JarikoTrace(JarikoTraceKind.Parsing, "CHKPTREE")
-        callback.traceBlock(trace) {
+        callback.traceBlockIfEnabled(trace) {
             val logSource = { LogSourceData(executionProgramName, "") }
             MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "CHKPTREE", "START"))
             MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "CHKPTREE"))
@@ -557,7 +557,7 @@ class RpgParserFacade {
         val parser = createParser(code.byteInputStream(Charsets.UTF_8).bomInputStream(), errors, longLines = true)
         val callback = MainExecutionContext.getConfiguration().jarikoCallback
         val trace = JarikoTrace(JarikoTraceKind.Parsing, "RCONTEXT")
-        val root = callback.traceBlock(trace) {
+        val root = callback.traceBlockIfEnabled(trace) {
             val root: RContext
             MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "RCONTEXT", "START"))
             MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "RCONTEXT"))
@@ -595,7 +595,7 @@ class RpgParserFacade {
             if (compiledFile.exists()) {
                 val callback = MainExecutionContext.getConfiguration().jarikoCallback
                 val trace = JarikoTrace(JarikoTraceKind.Parsing, "AST")
-                callback.traceBlock(trace) {
+                callback.traceBlockIfEnabled(trace) {
                     val logSource = { LogSourceData(executionProgramName, "") }
                     MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "START"))
                     MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "AST"))
@@ -645,7 +645,7 @@ class RpgParserFacade {
             val logSource = { LogSourceData(executionProgramName, "") }
             val callback = MainExecutionContext.getConfiguration().jarikoCallback
             val trace = JarikoTrace(JarikoTraceKind.Parsing, "AST")
-            callback.traceBlock(trace) {
+            callback.traceBlockIfEnabled(trace) {
                 val compilationUnit: CompilationUnit
                 MainExecutionContext.log(LazyLogEntry.produceStatement(logSource, "AST", "START"))
                 MainExecutionContext.log(LazyLogEntry.produceParsingStart(logSource, "AST"))

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -794,6 +794,36 @@ class JarikoCallbackTest : AbstractTest() {
         assert(finishCount > 0)
     }
 
+    /**
+     * Test if trace configurations work as expected.
+     */
+    @Test
+    fun traceConfigurationTest() {
+        val targetPgm = "TRACETST1"
+        testTraceConfiguration(targetPgm, listOf(JarikoTraceKind.MainExecutionContext))
+        testTraceConfiguration(targetPgm, listOf(JarikoTraceKind.Parsing))
+        testTraceConfiguration(targetPgm, listOf(JarikoTraceKind.CompositeStatement))
+        testTraceConfiguration(targetPgm, listOf(JarikoTraceKind.RpgProgram))
+        testTraceConfiguration(targetPgm, listOf(JarikoTraceKind.SymbolTable))
+        testTraceConfiguration(targetPgm, listOf(JarikoTraceKind.CallStmt))
+        testTraceConfiguration(targetPgm, listOf(JarikoTraceKind.ExecuteSubroutine))
+        testTraceConfiguration(targetPgm, listOf(JarikoTraceKind.FunctionCall))
+        testTraceConfiguration(targetPgm, listOf())
+
+        // Test default behaviour -> all enabled
+        val traces = mutableListOf<JarikoTrace>()
+
+        val options = Options()
+        val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }
+        val configuration = Configuration(options = options).apply {
+            jarikoCallback.startJarikoTrace = { trace -> traces.add(trace) }
+        }
+        executePgm(targetPgm, configuration = configuration, systemInterface = systemInterface)
+
+        // Kinds are reported at least once
+        JarikoTraceKind.entries.forEach { kind -> assert(traces.any { it.kind == kind }) }
+    }
+
     @Test
     fun traceOpenedAlsoClosedTest() {
         val startTraces = mutableListOf<JarikoTrace>()
@@ -1662,5 +1692,24 @@ class JarikoCallbackTest : AbstractTest() {
     private fun List<RpgTrace>.assertExecutedInSource(sourceId: String, line: Int) {
         val candidate = this.find { it.program == sourceId && it.line == line }
         assertNotNull(candidate, "could not find a trace at line $line executed in $sourceId")
+    }
+
+    /**
+     * Utility method to easily test trace configurations
+     */
+    private fun testTraceConfiguration(program: String, kinds: List<JarikoTraceKind>) {
+        val traces = mutableListOf<JarikoTrace>()
+        var closedCount = 0
+
+        val options = Options(enabledJarikoTraces = kinds)
+        val systemInterface = JavaSystemInterface().apply { onDisplay = { _, _ -> run {} } }
+        val configuration = Configuration(options = options).apply {
+            jarikoCallback.startJarikoTrace = { trace -> traces.add(trace) }
+            jarikoCallback.finishJarikoTrace = { ++closedCount }
+        }
+        executePgm(program, configuration = configuration, systemInterface = systemInterface)
+
+        assertEquals(traces.size, closedCount, "open traces do not match closed traces")
+        assert(traces.all { trace -> kinds.any { kind -> kind == trace.kind } }) { "got unexpected trace kind" }
     }
 }


### PR DESCRIPTION
## Description

> Note: This feature does not add/alter any RPGLE functionality.

Add an option to filter out Jariko traces by kind.

### Technical notes

A new optional array of `JarikoTraceKind`s option called `enabledJarikoTraces` was added in the `Options` class. 
It is intended to be a whitelist of all the enabled `JarikoTraceKind`s.

To ensure compatibility with existing systems, by default, when set to `null`, all traces are considered enabled. Use an empty array to disable them all.

> Note: As this behaviour might be counterintuitive the `enabledJarikoTraces` field is private and is not intended to be directly manipulated in the codebase. Use the safe wrappers `enableAllJarikoTraces()`, `getEnabledJarikoTraces()` and `setEnabledJarikoTraces(kinds: List<JarikoTraceKind>)` instead.

Related to:
- LS25003049

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
