### PR TITLE
fix: propagate CallProgramHandler errors when program is uninitialized

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/program.kt
@@ -77,6 +77,7 @@ class RpgProgram(
 
     lateinit var activationGroup: ActivationGroup
     private var initialized = false
+    val isInitialized get() = initialized
 
     private val logHandlers: MutableList<InterpreterLogHandler> by lazy {
         systemInterface!!.getAllLogHandlers()

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -1226,7 +1226,7 @@ data class CallStmt(
                             }
                         }
                 } catch (e: Exception) {
-                    if (program is RpgProgram) {
+                    if (program is RpgProgram && program.isInitialized) {
                         MainExecutionContext
                             .getMemorySliceMgr()
                             ?.remove(MemorySliceId(program.activationGroup.assignedName, programToCall))

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/execution/CallProgramHandlerTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/execution/CallProgramHandlerTest.kt
@@ -18,6 +18,7 @@
 package com.smeup.rpgparser.execution
 
 import com.smeup.rpgparser.AbstractTest
+import com.smeup.rpgparser.interpreter.IMemorySliceStorage
 import com.smeup.rpgparser.interpreter.StringValue
 import com.smeup.rpgparser.interpreter.SystemInterface
 import com.smeup.rpgparser.interpreter.Value
@@ -31,6 +32,7 @@ import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class CallProgramHandlerTest : AbstractTest() {
@@ -165,6 +167,30 @@ class CallProgramHandlerTest : AbstractTest() {
         val result = jariko.singleCall(listOf(""), configuration)
         require(result != null)
         assertTrue { result.parmsList[0].trim().contains("HELLO JARIKO") }
+    }
+
+    /**
+     * This test reproduces the 'CallProgramHandler' implementation in Kokos where the handleCall throws an error.
+     * The assertion is: the exception thrown inside handleCall propagates to the caller.
+     * */
+    @Test
+    fun testCallProgramHandlerErrorPropagation() {
+        val systemInterface: SystemInterface = JavaSystemInterface()
+        val programFinders: List<RpgProgramFinder> = listOf(DirRpgProgramFinder(File("src/test/resources/")))
+        val memorySliceStorage = IMemorySliceStorage.createMemoryStorage(mutableMapOf())
+        val configuration = Configuration(memorySliceStorage = memorySliceStorage)
+        val callProgramHandler =
+            CallProgramHandler(
+                handleCall = { _: String, _: SystemInterface, _: LinkedHashMap<String, Value> ->
+                    throw RuntimeException("Error from handleCall")
+                },
+            )
+        configuration.options.callProgramHandler = callProgramHandler
+        val exception =
+            assertFailsWith<RuntimeException> {
+                getProgram("CALLER.rpgle", systemInterface, programFinders).singleCall(listOf(""), configuration)
+            }
+        assertTrue { exception.message!!.contains("Error from handleCall") }
     }
 
     private fun doPost(


### PR DESCRIPTION
## Summary

- Added `isInitialized` public getter to `RpgProgram` exposing the private `initialized` flag
- Guarded `program.activationGroup` access in `CallStmt`'s catch block with an `isInitialized` check
- Added `testCallProgramHandlerErrorPropagation` to verify exceptions thrown inside `handleCall` propagate to the caller

## Root cause

When `callProgramHandler.handleCall` throws before the `RpgProgram` is initialized, the catch block in `CallStmt` attempted to access `program.activationGroup` (a `lateinit var`) unconditionally. This caused an `UninitializedPropertyAccessException` that replaced the original exception, hiding the real error.

The typical case is doped programs implemented in Kokos: the `CallProgramHandler` intercepts the call and executes the program via JVM code. If that implementation throws, the error was silently swallowed by the uninitialized access.

## Test plan

- [x] Run `./gradlew :rpgJavaInterpreter-core:test --tests "com.smeup.rpgparser.execution.CallProgramHandlerTest.testCallProgramHandlerErrorPropagation"` — should pass
- [x] Run `./gradlew check` — full test suite green