### PR TITLE
Bugfix/ls25002732/memory slice persistence error of a failing called program

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/symbol_table_storaging.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/symbol_table_storaging.kt
@@ -114,6 +114,8 @@ class MemorySliceMgr(
 
     fun getSize() = memorySlices.size
 
+    fun remove(memorySliceId: MemorySliceId) = memorySlices.remove(memorySliceId)
+
     private fun getDataDefinition(
         name: String,
         symbolTable: ISymbolTable,

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/symbol_table_storaging.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/symbol_table_storaging.kt
@@ -112,6 +112,8 @@ class MemorySliceMgr(
         storage.open()
     }
 
+    fun getSize() = memorySlices.size
+
     private fun getDataDefinition(
         name: String,
         symbolTable: ISymbolTable,

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1226,9 +1226,11 @@ data class CallStmt(
                             }
                         }
                 } catch (e: Exception) {
-                    MainExecutionContext
-                        .getMemorySliceMgr()
-                        ?.remove(MemorySliceId((program as RpgProgram).activationGroup.assignedName, programToCall))
+                    if (program is RpgProgram) {
+                        MainExecutionContext
+                            .getMemorySliceMgr()
+                            ?.remove(MemorySliceId(program.activationGroup.assignedName, programToCall))
+                    }
 
                     // TODO Catch a more specific exception?
                     if (errorIndicator == null) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1228,7 +1228,7 @@ data class CallStmt(
                 } catch (e: Exception) {
                     MainExecutionContext
                         .getMemorySliceMgr()
-                        ?.remove(MemorySliceId(MainExecutionContext.getConfiguration().defaultActivationGroupName, programToCall))
+                        ?.remove(MemorySliceId((program as RpgProgram).activationGroup.assignedName, programToCall))
 
                     // TODO Catch a more specific exception?
                     if (errorIndicator == null) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1226,6 +1226,10 @@ data class CallStmt(
                             }
                         }
                 } catch (e: Exception) {
+                    MainExecutionContext
+                        .getMemorySliceMgr()
+                        ?.remove(MemorySliceId(MainExecutionContext.getConfiguration().defaultActivationGroupName, programToCall))
+
                     // TODO Catch a more specific exception?
                     if (errorIndicator == null) {
                         if (program is RpgProgram) {

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1577,8 +1577,8 @@ data class IfStmt(
          * after unwrapping we need to update the offset of each 'last' statement
          */
 
-        // Update last pointer in then body
         if (thenBody.isNotEmpty()) {
+            // Update last pointer in then body
             val offsetOfLastStatement = thenBody.size
             val lastStatementMustRedirectTo = nextOperationAt - offsetOfLastStatement
             thenBody.last().nextOperationOffset = lastStatementMustRedirectTo

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -18,6 +18,7 @@ package com.smeup.rpgparser.evaluation
 
 import com.smeup.rpgparser.*
 import com.smeup.rpgparser.execution.*
+import com.smeup.rpgparser.experimental.PropertiesFileStorage
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
 import com.smeup.rpgparser.jvminterop.JvmProgramRaw
@@ -27,6 +28,7 @@ import com.smeup.rpgparser.parsing.parsetreetoast.AstResolutionError
 import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.utils.asInt
 import com.smeup.rpgparser.utils.getRootCause
+import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -2860,6 +2862,24 @@ Test 6
     fun executeFUNCALLMUTABILITY() {
         val expected = listOf("ok")
         assertEquals(expected, "FUNCALLMUTABILITY".outputOf())
+    }
+
+    @Before
+    fun before() {
+        val lastPathComponent =
+            if (DEMO) {
+                "demo"
+            } else {
+                "${System.currentTimeMillis()}"
+            }
+        simpleStorageTempDir = File(System.getProperty("java.io.tmpdir"), "/teststorage/$lastPathComponent")
+    }
+
+    @Test
+    fun executeRTCALLERERR() {
+        val storage = PropertiesFileStorage(simpleStorageTempDir)
+        val config = Configuration(storage)
+        executePgm("RTCALLERERR", configuration = config)
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/evaluation/InterpreterTest.kt
@@ -18,7 +18,6 @@ package com.smeup.rpgparser.evaluation
 
 import com.smeup.rpgparser.*
 import com.smeup.rpgparser.execution.*
-import com.smeup.rpgparser.experimental.PropertiesFileStorage
 import com.smeup.rpgparser.interpreter.*
 import com.smeup.rpgparser.jvminterop.JavaSystemInterface
 import com.smeup.rpgparser.jvminterop.JvmProgramRaw
@@ -28,7 +27,6 @@ import com.smeup.rpgparser.parsing.parsetreetoast.AstResolutionError
 import com.smeup.rpgparser.parsing.parsetreetoast.resolveAndValidate
 import com.smeup.rpgparser.utils.asInt
 import com.smeup.rpgparser.utils.getRootCause
-import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -2862,24 +2860,6 @@ Test 6
     fun executeFUNCALLMUTABILITY() {
         val expected = listOf("ok")
         assertEquals(expected, "FUNCALLMUTABILITY".outputOf())
-    }
-
-    @Before
-    fun before() {
-        val lastPathComponent =
-            if (DEMO) {
-                "demo"
-            } else {
-                "${System.currentTimeMillis()}"
-            }
-        simpleStorageTempDir = File(System.getProperty("java.io.tmpdir"), "/teststorage/$lastPathComponent")
-    }
-
-    @Test
-    fun executeRTCALLERERR() {
-        val storage = PropertiesFileStorage(simpleStorageTempDir)
-        val config = Configuration(storage)
-        executePgm("RTCALLERERR", configuration = config)
     }
 
     @Test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/MemorySliceStorageTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/MemorySliceStorageTest.kt
@@ -225,6 +225,39 @@ open class MemorySliceStorageTest : AbstractTest() {
         assertEquals(1, numElementsMemorySlices)
     }
 
+    @Test
+    fun ensureMemorySlicesOnCalledPgmError_usingAnotherActivationGroup() {
+        // Testing program
+        val programName = "RTCALLERERR2.rpgle"
+        val path = javaClass.getResource("/$programName")
+
+        // Here I set the path from where jariko will search for the rpg sources
+        val rpgProgramFinders = listOf(DirRpgProgramFinder(File(path.path).parentFile))
+
+        // Here I set configuration
+        var numElementsMemorySlices = 0
+        val configuration =
+            Configuration(
+                PropertiesFileStorage(simpleStorageTempDir),
+                JarikoCallback(
+                    onCallPgmError = { errorEvent: ErrorEvent ->
+                        numElementsMemorySlices = MainExecutionContext.getMemorySliceMgr()?.getSize() ?: 0
+                    },
+                ),
+            )
+
+        // Simulate the execution of a program that calls another that goes in error
+        println("Executing $programName")
+        executePgmWithStringArgs(
+            programName = programName,
+            programFinders = rpgProgramFinders,
+            programArgs = listOf<String>(),
+            configuration = configuration,
+        )
+
+        assertEquals(1, numElementsMemorySlices)
+    }
+
     // Test flow:
     // Step 0 - Executing ACTGRP_FIX that exits in RT
     // Step 1 - Executing ACTGRP_FIX that exits in LR (forced LR programmatically via callback)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/MemorySliceStorageTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/MemorySliceStorageTest.kt
@@ -190,6 +190,13 @@ open class MemorySliceStorageTest : AbstractTest() {
         assertEquals(times, x.asInt().value.toInt())
     }
 
+    @Test
+    fun executeRTCALLERERR() {
+        val storage = PropertiesFileStorage(simpleStorageTempDir)
+        val config = Configuration(storage)
+        executePgm("RTCALLERERR", configuration = config)
+    }
+
     // Test flow:
     // Step 0 - Executing ACTGRP_FIX that exits in RT
     // Step 1 - Executing ACTGRP_FIX that exits in LR (forced LR programmatically via callback)

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/MemorySliceStorageTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/interpreter/MemorySliceStorageTest.kt
@@ -18,7 +18,9 @@ package com.smeup.rpgparser.interpreter
 
 import com.smeup.rpgparser.AbstractTest
 import com.smeup.rpgparser.execution.Configuration
+import com.smeup.rpgparser.execution.ErrorEvent
 import com.smeup.rpgparser.execution.JarikoCallback
+import com.smeup.rpgparser.execution.MainExecutionContext
 import com.smeup.rpgparser.experimental.PropertiesFileStorage
 import com.smeup.rpgparser.rpginterop.DirRpgProgramFinder
 import org.junit.After
@@ -191,10 +193,36 @@ open class MemorySliceStorageTest : AbstractTest() {
     }
 
     @Test
-    fun executeRTCALLERERR() {
-        val storage = PropertiesFileStorage(simpleStorageTempDir)
-        val config = Configuration(storage)
-        executePgm("RTCALLERERR", configuration = config)
+    fun ensureMemorySlicesOnCalledPgmError() {
+        // Testing program
+        val programName = "RTCALLERERR.rpgle"
+        val path = javaClass.getResource("/$programName")
+
+        // Here I set the path from where jariko will search for the rpg sources
+        val rpgProgramFinders = listOf(DirRpgProgramFinder(File(path.path).parentFile))
+
+        // Here I set configuration
+        var numElementsMemorySlices = 0
+        val configuration =
+            Configuration(
+                PropertiesFileStorage(simpleStorageTempDir),
+                JarikoCallback(
+                    onCallPgmError = { errorEvent: ErrorEvent ->
+                        numElementsMemorySlices = MainExecutionContext.getMemorySliceMgr()?.getSize() ?: 0
+                    },
+                ),
+            )
+
+        // Simulate the execution of a program that calls another that goes in error
+        println("Executing $programName")
+        executePgmWithStringArgs(
+            programName = programName,
+            programFinders = rpgProgramFinders,
+            programArgs = listOf<String>(),
+            configuration = configuration,
+        )
+
+        assertEquals(1, numElementsMemorySlices)
     }
 
     // Test flow:

--- a/rpgJavaInterpreter-core/src/test/resources/RTCALLEEERR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/RTCALLEEERR.rpgle
@@ -1,0 +1,6 @@
+     D C               S              1
+     D D               S              1
+     C                   EVAL      C='C'
+     C                   EVAL      D='D'
+     C     1             DIV       0             RESULT            9 0
+     C                   SETON

--- a/rpgJavaInterpreter-core/src/test/resources/RTCALLEEERR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/RTCALLEEERR.rpgle
@@ -1,6 +1,9 @@
      D C               S              1
      D D               S              1
+
      C                   EVAL      C='C'
      C                   EVAL      D='D'
      C     1             DIV       0             RESULT            9 0
-     C                   SETON
+     C     'HI'          DSPLY
+
+     C                   SETON                                        RT

--- a/rpgJavaInterpreter-core/src/test/resources/RTCALLEEERR2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/RTCALLEEERR2.rpgle
@@ -1,0 +1,11 @@
+     H ACTGRP('MYACT')
+
+     D C               S              1
+     D D               S              1
+
+     C                   EVAL      C='C'
+     C                   EVAL      D='D'
+     C     1             DIV       0             RESULT            9 0
+     C     'HI'          DSPLY
+
+     C                   SETON                                        RT

--- a/rpgJavaInterpreter-core/src/test/resources/RTCALLERERR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/RTCALLERERR.rpgle
@@ -1,0 +1,6 @@
+     D A               S              1
+     D B               S              1
+     C                   EVAL      A='A'
+     C                   EVAL      B='B'
+     C                   CALL      'RTCALLEEERR'                        37
+     C                   SETON

--- a/rpgJavaInterpreter-core/src/test/resources/RTCALLERERR.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/RTCALLERERR.rpgle
@@ -1,6 +1,9 @@
      D A               S              1
      D B               S              1
+
      C                   EVAL      A='A'
      C                   EVAL      B='B'
      C                   CALL      'RTCALLEEERR'                        37
-     C                   SETON
+     C     *IN37         DSPLY
+
+     C                   SETON                                          LR

--- a/rpgJavaInterpreter-core/src/test/resources/RTCALLERERR2.rpgle
+++ b/rpgJavaInterpreter-core/src/test/resources/RTCALLERERR2.rpgle
@@ -1,0 +1,9 @@
+     D A               S              1
+     D B               S              1
+
+     C                   EVAL      A='A'
+     C                   EVAL      B='B'
+     C                   CALL      'RTCALLEEERR2'                       37
+     C     *IN37         DSPLY
+
+     C                   SETON                                          LR


### PR DESCRIPTION
## Description

This PR fixes the MemorySlice persistence error.

When a program calls another one, by specifing an error indicator (for example, 37) and callee program fails,  the list of MemorySlice has the item related failed program yet. To fix this problem we must remove this one by using MemorySliceMgr as soon as a program fails.


## Checklist:
- [ ] If this feature involves RPGLE fixes or improvements, they are well-described in the summary.
- [x] There are tests for this feature.
- [x] RPGLE code used for tests is easily understandable and includes comments that clarify the purpose of this feature.
- [x] The code follows Kotlin conventions (run `./gradlew ktlintCheck`).
- [x] The code passes all tests (run `./gradlew check`).
- [ ] Relevant documentation is included in the `docs` directory.
