### PR TITLE
Bugfix/LS25002737/Comparison between decimal and `*ZEROS`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -463,6 +463,12 @@ data class DecimalValue(@Contextual val value: BigDecimal) : NumberValue() {
             else -> super.compareTo(other)
         }
 
+    override fun equals(other: Any?): Boolean =
+        when (other) {
+            is ZeroValue -> this.value == getZero()
+            else -> super.equals(other)
+        }
+
     override fun asString(): StringValue {
         return StringValue(value.toPlainString())
     }
@@ -943,6 +949,12 @@ object ZeroValue : Value {
         when (other) {
             is DecimalValue -> other.getZero().compareTo(other.asDecimal().value)
             else -> super.compareTo(other)
+        }
+
+    override fun equals(other: Any?): Boolean =
+        when (other) {
+            is DecimalValue -> other.getZero() == other.asDecimal().value
+            else -> super.equals(other)
         }
 }
 

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -465,6 +465,7 @@ data class DecimalValue(@Contextual val value: BigDecimal) : NumberValue() {
 
     override fun equals(other: Any?): Boolean =
         when (other) {
+            is DecimalValue -> this.value == other.value
             is ZeroValue -> this.value == getZero()
             else -> super.equals(other)
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -459,6 +459,7 @@ data class DecimalValue(@Contextual val value: BigDecimal) : NumberValue() {
         when (other) {
             is IntValue -> compareTo(other.asDecimal())
             is DecimalValue -> this.value.compareTo(other.value)
+            is ZeroValue -> this.value.compareTo(0.toBigDecimal())
             else -> super.compareTo(other)
         }
 
@@ -928,6 +929,12 @@ object ZeroValue : Value {
 
     // FIXME: Check if it also applies to booleans and if that is the case uncomment line below
     // override fun asBoolean() = BooleanValue.FALSE
+
+    override operator fun compareTo(other: Value): Int =
+        when (other) {
+            is DecimalValue -> DecimalValue.ZERO.compareTo(other.asDecimal())
+            else -> super.compareTo(other)
+        }
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -474,7 +474,7 @@ data class DecimalValue(@Contextual val value: BigDecimal) : NumberValue() {
      * @return A BigDecimal object representing zero with the scale derived
      *         from the "value" field of the DecimalValue instance.
      */
-    private fun getZero(): BigDecimal = "0.".plus("0".repeat(this.value.scale())).toBigDecimal()
+    fun getZero(): BigDecimal = "0.".plus("0".repeat(this.value.scale())).toBigDecimal()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -941,7 +941,7 @@ object ZeroValue : Value {
 
     override operator fun compareTo(other: Value): Int =
         when (other) {
-            is DecimalValue -> DecimalValue.ZERO.compareTo(other.asDecimal())
+            is DecimalValue -> other.getZero().compareTo(other.asDecimal().value)
             else -> super.compareTo(other)
         }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -459,13 +459,22 @@ data class DecimalValue(@Contextual val value: BigDecimal) : NumberValue() {
         when (other) {
             is IntValue -> compareTo(other.asDecimal())
             is DecimalValue -> this.value.compareTo(other.value)
-            is ZeroValue -> this.value.compareTo(0.toBigDecimal())
+            is ZeroValue -> this.value.compareTo(getZero())
             else -> super.compareTo(other)
         }
 
     override fun asString(): StringValue {
         return StringValue(value.toPlainString())
     }
+
+    /**
+     * Generates a BigDecimal representation of zero with the same scale
+     * as the current DecimalValue instance.
+     *
+     * @return A BigDecimal object representing zero with the scale derived
+     *         from the "value" field of the DecimalValue instance.
+     */
+    private fun getZero(): BigDecimal = "0.".plus("0".repeat(this.value.scale())).toBigDecimal()
 }
 
 @Serializable

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -948,12 +948,14 @@ object ZeroValue : Value {
 
     override operator fun compareTo(other: Value): Int =
         when (other) {
+            is ZeroValue -> 0
             is DecimalValue -> other.getZero().compareTo(other.asDecimal().value)
             else -> super.compareTo(other)
         }
 
     override fun equals(other: Any?): Boolean =
         when (other) {
+            is ZeroValue -> true
             is DecimalValue -> other.getZero() == other.asDecimal().value
             else -> super.equals(other)
         }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1216,4 +1216,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("EQ VAL", "EQ ZERO")
         assertEquals(expected, "smeup/MUDRNRAPU001148".outputOf())
     }
+
+    /**
+     * This program shows the message on a true case of `IFNE` when a decimal value is compared to `*ZEROS`.
+     * @see #LS25002737
+     */
+    @Test
+    fun executeMUDRNRAPU001149() {
+        val expected = listOf("NE VAL", "NE ZERO")
+        assertEquals(expected, "smeup/MUDRNRAPU001149".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1226,4 +1226,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("NE VAL", "NE ZERO")
         assertEquals(expected, "smeup/MUDRNRAPU001149".outputOf())
     }
+
+    /**
+     * This program shows the message on a true case of `IFGE` when a decimal value is compared to `*ZEROS`.
+     * @see #LS25002737
+     */
+    @Test
+    fun executeMUDRNRAPU001150() {
+        val expected = listOf("GE VAL", "GE ZERO")
+        assertEquals(expected, "smeup/MUDRNRAPU001150".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1196,4 +1196,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("GT VAL", "GT ZERO")
         assertEquals(expected, "smeup/MUDRNRAPU001146".outputOf())
     }
+
+    /**
+     * This program shows the message on a true case of `IFLT` when a decimal value is compared to `*ZEROS`.
+     * @see #LS25002737
+     */
+    @Test
+    fun executeMUDRNRAPU001147() {
+        val expected = listOf("LT VAL", "LT ZERO")
+        assertEquals(expected, "smeup/MUDRNRAPU001147".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1236,4 +1236,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("GE VAL", "GE ZERO")
         assertEquals(expected, "smeup/MUDRNRAPU001150".outputOf())
     }
+
+    /**
+     * This program shows the message on a true case of `IFLE` when a decimal value is compared to `*ZEROS`.
+     * @see #LS25002737
+     */
+    @Test
+    fun executeMUDRNRAPU001151() {
+        val expected = listOf("LE VAL", "LE ZERO")
+        assertEquals(expected, "smeup/MUDRNRAPU001151".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1192,7 +1192,7 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
      * @see #LS25002737
      */
     @Test
-    fun executeMUDRNRAPU001165() {
+    fun executeMUDRNRAPU001146() {
         val expected = listOf("GT VAL", "GT ZERO")
         assertEquals(expected, "smeup/MUDRNRAPU001146".outputOf())
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1206,4 +1206,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("LT VAL", "LT ZERO")
         assertEquals(expected, "smeup/MUDRNRAPU001147".outputOf())
     }
+
+    /**
+     * This program shows the message on a true case of `IFEQ` when a decimal value is compared to `*ZEROS`.
+     * @see #LS25002737
+     */
+    @Test
+    fun executeMUDRNRAPU001148() {
+        val expected = listOf("EQ VAL", "EQ ZERO")
+        assertEquals(expected, "smeup/MUDRNRAPU001148".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1186,4 +1186,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         )
         assertEquals(expected, "smeup/MUDRNRAPU001145".outputOf())
     }
+
+    /**
+     * This program shows the message on a true case of `IFGT` when a decimal value is compared to `*ZEROS`.
+     * @see #LS25002737
+     */
+    @Test
+    fun executeMUDRNRAPU001165() {
+        val expected = listOf("GT VAL", "GT ZERO")
+        assertEquals(expected, "smeup/MUDRNRAPU001146".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001146.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001146.rpgle
@@ -7,9 +7,12 @@
      V* ==============================================================
     O * JARIKO ANOMALY
     O * Before the fix, the error occurred was:
-    O *  Program CMPZERO1 - Issue executing IfStmt at line 16.
-    O *   An operation is not implemented: Cannot compare
+    O *  Program MUDRNRAPU001146 - Issue executing IfStmt at line 19.
+    O *  An operation is not implemented: Cannot compare
     O *   DecimalValue(value=1.0) to ZeroValue
+    O *  Program MUDRNRAPU001146 - Issue executing IfStmt at line 23.
+    O *  An operation is not implemented: Cannot compare ZeroValue to
+    O *   DecimalValue(value=-1.0)
      V* ==============================================================
      D VAL             S              2  1 INZ(1.0)
 

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001146.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001146.rpgle
@@ -1,0 +1,25 @@
+     V* ==============================================================
+     V* 16/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program shows the message on a true case of `IFGT` when
+    O *  a decimal value is compared to `*ZEROS`.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *  Program CMPZERO1 - Issue executing IfStmt at line 16.
+    O *   An operation is not implemented: Cannot compare
+    O *   DecimalValue(value=1.0) to ZeroValue
+     V* ==============================================================
+     D VAL             S              2  1 INZ(1.0)
+
+     C     VAL           IFGT      *ZEROS
+     C     'GT VAL'      DSPLY
+     C                   ENDIF
+
+     C                   EVAL      VAL=-1.0
+     C     *ZEROS        IFGT      VAL
+     C     'GT ZERO'     DSPLY
+     C                   ENDIF
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001147.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001147.rpgle
@@ -1,0 +1,19 @@
+     V* ==============================================================
+     V* 16/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program shows the message on a true case of `IFLT` when
+    O *  a decimal value is compared to `*ZEROS`.
+     V* ==============================================================
+     D VAL             S              2  1 INZ(-1.0)
+
+     C     VAL           IFLT      *ZEROS
+     C     'LT VAL'      DSPLY
+     C                   ENDIF
+
+     C                   EVAL      VAL=1.0
+     C     *ZEROS        IFLT      VAL
+     C     'LT ZERO'     DSPLY
+     C                   ENDIF
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001148.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001148.rpgle
@@ -5,7 +5,7 @@
     O * This program shows the message on a true case of `IFEQ` when
     O *  a decimal value is compared to `*ZEROS`.
      V* ==============================================================
-     D VAL             S              3  1 INZ(0.0)
+     D VAL             S              3  2 INZ(0.00)
 
      C     VAL           IFEQ      *ZEROS
      C     'EQ VAL'      DSPLY

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001148.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001148.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 16/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program shows the message on a true case of `IFEQ` when
+    O *  a decimal value is compared to `*ZEROS`.
+     V* ==============================================================
+     D VAL             S              3  1 INZ(0.0)
+
+     C     VAL           IFEQ      *ZEROS
+     C     'EQ VAL'      DSPLY
+     C                   ENDIF
+
+     C     *ZEROS        IFEQ      VAL
+     C     'EQ ZERO'     DSPLY
+     C                   ENDIF
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001149.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001149.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 16/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program shows the message on a true case of `IFNE  when
+    O *  a decimal value is compared to `*ZEROS`.
+     V* ==============================================================
+     D VAL             S              2  1 INZ(1.0)
+
+     C     VAL           IFNE      *ZEROS
+     C     'NE VAL'      DSPLY
+     C                   ENDIF
+
+     C     *ZEROS        IFNE      VAL
+     C     'NE ZERO'     DSPLY
+     C                   ENDIF
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001150.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001150.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 16/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program shows the message on a true case of `IFGE  when
+    O *  a decimal value is compared to `*ZEROS`.
+     V* ==============================================================
+     D VAL             S              3  2 INZ(0.00)
+
+     C     VAL           IFGE      *ZEROS
+     C     'GE VAL'      DSPLY
+     C                   ENDIF
+
+     C     *ZEROS        IFGE      VAL
+     C     'GE ZERO'     DSPLY
+     C                   ENDIF
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001151.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001151.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 16/07/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program shows the message on a true case of `IFLE  when
+    O *  a decimal value is compared to `*ZEROS`.
+     V* ==============================================================
+     D VAL             S              3  2 INZ(0.00)
+
+     C     VAL           IFLE      *ZEROS
+     C     'LE VAL'      DSPLY
+     C                   ENDIF
+
+     C     *ZEROS        IFLE      VAL
+     C     'LE ZERO'     DSPLY
+     C                   ENDIF
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work improves Jariko by adding the ability to use `IFxx` when one of the two factor has `*ZEROS` keyword, like this snippet:
```
     D VAL             S              2  1 INZ(1.0)

     C     VAL           IFGT      *ZEROS
     ...
     C                   ENDIF
```

### Technical notes
`DecimalValue` and `ZeroValue` have been improved by adding the missed logic of comparison. The logic has been extended to all compare operations of  `IFxx`.

Related to #LS25002737

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
