### PR TITLE
Bugfix/jvm target version

### DIFF
--- a/dspfparser/build.gradle
+++ b/dspfparser/build.gradle
@@ -6,7 +6,6 @@ buildscript {
             name 'JFrog OSS snapshot repo'
             url  'https://oss.jfrog.org/oss-snapshot-local/'
         }
-        jcenter()
     }
 
     dependencies {
@@ -37,6 +36,22 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion"
 
+}
+
+compileTestKotlin {
+    sourceCompatibility = "$jvmVersion"
+    targetCompatibility = "$jvmVersion"
+}
+
+compileKotlin {
+    sourceCompatibility = "$jvmVersion"
+    targetCompatibility = "$jvmVersion"
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("$jvmVersion"))
+    }
 }
 
 task version {

--- a/dspfparser/build.gradle
+++ b/dspfparser/build.gradle
@@ -23,7 +23,6 @@ apply plugin: 'idea'
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -10,7 +10,6 @@ buildscript {
             name 'JFrog OSS snapshot repo'
             url  'https://oss.jfrog.org/oss-snapshot-local/'
         }
-        jcenter()
     }
 
     dependencies {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -25,6 +25,22 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
 }
 
+compileTestKotlin {
+    sourceCompatibility = "$jvmVersion"
+    targetCompatibility = "$jvmVersion"
+}
+
+compileKotlin {
+    sourceCompatibility = "$jvmVersion"
+    targetCompatibility = "$jvmVersion"
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("$jvmVersion"))
+    }
+}
+
 task javadocJar(type: Jar) {
     archiveClassifier.set("javadoc")
     from javadoc

--- a/kolasu/build.gradle
+++ b/kolasu/build.gradle
@@ -63,6 +63,22 @@ dependencies {
 
 }
 
+compileTestKotlin {
+    sourceCompatibility = "$jvmVersion"
+    targetCompatibility = "$jvmVersion"
+}
+
+compileKotlin {
+    sourceCompatibility = "$jvmVersion"
+    targetCompatibility = "$jvmVersion"
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("$jvmVersion"))
+    }
+}
+
 task version {
     doLast {
         print "Version ${version}"

--- a/kolasu/build.gradle
+++ b/kolasu/build.gradle
@@ -46,7 +46,6 @@ apply plugin: 'idea'
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -110,7 +110,6 @@ compileJava {
 compileTestKotlin {
     sourceCompatibility = "$jvmVersion"
     targetCompatibility = "$jvmVersion"
-    kotlinOptions.jvmTarget = "$jvmVersion"
     dependsOn generateTestGrammarSource
 }
 
@@ -118,8 +117,13 @@ compileKotlin {
     sourceCompatibility = "$jvmVersion"
     targetCompatibility = "$jvmVersion"
     source generatedMainFile, sourceSets.main.java, sourceSets.main.kotlin
-    kotlinOptions.jvmTarget = "$jvmVersion"
     dependsOn generateGrammarSource
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("$jvmVersion"))
+    }
 }
 
 ktlintTestSourceSetCheck {

--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -32,7 +32,6 @@ buildscript {
             url  'https://oss.jfrog.org/oss-snapshot-localrun/'
         }
         maven { url 'https://jitpack.io' }
-        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
## Description

This pull request updates the Gradle build configuration across several modules to modernize repository usage and standardize Kotlin compilation settings. The most significant changes are the removal of the deprecated `jcenter()` repository and the improved configuration of Kotlin compiler options to ensure consistent JVM target compatibility.

**Repository configuration updates:**
* Removed the use of the deprecated `jcenter()` repository from `dspfparser/build.gradle`, `examples/build.gradle`, `kolasu/build.gradle`, and `rpgJavaInterpreter-core/build.gradle` to improve build reliability and future-proof the project. [[1]](diffhunk://#diff-d25d66325a8df05dcd16cf89249766e7878944ec9cc1713840cb346a5741476cL9) [[2]](diffhunk://#diff-d25d66325a8df05dcd16cf89249766e7878944ec9cc1713840cb346a5741476cL27) [[3]](diffhunk://#diff-53297098330d2d6e11b521573f5c03826ca27f74e3cb5284fd975385ea7d75daL13) [[4]](diffhunk://#diff-69fd23dec8f25d1bbdf85d86f3e8ca77938d76ba9de041d207b2fbf6e766f5cfL49) [[5]](diffhunk://#diff-2311b8fc0d9366597771792af1fa0b18471e6432db6b485eddb090ce2cfa1a00L35)

**Kotlin compilation improvements:**
* Added standardized configuration for `compileKotlin` and `compileTestKotlin` tasks in all modules to set `sourceCompatibility` and `targetCompatibility` based on the `$jvmVersion` variable, ensuring consistent JVM target settings. [[1]](diffhunk://#diff-d25d66325a8df05dcd16cf89249766e7878944ec9cc1713840cb346a5741476cR40-R55) [[2]](diffhunk://#diff-53297098330d2d6e11b521573f5c03826ca27f74e3cb5284fd975385ea7d75daR27-R42) [[3]](diffhunk://#diff-69fd23dec8f25d1bbdf85d86f3e8ca77938d76ba9de041d207b2fbf6e766f5cfR65-R80)
* Introduced a `tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach` block in all modules to set the Kotlin compiler's `jvmTarget` property using the new `compilerOptions` API, aligning with Gradle best practices. [[1]](diffhunk://#diff-d25d66325a8df05dcd16cf89249766e7878944ec9cc1713840cb346a5741476cR40-R55) [[2]](diffhunk://#diff-53297098330d2d6e11b521573f5c03826ca27f74e3cb5284fd975385ea7d75daR27-R42) [[3]](diffhunk://#diff-69fd23dec8f25d1bbdf85d86f3e8ca77938d76ba9de041d207b2fbf6e766f5cfR65-R80) [[4]](diffhunk://#diff-2311b8fc0d9366597771792af1fa0b18471e6432db6b485eddb090ce2cfa1a00L113-R127)
* Removed legacy `kotlinOptions.jvmTarget` assignments in `rpgJavaInterpreter-core/build.gradle` in favor of the new `compilerOptions` approach.

Related to # (issue)

## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [ ] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [ ] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
