### PR TITLE
Bugfix/ls25003335/cu idempotence

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/facade/copy.kt
@@ -192,7 +192,6 @@ data class CopyBlock(val copyId: CopyId, val start: Int, var end: Int) {
  * */
 @Serializable
 class CopyBlocks : Iterable<CopyBlock> {
-
     private val copyBlocks = mutableListOf<CopyBlock>()
 
     private val revertOrderedCopyBlocks = mutableListOf<CopyBlock>()
@@ -314,4 +313,17 @@ class CopyBlocks : Iterable<CopyBlock> {
     private fun getChildren(copyBlock: CopyBlock) = copyBlocks.filter { it.parent == copyBlock }
 
     private fun getCopyBlocksBefore(line: Int) = firstLevelBlocks.filter { copyBlock -> copyBlock.end <= line }
+
+    override fun equals(other: Any?): Boolean {
+        if (other === this) return true
+        if (other !is CopyBlocks) return false
+        return this.hashCode() == other.hashCode()
+    }
+
+    override fun hashCode(): Int {
+        var result = copyBlocks.hashCode()
+        result = 31 * result + revertOrderedCopyBlocks.hashCode()
+        result = 31 * result + blocksStack.hashCode()
+        return result
+    }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/rpgcompiler.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/utils/rpgcompiler.kt
@@ -105,10 +105,10 @@ private fun compileFile(
                 // I cannot resolve and validate the cu before serializing elsewhere
                 // I have unexpected behaviours when I try to use it
                 runCatching {
-                    cu!!.resolveAndValidate()
-                }.onFailure {
+                    cu.resolveAndValidate()
+                }.onFailure { error ->
                     compiledFile.delete()
-                    return CompilationResult(file, null, null, it)
+                    return CompilationResult(file, null, null, error)
                 }
                 println("Compiled in $compiledFile")
             }
@@ -258,8 +258,7 @@ fun doCompilationAtRuntime(
         "This method can be used just for runtime compilations"
     }
     println("Compiling inputstream to outputstream... ")
-    val cu: CompilationUnit?
-    cu = RpgParserFacade().apply {
+    val cu = RpgParserFacade().apply {
         this.muteSupport = muteSupport!!
     }.parseAndProduceAst(src)
     out?.let { stream ->

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -36,7 +36,6 @@ import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.*
-import kotlin.io.path.Path
 import kotlin.test.*
 
 open class InterpreterTest : AbstractTest() {


### PR DESCRIPTION
## Description

> Note: This PR does not add/alter any RPGLE functionality.

Add test to check for `CompilationUnit` idempotence.

Also includes some tweaks in the logic:
- Refactored `allDataDefinitions` property in order to ensure its immutability
- Added overrides for `equals` and `hashCode` for `CopyBlocks` in order to properly check `CompilationUnit`s equality
- Cleaned up some warnings

Related to:
- LS25003335

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
