### PR TITLE
bugfix/LS25003713/Compare `*ZEROS` with number

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -993,6 +993,7 @@ object ZeroValue : Value {
     override operator fun compareTo(other: Value): Int =
         when (other) {
             is ZeroValue -> 0
+            is IntValue -> 0.compareTo(other.value)
             is DecimalValue -> other.getZero().compareTo(other.asDecimal().value)
             else -> super.compareTo(other)
         }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/values.kt
@@ -1061,8 +1061,8 @@ object JulValue : Value {
 
 /**
  * The container should always be a DS value
+ * TODO: Serializable decorator is deactivated. See `ProjectedArrayValue to Json` test for reason.
  */
-// @Serializable TODO: See `ProjectedArrayValue to Json` test for reason.
 class ProjectedArrayValue(
     val container: DataStructValue,
     val field: FieldDefinition,

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1470,4 +1470,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("LE VAL", "LE ZERO")
         assertEquals(expected, "smeup/MUDRNRAPU001151".outputOf())
     }
+
+    /**
+     * This program performs `IF` statement between a *ZEROES and integer.
+     * @see #LS25003713
+     */
+    @Test
+    fun executeMUDRNRAPU001152() {
+        val expected = listOf("TRUE", "TRUE")
+        assertEquals(expected, "smeup/MUDRNRAPU001152".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001152.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001152.rpgle
@@ -1,0 +1,20 @@
+     V* ==============================================================
+     V* 16/09/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program performs `IF` statement between a *ZEROES and
+    O *  integer.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *     Cannot compare ZeroValue to IntValue(value=999)
+     V* ==============================================================
+     C                   IF        *ZEROS<999
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+
+     C                   IF        999>*ZEROS
+     C     'TRUE'        DSPLY
+     C                   ENDIF
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description
This work improves Jariko by adding the ability for `IF` statement to compare the left side `*ZEROS` with integer value, like this snippet:
```
     C                   IF        *ZEROS<999
     C     'TRUE'        DSPLY
     C                   ENDIF
```

### Technical notes
`ZeroValue` has been improved by adding the missed logic of comparison. 

Related to #LS25003713

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
