### PR TITLE
security: bump log4j-core to 2.25.4

### DIFF
--- a/rpgJavaInterpreter-core/build.gradle
+++ b/rpgJavaInterpreter-core/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 
     implementation "org.apache.logging.log4j:log4j-api-kotlin:1.5.0"
     implementation "org.apache.logging.log4j:log4j-api:2.25.3"
-    implementation 'org.apache.logging.log4j:log4j-core:2.25.3'
+    implementation 'org.apache.logging.log4j:log4j-core:2.25.4'
 
     implementation 'commons-io:commons-io:2.21.0'
     implementation("com.github.ajalt:clikt:3.5.2") {


### PR DESCRIPTION
Updates log4j-core dependency from 2.25.3 to 2.25.4
CVE-2025-68161