### PR TITLE
Bugfix/maven deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,14 +25,12 @@ jobs:
           echo "signing.secretKeyRingFile=${HOME}/private.gpg" >> ~/.gradle/gradle.properties
           echo "centralUsername=${{ secrets.CENTRAL_USERNAME }}" >> ~/.gradle/gradle.properties
           echo "centralPassword=${{ secrets.CENTRAL_PASSWORD }}" >> ~/.gradle/gradle.properties
-          echo "sonatypeUsername=${{ secrets.OSSRH_USERNAME }}" >> ~/.gradle/gradle.properties
-          echo "sonatypePassword=${{ secrets.OSSRH_PASSWORD }}" >> ~/.gradle/gradle.properties
-      # deploy to Central Portal with fallback to OSSRH
+      # deploy to Central Portal, throw error if CENTRAL_USERNAME is not set
       - run: |
           if [ -n "${{ secrets.CENTRAL_USERNAME }}" ]; then
             echo "Publishing to Central Portal..."
             ./gradlew publishToCentralPortal
           else
-            echo "Falling back to OSSRH..."
-            ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+            echo "Error: CENTRAL_USERNAME is not set. Publishing to Central Portal requires this secret."
+            exit 1
           fi

--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,8 @@ subprojects {
             url 'https://repo.smeup.cloud/nexus/repository/public/'
         }
         maven { url 'https://jitpack.io' }
-        // the sonatype repo inclusion allows to work with the reload snapshot version
-        maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
+        // the repo inclusion allows to work with the reload snapshot version
+        maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
         maven { url 'https://oss.jfrog.org/oss-snapshot-local/' }
         jcenter()
     }
@@ -91,19 +91,11 @@ nexusPublishing {
     // however take in account that this flag in the other cases must be true or false depending on the version name
     useStaging = !(project.gradle.startParameter.taskNames.contains("publishToSmeup") || jarikoVersion.endsWith("SNAPSHOT"))
     repositories {
-        // Primary: Central Portal (new Sonatype publishing system)
         centralPortal {
             nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
             snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
             username = findProperty("centralUsername")
             password = findProperty("centralPassword")
-        }
-        // Fallback: Legacy OSSRH (for backward compatibility)
-        sonatype {
-            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
-            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            username = findProperty("sonatypeUsername")
-            password = findProperty("sonatypePassword")
         }
         smeup {
             nexusUrl = uri("https://repo.smeup.cloud/nexus/content/repositories/releases/")

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,9 +97,9 @@ If you want to force the execution of all checks:
  _try to clean the .gradle directory_)
 
 ## Dependency from develop-SNAPSHOT
-This snapshot is published in Maven Central via Sonatype Central Portal (migrated from deprecated OSSRH), if you want to work with this version you can:
- - cloning jariko repo and to deploy in maven local by using ./gradlew deploy
- - or adding this maven repository url https://s01.oss.sonatype.org/content/repositories/snapshots/ to your pom or gradle script
+This snapshot is published in Maven Central via Sonatype Central Portal (migrated from deprecated OSSRH), if you want to work with SNAPSHOT version you can:
+ - cloning jariko repo and to deploy in maven local by using ./gradlew publishToMavenLocal
+ - or adding this maven repository url https://central.sonatype.com/repository/maven-snapshots/ to your pom or gradle script
 
 ## Tests regarding db native access
 


### PR DESCRIPTION
## Description

This pull request updates the project's publishing process and documentation to reflect the migration from the deprecated OSSRH (Sonatype) to the new Sonatype Central Portal for publishing artifacts. The workflow and documentation now use updated credentials, repository URLs, and Gradle commands to support this change.

**CI/CD workflow updates:**

* Updated `.github/workflows/publish.yml` to use `CENTRAL_USERNAME` and `CENTRAL_PASSWORD` secrets instead of the old OSSRH credentials, and changed the deployment step to publish via the Central Portal with a check for the required secret.

**Documentation updates:**

* Updated `docs/development.md` to reference the new Maven Central snapshot repository URL and the correct Gradle command (`publishToMavenLocal`) for local deployment, reflecting the migration from OSSRH to the Central Portal.

Fix #772

## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [ ] There are tests for this feature.
- [ ] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [ ] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [ ] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
