### PR TITLE
bugfix/LS25003713/`ADD` to a variable initialized with `*ZEROS`

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/add.kt
@@ -36,7 +36,11 @@ fun add(
     position: Position? = null,
 ): Value {
     val addendOneValue: Value = interpreterCore.eval(addendOneExpr)
-    require(addendOneValue is NumberValue || (addendOneValue is ArrayValue && addendOneValue.elementType is NumberType)) {
+    require(
+        addendOneValue is NumberValue ||
+            (addendOneValue is ArrayValue && addendOneValue.elementType is NumberType) ||
+            addendOneValue is ZeroValue,
+    ) {
         "$addendOneValue should be a number"
     }
     val addendTwoValue: Value = interpreterCore.eval(addendTwoExpr)
@@ -72,6 +76,7 @@ private fun makeStandaloneValue(
     position: Position?,
 ): Value =
     when {
+        addendOneValue is ZeroValue -> addendTwoValue
         addendOneValue is IntValue && addendTwoValue is IntValue ->
             IntValue(
                 addendOneValue.asInt().value.plus(addendTwoValue.asInt().value),

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/smeup/MULANGT10BaseCodopTest.kt
@@ -1480,4 +1480,14 @@ open class MULANGT10BaseCodopTest : MULANGTTest() {
         val expected = listOf("TRUE", "TRUE")
         assertEquals(expected, "smeup/MUDRNRAPU001152".outputOf())
     }
+
+    /**
+     * This program increments a variable previously declared with *ZEROS.
+     * @see #LS25002737
+     */
+    @Test
+    fun executeMUDRNRAPU001153() {
+        val expected = listOf("0", "1")
+        assertEquals(expected, "smeup/MUDRNRAPU001153".outputOf())
+    }
 }

--- a/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001153.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/smeup/MUDRNRAPU001153.rpgle
@@ -1,0 +1,18 @@
+     V* ==============================================================
+     V* 17/09/2025 APU001 Creation
+     V* ==============================================================
+    O * PROGRAM GOAL
+    O * This program increments a variable previously declared
+    O *  with *ZEROS.
+     V* ==============================================================
+    O * JARIKO ANOMALY
+    O * Before the fix, the error occurred was:
+    O *     ZeroValue should be a number
+     V* ==============================================================
+     C                   Z-ADD     *ZEROS        VAR               1 0
+     C     VAR           DSPLY
+     C                   ADD       1             VAR
+     C     VAR           DSPLY
+
+     C                   SETON                                          LR
+


### PR DESCRIPTION
## Description
This work improves Jariko by adding the ability for `ADD` statement to increase the value of a variable previously initialized with `*ZEROS` keyword, like in this snippet:
```
     C                   Z-ADD     *ZEROS        VAR               1 0
     C                   ADD       1             VAR
```

Related to #LS25003713

## Checklist:
- [x] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
