### PR TITLE
Bugfix/LS25002732/`ADD` between two arrays

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
@@ -66,7 +66,6 @@ interface InterpreterCore {
     fun dataDefinitionByName(name: String): AbstractDataDefinition?
     fun mult(statement: MultStmt): Value
     fun div(statement: DivStmt): Value
-    fun sub(statement: SubStmt): Value
     fun rawRender(values: List<Value>): String
     fun optimizedIntExpression(expression: Expression): () -> Long
     fun enterCondition(index: Value, end: Value, downward: Boolean): Boolean

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
@@ -66,7 +66,6 @@ interface InterpreterCore {
     fun dataDefinitionByName(name: String): AbstractDataDefinition?
     fun mult(statement: MultStmt): Value
     fun div(statement: DivStmt): Value
-    fun add(statement: AddStmt): Value
     fun sub(statement: SubStmt): Value
     fun rawRender(values: List<Value>): String
     fun optimizedIntExpression(expression: Expression): () -> Long

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
@@ -64,7 +64,6 @@ interface InterpreterCore {
     fun fillDataFrom(dbFile: EnrichedDBFile, record: Record)
     fun exists(dataName: String): Boolean
     fun dataDefinitionByName(name: String): AbstractDataDefinition?
-    fun div(statement: DivStmt): Value
     fun rawRender(values: List<Value>): String
     fun optimizedIntExpression(expression: Expression): () -> Long
     fun enterCondition(index: Value, end: Value, downward: Boolean): Boolean

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/InterpreterCore.kt
@@ -64,7 +64,6 @@ interface InterpreterCore {
     fun fillDataFrom(dbFile: EnrichedDBFile, record: Record)
     fun exists(dataName: String): Boolean
     fun dataDefinitionByName(name: String): AbstractDataDefinition?
-    fun mult(statement: MultStmt): Value
     fun div(statement: DivStmt): Value
     fun rawRender(values: List<Value>): String
     fun optimizedIntExpression(expression: Expression): () -> Long

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
@@ -117,7 +117,7 @@ private fun makeArrayValue(addendOneValue: NumberValue, addendTwoValue: ArrayVal
         newArrayValue.setElement(
             index + 1,
         makeSingleValue(addendOneValue, newArrayValue.getElement(index + 1), position)
-    )}
+    ) }
 
     return newArrayValue
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
@@ -21,40 +21,34 @@ import com.smeup.rpgparser.parsing.ast.Expression
 import com.strumenta.kolasu.model.Position
 
 /**
- * Performs addition of two numerical expressions. The method evaluates the provided expressions
- * and computes the sum based on their types.
+ * Adds two numerical expressions and returns the resulting value.
  *
- * @param value The first expression to be added. This should evaluate to either a single numerical value
- *              or an array of numerical values.
- * @param target The second expression to be added. This should evaluate to either a single numerical value
- *               or an array of numerical values.
- * @param interpreterCore The interpreter core responsible for evaluating the expressions.
- * @param position The position in the source code where this addition is invoked. Used for error reporting
- *                 and debugging. Nullable.
- * @return The result of the addition as a single numerical value.
- * @throws IllegalArgumentException If either of the evaluated expressions is not a number or an array of numbers.
- * @throws UnsupportedOperationException If the addition operation is not supported for the given evaluated types.
+ * @param addendOneExpression the first expression to be evaluated and added
+ * @param addendTwoExpression the second expression to be evaluated and added
+ * @param interpreterCore the interpreter core used to evaluate the expressions
+ * @param position the position in the code where this operation occurs, can be null
+ * @return the result of the addition as a Value; throws an exception if the addition cannot be performed
  */
 fun add(
-    value: Expression,
-    target: Expression,
+    addendOneExpression: Expression,
+    addendTwoExpression: Expression,
     interpreterCore: InterpreterCore,
     position: Position? = null
 ): Value {
-    val addend1: Value = interpreterCore.eval(value)
-    require(addend1 is NumberValue || (addend1 is ArrayValue && addend1.elementType is NumberType)) {
-        "$addend1 should be a number"
+    val addendOneValue: Value = interpreterCore.eval(addendOneExpression)
+    require(addendOneValue is NumberValue || (addendOneValue is ArrayValue && addendOneValue.elementType is NumberType)) {
+        "$addendOneValue should be a number"
     }
-    val addend2: Value = interpreterCore.eval(target)
-    require(addend2 is NumberValue || (addend2 is ArrayValue && addend2.elementType is NumberType)) {
-        "$addend2 should be a number"
+    val addendTwoValue: Value = interpreterCore.eval(addendTwoExpression)
+    require(addendTwoValue is NumberValue || (addendTwoValue is ArrayValue && addendTwoValue.elementType is NumberType)) {
+        "$addendTwoValue should be a number"
     }
 
     return when {
-        addend1 is IntValue && addend2 is IntValue -> IntValue(addend1.asInt().value.plus(addend2.asInt().value))
-        addend1 is IntValue && addend2 is DecimalValue -> DecimalValue(addend1.asDecimal().value.plus(addend2.value))
-        addend1 is DecimalValue && addend2 is IntValue -> DecimalValue(addend1.value.plus(addend2.asDecimal().value))
-        addend1 is DecimalValue && addend2 is DecimalValue -> DecimalValue(addend1.value.plus(addend2.value))
-        else -> throw UnsupportedOperationException("I do not know how to sum $addend1 and $addend2 at $position")
+        addendOneValue is IntValue && addendTwoValue is IntValue -> IntValue(addendOneValue.asInt().value.plus(addendTwoValue.asInt().value))
+        addendOneValue is IntValue && addendTwoValue is DecimalValue -> DecimalValue(addendOneValue.asDecimal().value.plus(addendTwoValue.value))
+        addendOneValue is DecimalValue && addendTwoValue is IntValue -> DecimalValue(addendOneValue.value.plus(addendTwoValue.asDecimal().value))
+        addendOneValue is DecimalValue && addendTwoValue is DecimalValue -> DecimalValue(addendOneValue.value.plus(addendTwoValue.value))
+        else -> throw UnsupportedOperationException("I do not know how to sum $addendOneValue and $addendTwoValue at $position")
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
@@ -51,7 +51,7 @@ fun add(
     return when {
         addendOneValue is ArrayValue && addendTwoValue is ArrayValue -> makeArrayValue(addendOneValue, addendTwoValue, position)
         addendTwoValue is NumberValue && addendOneValue is ArrayValue -> makeArrayValue(addendTwoValue, addendOneValue, position)
-        else -> makeSingleValue(addendOneValue, addendTwoValue, position)
+        else -> makeStandaloneValue(addendOneValue, addendTwoValue, position)
     }
 }
 
@@ -66,7 +66,7 @@ fun add(
  *         which will be either an `IntValue` or a `DecimalValue` depending on the input types
  * @throws UnsupportedOperationException if the provided `Value` types cannot be summed or are unsupported
  */
-private fun makeSingleValue(addendOneValue: Value, addendTwoValue: Value, position: Position?): Value {
+private fun makeStandaloneValue(addendOneValue: Value, addendTwoValue: Value, position: Position?): Value {
     return when {
         addendOneValue is IntValue && addendTwoValue is IntValue -> IntValue(addendOneValue.asInt().value.plus(addendTwoValue.asInt().value))
         addendOneValue is IntValue && addendTwoValue is DecimalValue -> DecimalValue(addendOneValue.asDecimal().value.plus(addendTwoValue.value))
@@ -93,7 +93,7 @@ private fun makeArrayValue(addendOneValue: ArrayValue, addendTwoValue: ArrayValu
         .forEach { index ->
             newArrayValue.setElement(
                 index,
-                makeSingleValue(addendOneValue.getElement(index), newArrayValue.getElement(index), position)
+                makeStandaloneValue(addendOneValue.getElement(index), newArrayValue.getElement(index), position)
             )
         }
 
@@ -116,7 +116,7 @@ private fun makeArrayValue(addendOneValue: NumberValue, addendTwoValue: ArrayVal
     addendTwoValue.elements().forEachIndexed { index, _ ->
         newArrayValue.setElement(
             index + 1,
-        makeSingleValue(addendOneValue, newArrayValue.getElement(index + 1), position)
+        makeStandaloneValue(addendOneValue, newArrayValue.getElement(index + 1), position)
     ) }
 
     return newArrayValue

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.smeup.rpgparser.interpreter
+
+import com.smeup.rpgparser.parsing.ast.Expression
+import com.strumenta.kolasu.model.Position
+
+/**
+ * Performs addition of two numerical expressions. The method evaluates the provided expressions
+ * and computes the sum based on their types.
+ *
+ * @param value The first expression to be added. This should evaluate to either a single numerical value
+ *              or an array of numerical values.
+ * @param target The second expression to be added. This should evaluate to either a single numerical value
+ *               or an array of numerical values.
+ * @param interpreterCore The interpreter core responsible for evaluating the expressions.
+ * @param position The position in the source code where this addition is invoked. Used for error reporting
+ *                 and debugging. Nullable.
+ * @return The result of the addition as a single numerical value.
+ * @throws IllegalArgumentException If either of the evaluated expressions is not a number or an array of numbers.
+ * @throws UnsupportedOperationException If the addition operation is not supported for the given evaluated types.
+ */
+fun add(
+    value: Expression,
+    target: Expression,
+    interpreterCore: InterpreterCore,
+    position: Position? = null
+): Value {
+    val addend1: Value = interpreterCore.eval(value)
+    require(addend1 is NumberValue || (addend1 is ArrayValue && addend1.elementType is NumberType)) {
+        "$addend1 should be a number"
+    }
+    val addend2: Value = interpreterCore.eval(target)
+    require(addend2 is NumberValue || (addend2 is ArrayValue && addend2.elementType is NumberType)) {
+        "$addend2 should be a number"
+    }
+
+    return when {
+        addend1 is IntValue && addend2 is IntValue -> IntValue(addend1.asInt().value.plus(addend2.asInt().value))
+        addend1 is IntValue && addend2 is DecimalValue -> DecimalValue(addend1.asDecimal().value.plus(addend2.value))
+        addend1 is DecimalValue && addend2 is IntValue -> DecimalValue(addend1.value.plus(addend2.asDecimal().value))
+        addend1 is DecimalValue && addend2 is DecimalValue -> DecimalValue(addend1.value.plus(addend2.value))
+        else -> throw UnsupportedOperationException("I do not know how to sum $addend1 and $addend2 at $position")
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
@@ -23,23 +23,23 @@ import com.strumenta.kolasu.model.Position
 /**
  * Adds two numerical expressions and returns the resulting value.
  *
- * @param addendOneExpression the first expression to be evaluated and added
- * @param addendTwoExpression the second expression to be evaluated and added
+ * @param addendOneExpr the first expression to be evaluated and added
+ * @param addendTwoExpr the second expression to be evaluated and added
  * @param interpreterCore the interpreter core used to evaluate the expressions
  * @param position the position in the code where this operation occurs, can be null
  * @return the result of the addition as a Value; throws an exception if the addition cannot be performed
  */
 fun add(
-    addendOneExpression: Expression,
-    addendTwoExpression: Expression,
+    addendOneExpr: Expression,
+    addendTwoExpr: Expression,
     interpreterCore: InterpreterCore,
     position: Position? = null
 ): Value {
-    val addendOneValue: Value = interpreterCore.eval(addendOneExpression)
+    val addendOneValue: Value = interpreterCore.eval(addendOneExpr)
     require(addendOneValue is NumberValue || (addendOneValue is ArrayValue && addendOneValue.elementType is NumberType)) {
         "$addendOneValue should be a number"
     }
-    val addendTwoValue: Value = interpreterCore.eval(addendTwoExpression)
+    val addendTwoValue: Value = interpreterCore.eval(addendTwoExpr)
     require(addendTwoValue is NumberValue || (addendTwoValue is ArrayValue && addendTwoValue.elementType is NumberType)) {
         "$addendTwoValue should be a number"
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
@@ -44,6 +44,10 @@ fun add(
         "$addendTwoValue should be a number"
     }
 
+    if (addendOneValue is NumberValue && addendTwoValue is ArrayValue) {
+        throw UnsupportedOperationException("Cannot add an Array to a Standalone. At: $position")
+    }
+
     return when {
         addendOneValue is ArrayValue && addendTwoValue is ArrayValue -> makeArrayValue(addendOneValue, addendTwoValue, position)
         addendTwoValue is NumberValue && addendOneValue is ArrayValue -> makeArrayValue(addendTwoValue, addendOneValue, position)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
@@ -45,10 +45,53 @@ fun add(
     }
 
     return when {
+        addendOneValue is ArrayValue && addendTwoValue is ArrayValue -> makeArrayValue(addendOneValue, addendTwoValue, position)
+        addendOneValue is ArrayValue && addendTwoValue is NumberValue -> TODO()
+        else -> makeSingleValue(addendOneValue, addendTwoValue, position)
+    }
+}
+
+/**
+ * Combines the values of two `Value` objects into a single `Value`,
+ * performing addition based on their types.
+ *
+ * @param addendOneValue the first `Value` to be added; must be of type `IntValue` or `DecimalValue`
+ * @param addendTwoValue the second `Value` to be added; must be of type `IntValue` or `DecimalValue`
+ * @param position optional `Position` for contextual information during operation; used in exception message if applicable
+ * @return a newly created `Value` resulting from the addition of `addendOneValue` and `addendTwoValue`,
+ *         which will be either an `IntValue` or a `DecimalValue` depending on the input types
+ * @throws UnsupportedOperationException if the provided `Value` types cannot be summed or are unsupported
+ */
+private fun makeSingleValue(addendOneValue: Value, addendTwoValue: Value, position: Position?): Value {
+    return when {
         addendOneValue is IntValue && addendTwoValue is IntValue -> IntValue(addendOneValue.asInt().value.plus(addendTwoValue.asInt().value))
         addendOneValue is IntValue && addendTwoValue is DecimalValue -> DecimalValue(addendOneValue.asDecimal().value.plus(addendTwoValue.value))
         addendOneValue is DecimalValue && addendTwoValue is IntValue -> DecimalValue(addendOneValue.value.plus(addendTwoValue.asDecimal().value))
         addendOneValue is DecimalValue && addendTwoValue is DecimalValue -> DecimalValue(addendOneValue.value.plus(addendTwoValue.value))
         else -> throw UnsupportedOperationException("I do not know how to sum $addendOneValue and $addendTwoValue at $position")
     }
+}
+
+/**
+ * Creates a new `ArrayValue` by combining the elements of two input `ArrayValue` objects.
+ * The operation is element-wise and applies up to the minimum size of the two arrays.
+ *
+ * @param addendOneValue the first `ArrayValue` instance whose elements will be processed
+ * @param addendTwoValue the second `ArrayValue` instance whose elements will be combined
+ * @param position an optional `Position` object providing context for error reporting
+ * @return a new `ArrayValue` containing the combined elements
+ */
+private fun makeArrayValue(addendOneValue: ArrayValue, addendTwoValue: ArrayValue, position: Position?): ArrayValue {
+    val minSize = minOf(addendOneValue.arrayLength(), addendTwoValue.arrayLength())
+    val newArrayValue = addendTwoValue.copy()
+
+    1.rangeTo(minSize)
+        .forEach { index ->
+            newArrayValue.setElement(
+                index,
+                makeSingleValue(addendOneValue.getElement(index), newArrayValue.getElement(index), position)
+            )
+        }
+
+    return newArrayValue
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
@@ -46,7 +46,7 @@ fun add(
 
     return when {
         addendOneValue is ArrayValue && addendTwoValue is ArrayValue -> makeArrayValue(addendOneValue, addendTwoValue, position)
-        addendOneValue is ArrayValue && addendTwoValue is NumberValue -> TODO()
+        addendTwoValue is NumberValue && addendOneValue is ArrayValue -> makeArrayValue(addendTwoValue, addendOneValue, position)
         else -> makeSingleValue(addendOneValue, addendTwoValue, position)
     }
 }
@@ -92,6 +92,28 @@ private fun makeArrayValue(addendOneValue: ArrayValue, addendTwoValue: ArrayValu
                 makeSingleValue(addendOneValue.getElement(index), newArrayValue.getElement(index), position)
             )
         }
+
+    return newArrayValue
+}
+
+/**
+ * Creates a new `ArrayValue` by applying an additive operation to each element of the provided array
+ * with the given `NumberValue`.
+ *
+ * @param addendOneValue the `NumberValue` to be added to each element of the `ArrayValue`
+ * @param addendTwoValue the `ArrayValue` whose elements will be modified
+ * @param position an optional `Position` used for contextual information during the operation, such as in exception messages
+ * @return an updated `ArrayValue` where each of its elements has been modified by adding `addendOneValue`
+ *         using the `makeSingleValue` operation
+ */
+private fun makeArrayValue(addendOneValue: NumberValue, addendTwoValue: ArrayValue, position: Position?): ArrayValue {
+    val newArrayValue = addendTwoValue.copy()
+
+    addendTwoValue.elements().forEachIndexed { index, _ ->
+        newArrayValue.setElement(
+            index + 1,
+        makeSingleValue(addendOneValue, newArrayValue.getElement(index + 1), position)
+    )}
 
     return newArrayValue
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/div.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/div.kt
@@ -45,7 +45,7 @@ fun div(
     isHalfAdjust: Boolean,
     interpreterCore: InterpreterCore,
     position: Position? = null,
-    mvrTarget: AssignableExpression? = null,
+    mvrTarget: AssignableExpression? = null
 ): Value {
     // TODO When will pass my PR for more robustness replace Value.render with NumericValue.bigDecimal
     val dividend = BigDecimal(interpreterCore.eval(dividendExpr).render())

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/div.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/div.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.smeup.rpgparser.interpreter
+
+import com.smeup.rpgparser.parsing.ast.AssignableExpression
+import com.smeup.rpgparser.parsing.ast.Expression
+import com.strumenta.kolasu.model.Position
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+/**
+ * Divides the value of the dividend expression by the value of the divisor expression and optionally adjusts
+ * the result rounding based on the `isHalfAdjust` flag. If `mvrTarget` is specified, it also calculates the remainder (rest)
+ * and assigns it to the specified target expression.
+ *
+ * @param dividendExpr The expression representing the dividend.
+ * @param divisorExpr The expression representing the divisor.
+ * @param targetType The type to which the result should be cast or scaled.
+ * @param isHalfAdjust A flag indicating whether to use half-up rounding for the result.
+ * @param interpreterCore The core of the interpreter used for evaluating expressions and handling assignments.
+ * @param position The position in the source code associated with this operation, or null if not applicable.
+ * @param mvrTarget An optional assignable expression to store the remainder of the division; null if not required.
+ * @return The result of the division as a scaled and rounded Value, depending on `targetType` and `isHalfAdjust`.
+ */
+fun div(
+    dividendExpr: Expression,
+    divisorExpr: Expression,
+    targetType: Type,
+    isHalfAdjust: Boolean,
+    interpreterCore: InterpreterCore,
+    position: Position? = null,
+    mvrTarget: AssignableExpression? = null,
+): Value {
+    // TODO When will pass my PR for more robustness replace Value.render with NumericValue.bigDecimal
+    val dividend = BigDecimal(interpreterCore.eval(dividendExpr).render())
+    val divisor = BigDecimal(interpreterCore.eval(divisorExpr).render())
+    val quotient = dividend.divide(divisor, MathContext.DECIMAL128)
+
+    require(targetType is NumberType)
+
+    // calculation of rest
+    // NB. rest based on type of quotient
+    if (mvrTarget != null) {
+        val restType = mvrTarget.type()
+        require(restType is NumberType)
+        val truncatedQuotient: BigDecimal = quotient.setScale(targetType.decimalDigits, RoundingMode.DOWN)
+        val rest: BigDecimal = dividend.subtract(truncatedQuotient.multiply(divisor))
+        interpreterCore.assign(
+            mvrTarget,
+            DecimalValue(rest.setScale(restType.decimalDigits, RoundingMode.DOWN))
+        )
+    }
+
+    return if (isHalfAdjust) {
+        DecimalValue(quotient.setScale(targetType.decimalDigits, RoundingMode.HALF_UP))
+    } else {
+        DecimalValue(quotient.setScale(targetType.decimalDigits, RoundingMode.DOWN))
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -1128,24 +1128,6 @@ open class InternalInterpreter(
         }
     }
 
-    override fun add(statement: AddStmt): Value {
-        val addend1 = eval(statement.addend1)
-        require(addend1 is NumberValue) {
-            "$addend1 should be a number"
-        }
-        val addend2 = eval(statement.right)
-        require(addend2 is NumberValue) {
-            "$addend2 should be a number"
-        }
-        return when {
-            addend1 is IntValue && addend2 is IntValue -> IntValue(addend1.asInt().value.plus(addend2.asInt().value))
-            addend1 is IntValue && addend2 is DecimalValue -> DecimalValue(addend1.asDecimal().value.plus(addend2.value))
-            addend1 is DecimalValue && addend2 is IntValue -> DecimalValue(addend1.value.plus(addend2.asDecimal().value))
-            addend1 is DecimalValue && addend2 is DecimalValue -> DecimalValue(addend1.value.plus(addend2.value))
-            else -> throw UnsupportedOperationException("I do not know how to sum $addend1 and $addend2 at ${statement.position}")
-        }
-    }
-
     override fun sub(statement: SubStmt): Value {
         val minuend = eval(statement.minuend)
         require(minuend is NumberValue) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -897,20 +897,6 @@ open class InternalInterpreter(
         return value
     }
 
-    override fun mult(statement: MultStmt): Value {
-        // TODO When will pass my PR for more robustness replace Value.render with NumericValue.bigDecimal
-        val rightValue = BigDecimal(eval(statement.left).render())
-        val leftValue = BigDecimal(eval(statement.right).render())
-        val result = rightValue.multiply(leftValue)
-        val type = statement.target.type()
-        require(type is NumberType)
-        return if (statement.halfAdjust) {
-            DecimalValue(result.setScale(type.decimalDigits, RoundingMode.HALF_UP))
-        } else {
-            DecimalValue(result.setScale(type.decimalDigits, RoundingMode.DOWN))
-        }
-    }
-
     override fun div(statement: DivStmt): Value {
         // TODO When will pass my PR for more robustness replace Value.render with NumericValue.bigDecimal
         val dividend = BigDecimal(eval(statement.dividend).render())

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -35,9 +35,6 @@ import com.smeup.rpgparser.utils.resizeTo
 import com.strumenta.kolasu.model.Position
 import com.strumenta.kolasu.model.ReferenceByName
 import com.strumenta.kolasu.model.ancestor
-import java.math.BigDecimal
-import java.math.MathContext
-import java.math.RoundingMode
 import java.util.*
 import kotlin.math.min
 import kotlin.system.measureNanoTime

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -897,32 +897,6 @@ open class InternalInterpreter(
         return value
     }
 
-    override fun div(statement: DivStmt): Value {
-        // TODO When will pass my PR for more robustness replace Value.render with NumericValue.bigDecimal
-        val dividend = BigDecimal(eval(statement.dividend).render())
-        val divisor = BigDecimal(eval(statement.divisor).render())
-        val quotient = dividend.divide(divisor, MathContext.DECIMAL128)
-        val type = statement.target.type()
-        require(type is NumberType)
-        // calculation of rest
-        // NB. rest based on type of quotient
-        if (statement.mvrStatement != null) {
-            val restType = statement.mvrStatement.target?.type()
-            require(restType is NumberType)
-            val truncatedQuotient: BigDecimal = quotient.setScale(type.decimalDigits, RoundingMode.DOWN)
-            val rest: BigDecimal = dividend.subtract(truncatedQuotient.multiply(divisor))
-            assign(
-                statement.mvrStatement.target,
-                DecimalValue(rest.setScale(restType.decimalDigits, RoundingMode.DOWN))
-            )
-        }
-        return if (statement.halfAdjust) {
-            DecimalValue(quotient.setScale(type.decimalDigits, RoundingMode.HALF_UP))
-        } else {
-            DecimalValue(quotient.setScale(type.decimalDigits, RoundingMode.DOWN))
-        }
-    }
-
     override fun assign(dataDefinition: AbstractDataDefinition, value: Value): Value {
         // if I am working with a record format
         if (dataDefinition.type is RecordFormatType) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/internal_interpreter.kt
@@ -1128,24 +1128,6 @@ open class InternalInterpreter(
         }
     }
 
-    override fun sub(statement: SubStmt): Value {
-        val minuend = eval(statement.minuend)
-        require(minuend is NumberValue) {
-            "$minuend should be a number"
-        }
-        val subtrahend = eval(statement.right)
-        require(subtrahend is NumberValue) {
-            "$subtrahend should be a number"
-        }
-        return when {
-            minuend is IntValue && subtrahend is IntValue -> IntValue(minuend.asInt().value.minus(subtrahend.asInt().value))
-            minuend is IntValue && subtrahend is DecimalValue -> DecimalValue(minuend.asDecimal().value.minus(subtrahend.value))
-            minuend is DecimalValue && subtrahend is IntValue -> DecimalValue(minuend.value.minus(subtrahend.asDecimal().value))
-            minuend is DecimalValue && subtrahend is DecimalValue -> DecimalValue(minuend.value.minus(subtrahend.value))
-            else -> throw UnsupportedOperationException("I do not know how to sum $minuend and $subtrahend at ${statement.position}")
-        }
-    }
-
     private fun blankValue(dataDefinition: DataDefinition, forceElement: Boolean = false): Value {
         if (forceElement) TODO()
         return when (dataDefinition.type) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/mult.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/mult.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.smeup.rpgparser.interpreter
+
+import com.smeup.rpgparser.parsing.ast.Expression
+import com.strumenta.kolasu.model.Position
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * Multiplies the values of two expressions, formats the result according to the specified target type,
+ * and applies optional half adjustment rounding.
+ *
+ * @param leftExpression the left-hand side expression to be evaluated and multiplied.
+ * @param rightExpression the right-hand side expression to be evaluated and multiplied.
+ * @param targetType the numeric type that dictates how the result should be formatted.
+ * @param isHalfAdjust a flag specifying whether to apply half adjustment (rounding mode HALF_UP) or truncate (rounding mode DOWN).
+ * @param interpreterCore the core interpreter used to evaluate the expressions.
+ * @param position an optional position in the source code for logging or error reporting.
+ * @return a Value containing the result of the multiplication formatted according to the specified target type.
+ */
+fun mult(
+    leftExpression: Expression,
+    rightExpression: Expression,
+    targetType: Type,
+    isHalfAdjust: Boolean,
+    interpreterCore: InterpreterCore,
+    position: Position? = null
+): Value {
+    // TODO When will pass my PR for more robustness replace Value.render with NumericValue.bigDecimal
+    val leftValue = BigDecimal(interpreterCore.eval(leftExpression).render())
+    val rightValue = BigDecimal(interpreterCore.eval(rightExpression).render())
+    val result = rightValue.multiply(leftValue)
+
+    require(targetType is NumberType)
+
+    return if (isHalfAdjust) {
+        DecimalValue(result.setScale(targetType.decimalDigits, RoundingMode.HALF_UP))
+    } else {
+        DecimalValue(result.setScale(targetType.decimalDigits, RoundingMode.DOWN))
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/mult.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/mult.kt
@@ -26,8 +26,8 @@ import java.math.RoundingMode
  * Multiplies the values of two expressions, formats the result according to the specified target type,
  * and applies optional half adjustment rounding.
  *
- * @param leftExpression the left-hand side expression to be evaluated and multiplied.
- * @param rightExpression the right-hand side expression to be evaluated and multiplied.
+ * @param leftExpr the left-hand side expression to be evaluated and multiplied.
+ * @param rightExpr the right-hand side expression to be evaluated and multiplied.
  * @param targetType the numeric type that dictates how the result should be formatted.
  * @param isHalfAdjust a flag specifying whether to apply half adjustment (rounding mode HALF_UP) or truncate (rounding mode DOWN).
  * @param interpreterCore the core interpreter used to evaluate the expressions.
@@ -35,16 +35,16 @@ import java.math.RoundingMode
  * @return a Value containing the result of the multiplication formatted according to the specified target type.
  */
 fun mult(
-    leftExpression: Expression,
-    rightExpression: Expression,
+    leftExpr: Expression,
+    rightExpr: Expression,
     targetType: Type,
     isHalfAdjust: Boolean,
     interpreterCore: InterpreterCore,
     position: Position? = null
 ): Value {
     // TODO When will pass my PR for more robustness replace Value.render with NumericValue.bigDecimal
-    val leftValue = BigDecimal(interpreterCore.eval(leftExpression).render())
-    val rightValue = BigDecimal(interpreterCore.eval(rightExpression).render())
+    val leftValue = BigDecimal(interpreterCore.eval(leftExpr).render())
+    val rightValue = BigDecimal(interpreterCore.eval(rightExpr).render())
     val result = rightValue.multiply(leftValue)
 
     require(targetType is NumberType)

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sub.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/sub.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Sme.UP S.p.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.smeup.rpgparser.interpreter
+
+import com.smeup.rpgparser.parsing.ast.Expression
+import com.strumenta.kolasu.model.Position
+
+/**
+ * Subtracts the evaluated `subtrahendExpr` from the evaluated `minuendExpr`.
+ * The method supports operations between integer and decimal values.
+ *
+ * @param minuendExpr The expression representing the minuend.
+ * @param subtrahendExpr The expression representing the subtrahend.
+ * @param interpreterCore The interpreter core used to evaluate the expressions.
+ * @param position Optional positional information for error reporting.
+ * @return The result of the subtraction operation as a `Value`.
+ * @throws IllegalArgumentException If either the evaluated `minuendExpr` or `subtrahendExpr` is not a number.
+ * @throws UnsupportedOperationException If the operation cannot be performed on the provided values.
+ */
+fun sub(
+    minuendExpr: Expression,
+    subtrahendExpr: Expression,
+    interpreterCore: InterpreterCore,
+    position: Position? = null
+): Value {
+    val minuendValue = interpreterCore.eval(minuendExpr)
+    require(minuendValue is NumberValue) {
+        "$minuendValue should be a number"
+    }
+    val subtrahendValue = interpreterCore.eval(subtrahendExpr)
+    require(subtrahendValue is NumberValue) {
+        "$subtrahendValue should be a number"
+    }
+
+    return when {
+        minuendValue is IntValue && subtrahendValue is IntValue -> IntValue(minuendValue.asInt().value.minus(subtrahendValue.asInt().value))
+        minuendValue is IntValue && subtrahendValue is DecimalValue -> DecimalValue(minuendValue.asDecimal().value.minus(subtrahendValue.value))
+        minuendValue is DecimalValue && subtrahendValue is IntValue -> DecimalValue(minuendValue.value.minus(subtrahendValue.asDecimal().value))
+        minuendValue is DecimalValue && subtrahendValue is DecimalValue -> DecimalValue(minuendValue.value.minus(subtrahendValue.value))
+        else -> throw UnsupportedOperationException("I do not know how to sum $minuendValue and $subtrahendValue at $position")
+    }
+}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1878,7 +1878,7 @@ data class DivStmt(
         get() = factor2
 
     override fun execute(interpreter: InterpreterCore) {
-        interpreter.assign(target, interpreter.div(this))
+        interpreter.assign(target, div(dividend, divisor, target.type(), halfAdjust, interpreter, position, mvrStatement?.target))
     }
 
     override fun dataDefinition() = dataDefinition?.let { listOf(it) } ?: emptyList()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1850,7 +1850,7 @@ data class MultStmt(
         get() = factor2
 
     override fun execute(interpreter: InterpreterCore) {
-        interpreter.assign(target, interpreter.mult(this))
+        interpreter.assign(target, mult(left, right, target.type(), halfAdjust, interpreter, position))
     }
 
     override fun dataDefinition() = dataDefinition?.let { listOf(it) } ?: emptyList()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1924,7 +1924,7 @@ data class AddStmt(
         get() = left ?: result
 
     override fun execute(interpreter: InterpreterCore) {
-        interpreter.assign(result, interpreter.add(this))
+        interpreter.assign(result, add(this.addend1, this.right, interpreter, position))
     }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1977,7 +1977,7 @@ data class SubStmt(
         get() = left ?: result
 
     override fun execute(interpreter: InterpreterCore) {
-        interpreter.assign(result, interpreter.sub(this))
+        interpreter.assign(result, sub(minuend, right, interpreter, position))
     }
 }
 

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/JarikoCallbackTest.kt
@@ -1498,6 +1498,18 @@ class JarikoCallbackTest : AbstractTest() {
     }
 
     @Test
+    fun executeERROR57CallBackTest() {
+        executePgmCallBackTest("ERROR57", SourceReferenceType.Program, "ERROR57", mapOf(
+            14 to "Cannot add an Array to a Standalone at: Position(start=Line 14, Column 35, end=Line 14, Column 41))"
+        ))
+    }
+
+    @Test
+    fun executeERROR57SourceLineTest() {
+        executeSourceLineTest("ERROR57")
+    }
+
+    @Test
     fun bypassSyntaxErrorTest() {
         val configuration = Configuration().apply {
             options = Options().apply {

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1103,4 +1103,18 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         )
         assertEquals(expected, "smeup/MUDRNRAPU001128".outputOf())
     }
+
+    /**
+     * This program executes `ADD` operator between two Standalone arrays with same size.
+     * @see #LS25002732
+     */
+    @Test
+    fun executeMUDRNRAPU001140() {
+        val expected = listOf(
+            "ARR1 ITEMS", "1.00", "2.00", "3.00",
+            "ARR2 ITEMS", "2.00", "2.00", "2.00",
+            "ARR2 ITEMS", "3.00", "4.00", "5.00"
+        )
+        assertEquals(expected, "smeup/MUDRNRAPU001140".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1117,4 +1117,18 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         )
         assertEquals(expected, "smeup/MUDRNRAPU001140".outputOf())
     }
+
+    /**
+     * This program executes `ADD` operator between two Standalone arrays with the size of the left greater than right.
+     * @see #LS25002732
+     */
+    @Test
+    fun executeMUDRNRAPU001141() {
+        val expected = listOf(
+            "ARR1 ITEMS", "1.00", "2.00", "3.00",
+            "ARR2 ITEMS", "2.00", "2.00",
+            "ARR2 ITEMS", "3.00", "4.00"
+        )
+        assertEquals(expected, "smeup/MUDRNRAPU001141".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1145,4 +1145,17 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         )
         assertEquals(expected, "smeup/MUDRNRAPU001142".outputOf())
     }
+
+    /**
+     * This program executes `ADD` operator between a single value to an array.
+     * @see #LS25002732
+     */
+    @Test
+    fun executeMUDRNRAPU001143() {
+        val expected = listOf(
+            "ARR ITEMS", "2.00", "2.00", "2.00",
+            "ARR ITEMS", "7.00", "7.00", "7.00",
+        )
+        assertEquals(expected, "smeup/MUDRNRAPU001143".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1158,4 +1158,18 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         )
         assertEquals(expected, "smeup/MUDRNRAPU001143".outputOf())
     }
+
+    /**
+     * This program executes `ADD` operator between two Standalone arrays with same size but different type. The first is
+     *  decimal and the second is integer.
+     * @see #LS25002732
+     */
+    @Test
+    fun executeMUDRNRAPU001144() {
+        val expected = listOf(
+            "ARR2 ITEMS", "2", "2",
+            "ARR2 ITEMS", "3", "3"
+        )
+        assertEquals(expected, "smeup/MUDRNRAPU001144".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1131,4 +1131,18 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         )
         assertEquals(expected, "smeup/MUDRNRAPU001141".outputOf())
     }
+
+    /**
+     * This program executes `ADD` operator between two Standalone arrays with the size of the right greater than left.
+     * @see #LS25002732
+     */
+    @Test
+    fun executeMUDRNRAPU001142() {
+        val expected = listOf(
+            "ARR1 ITEMS", "1.00", "2.00",
+            "ARR2 ITEMS", "2.00", "2.00", "2.00",
+            "ARR2 ITEMS", "3.00", "4.00", "2.00"
+        )
+        assertEquals(expected, "smeup/MUDRNRAPU001142".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1154,7 +1154,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
     fun executeMUDRNRAPU001143() {
         val expected = listOf(
             "ARR ITEMS", "2.00", "2.00", "2.00",
-            "ARR ITEMS", "7.00", "7.00", "7.00",
+            "ARR ITEMS", "7.00", "7.00", "7.00"
         )
         assertEquals(expected, "smeup/MUDRNRAPU001143".outputOf())
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1172,4 +1172,18 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         )
         assertEquals(expected, "smeup/MUDRNRAPU001144".outputOf())
     }
+
+    /**
+     * This program executes `ADD` operator between two Standalone arrays with same size but different type. The first is
+     *  integer and the second is decimal.
+     * @see #LS25002732
+     */
+    @Test
+    fun executeMUDRNRAPU001145() {
+        val expected = listOf(
+            "ARR2 ITEMS", "2.50", "2.50",
+            "ARR2 ITEMS", "3.50", "3.50"
+        )
+        assertEquals(expected, "smeup/MUDRNRAPU001145".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/ERROR57.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/ERROR57.rpgle
@@ -1,0 +1,21 @@
+     V* ==============================================================
+     V* 14/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program executes `ADD` operator from an array to a
+    O *  standalone the procedure `PR2` which calls `PR1`.
+    O * In this case the program mustn't compile.
+     V* ==============================================================
+     DVAL              S              5  2 INZ(5)
+     DARR              S              5  2 DIM(3) INZ(2)
+     DMSG              S              5
+
+     C                   EXSR      SHOW_RES
+     C                   ADD       ARR           VAL
+     C                   EXSR      SHOW_RES
+     C                   SETON                                          LR
+
+     C     SHOW_RES      BEGSR
+     C                   EVAL      MSG=%CHAR(VAL)
+     C     MSG           DSPLY
+     C                   ENDSR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001140.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001140.rpgle
@@ -1,0 +1,45 @@
+     V* ==============================================================
+     V* 14/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program executes `ADD` operator between two Standalone
+    O *  arrays with same size.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *   `Program MUDRNRAPU001140 - Issue executing AddStmt at
+    O *    line 29. ConcreteArrayValue(elements=[...],
+    O *    elementType=NumberType(entireDigits=3, decimalDigits=2,
+    O *    rpgType=)) should be a number
+     V* ==============================================================
+     DARR1             S              5  2 DIM(3) INZ(1)
+     DARR2             S              5  2 DIM(3) INZ(2)
+     DSHOW_RES         PR
+     D                                5  2 DIM(3)
+
+     C                   CLEAR                   INDEX             1 0
+     C                   FOR       INDEX=1 TO 3
+     C                   EVAL      ARR1(INDEX)=ARR1(INDEX)
+     C                                          * INDEX
+     C                   ENDFOR
+     C     'ARR1 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES(ARR1)
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES(ARR2)
+     C                   ADD       ARR1          ARR2
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES(ARR2)
+     C                   SETON                                          LR
+
+     PSHOW_RES         B
+     DSHOW_RES         PI
+     DARRAY                           5  2 DIM(3)
+     DINDEX            S              1  0
+     DMSG              S              5
+      *
+     C                   FOR       INDEX=1 TO 3
+     C                   EVAL      MSG=%CHAR(ARRAY(INDEX))
+     C     MSG           DSPLY
+     C                   ENDFOR
+      *
+     PSHOW_RES         E

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001141.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001141.rpgle
@@ -1,0 +1,53 @@
+     V* ==============================================================
+     V* 14/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program executes `ADD` operator between two Standalone
+    O *  arrays with the size of the left greater than right.
+     V* ==============================================================
+     DARR1             S              5  2 DIM(3) INZ(1)
+     DARR2             S              5  2 DIM(2) INZ(2)
+     DSHOW_RES2        PR
+     D                                5  2 DIM(2)
+     DSHOW_RES3        PR
+     D                                5  2 DIM(3)
+
+     C                   CLEAR                   INDEX             1 0
+     C                   FOR       INDEX=1 TO 3
+     C                   EVAL      ARR1(INDEX)=ARR1(INDEX)
+     C                                          * INDEX
+     C                   ENDFOR
+     C     'ARR1 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES3(ARR1)
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES2(ARR2)
+     C                   ADD       ARR1          ARR2
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES2(ARR2)
+     C                   SETON                                          LR
+
+     PSHOW_RES2        B
+     DSHOW_RES2        PI
+     DARRAY                           5  2 DIM(2)
+     DINDEX            S              1  0
+     DMSG              S              5
+      *
+     C                   FOR       INDEX=1 TO 2
+     C                   EVAL      MSG=%CHAR(ARRAY(INDEX))
+     C     MSG           DSPLY
+     C                   ENDFOR
+      *
+     PSHOW_RES2        E
+
+     PSHOW_RES3        B
+     DSHOW_RES3        PI
+     DARRAY                           5  2 DIM(3)
+     DINDEX            S              1  0
+     DMSG              S              5
+      *
+     C                   FOR       INDEX=1 TO 3
+     C                   EVAL      MSG=%CHAR(ARRAY(INDEX))
+     C     MSG           DSPLY
+     C                   ENDFOR
+      *
+     PSHOW_RES3        E

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001142.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001142.rpgle
@@ -1,0 +1,53 @@
+     V* ==============================================================
+     V* 14/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program executes `ADD` operator between two Standalone
+    O *  arrays with the size of the right greater than left.
+     V* ==============================================================
+     DARR1             S              5  2 DIM(2) INZ(1)
+     DARR2             S              5  2 DIM(3) INZ(2)
+     DSHOW_RES2        PR
+     D                                5  2 DIM(2)
+     DSHOW_RES3        PR
+     D                                5  2 DIM(3)
+
+     C                   CLEAR                   INDEX             1 0
+     C                   FOR       INDEX=1 TO 2
+     C                   EVAL      ARR1(INDEX)=ARR1(INDEX)
+     C                                          * INDEX
+     C                   ENDFOR
+     C     'ARR1 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES2(ARR1)
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES3(ARR2)
+     C                   ADD       ARR1          ARR2
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES3(ARR2)
+     C                   SETON                                          LR
+
+     PSHOW_RES2        B
+     DSHOW_RES2        PI
+     DARRAY                           5  2 DIM(2)
+     DINDEX            S              1  0
+     DMSG              S              5
+      *
+     C                   FOR       INDEX=1 TO 2
+     C                   EVAL      MSG=%CHAR(ARRAY(INDEX))
+     C     MSG           DSPLY
+     C                   ENDFOR
+      *
+     PSHOW_RES2        E
+
+     PSHOW_RES3        B
+     DSHOW_RES3        PI
+     DARRAY                           5  2 DIM(3)
+     DINDEX            S              1  0
+     DMSG              S              5
+      *
+     C                   FOR       INDEX=1 TO 3
+     C                   EVAL      MSG=%CHAR(ARRAY(INDEX))
+     C     MSG           DSPLY
+     C                   ENDFOR
+      *
+     PSHOW_RES3        E

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001143.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001143.rpgle
@@ -1,0 +1,31 @@
+     V* ==============================================================
+     V* 14/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program executes `ADD` operator between a single value
+    O *  to an array.
+     V* ==============================================================
+     DVAL              S              5  2 INZ(5)
+     DARR              S              5  2 DIM(3) INZ(2)
+     DSHOW_RES         PR
+     D                                5  2 DIM(3)
+
+     C     'ARR ITEMS'   DSPLY
+     C                   CALLP     SHOW_RES(ARR)
+     C                   ADD       VAL           ARR
+     C     'ARR ITEMS'   DSPLY
+     C                   CALLP     SHOW_RES(ARR)
+     C                   SETON                                          LR
+
+     PSHOW_RES         B
+     DSHOW_RES         PI
+     DARRAY                           5  2 DIM(3)
+     DINDEX            S              1  0
+     DMSG              S              5
+      *
+     C                   FOR       INDEX=1 TO 3
+     C                   EVAL      MSG=%CHAR(ARRAY(INDEX))
+     C     MSG           DSPLY
+     C                   ENDFOR
+      *
+     PSHOW_RES         E

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001144.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001144.rpgle
@@ -1,0 +1,32 @@
+     V* ==============================================================
+     V* 15/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program executes `ADD` operator between two Standalone
+    O *  arrays with same size but different type. The first is
+    O *  decimal and the second is integer.
+     V* ==============================================================
+     DARR1             S              5  2 DIM(2) INZ(1.2)
+     DARR2             S              5  0 DIM(2) INZ(2)
+     DSHOW_RES         PR
+     D                                5  0 DIM(2)
+
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES(ARR2)
+     C                   ADD       ARR1          ARR2
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES(ARR2)
+     C                   SETON                                          LR
+
+     PSHOW_RES         B
+     DSHOW_RES         PI
+     DARRAY                           5  0 DIM(2)
+     DINDEX            S              1  0
+     DMSG              S              5
+      *
+     C                   FOR       INDEX=1 TO 2
+     C                   EVAL      MSG=%CHAR(ARRAY(INDEX))
+     C     MSG           DSPLY
+     C                   ENDFOR
+      *
+     PSHOW_RES         E

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001145.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001145.rpgle
@@ -1,0 +1,32 @@
+     V* ==============================================================
+     V* 15/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program executes `ADD` operator between two Standalone
+    O *  arrays with same size but different type. The first is
+    O *  integer and the second is decimal.
+     V* ==============================================================
+     DARR1             S              5  0 DIM(2) INZ(1)
+     DARR2             S              5  2 DIM(2) INZ(2.5)
+     DSHOW_RES         PR
+     D                                5  2 DIM(2)
+
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES(ARR2)
+     C                   ADD       ARR1          ARR2
+     C     'ARR2 ITEMS'  DSPLY
+     C                   CALLP     SHOW_RES(ARR2)
+     C                   SETON                                          LR
+
+     PSHOW_RES         B
+     DSHOW_RES         PI
+     DARRAY                           5  2 DIM(2)
+     DINDEX            S              1  0
+     DMSG              S              5
+      *
+     C                   FOR       INDEX=1 TO 2
+     C                   EVAL      MSG=%CHAR(ARRAY(INDEX))
+     C     MSG           DSPLY
+     C                   ENDFOR
+      *
+     PSHOW_RES         E


### PR DESCRIPTION
## Description
This work improves Jariko by adding the ability to perform `ADD` operator between two arrays, like this snippet:
```
     DARR1             S              5  2 DIM(3) INZ(1)
     DARR2             S              5  2 DIM(3) INZ(2)
     ...
     C                   ADD       ARR1          ARR2
```

### Technical notes
On Jariko this logic wasn't implemented. So, `AddStmt` has been improved:
1. by moving the `add` logic from `InternalInterpreter` into a specific file named `add.kt`. Note: this operation has been done for `sub`, `mult` and `div` too;
2. by implementing the array logic in `add.kt`.

Related to #LS25002732

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
